### PR TITLE
fix: web module unexpected type error

### DIFF
--- a/lazyllm/tools/webpages/webmodule.py
+++ b/lazyllm/tools/webpages/webmodule.py
@@ -213,6 +213,8 @@ class WebModule(ModuleBase):
                         s = s
                     except KeyError:
                         s = s
+                    except TypeError:
+                        s = s
                 return s, ''.join(log_history)
 
             log_history = []


### PR DESCRIPTION
Case when handling string without json type

"/home/mnt/yewentao/LazyLLM/lazyllm/tools/webpages/webmodule.py", line 222, in _respond_stream
    result, log = get_log_and_message(result)
  File "/home/mnt/yewentao/LazyLLM/lazyllm/tools/webpages/webmodule.py", line 205, in get_log_and_message
    if "type" not in r["choices"][0] or (
TypeError: list indices must be integers or slices, not str
