### PR TITLE
Update flow.py

### DIFF
--- a/lazyllm/flow/flow.py
+++ b/lazyllm/flow/flow.py
@@ -369,7 +369,7 @@ class Switch(LazyLLMFlowsBase):
             self.conds, items = list(args[0].keys()), list(args[0].values())
         else:
             self.conds, items = list(args[0::2]), args[1::2]
-        items = {repr(k): v for k, v in zip(self.conds, items)}
+        items = {f"{repr(k)}-{id(k)}": v for k, v in zip(self.conds, items)}
         super().__init__(**items, post_action=post_action, **kw)
         self._judge_on_full_input = judge_on_full_input
 


### PR DESCRIPTION
The `Switch` class where conditions with identical `repr` outputs could lead to key collisions, causing an incorrect mapping between conditions and their corresponding branches. To resolve this, we've enhanced the uniqueness of the condition keys by appending the `id` of the condition object to its `repr` string.

**Changes:**
- Modified the key generation logic in the `Switch` class to include both `repr` and `id`: ```python items = {f"{repr(k)}-{id(k)}": v for k, v in zip(self.conds, items)} ```

This ensures that each key in the `items` dictionary is unique, even if the `repr` of different conditions is the same.

**Example:**
```
from enum import Enum
from pydantic import BaseModel
import lazyllm
class ServiceType(str, Enum):
    order_query = " order_query"
    web_search = "web_search"  
    text_summary = "text_summary"  
    chat = "chat" 
    
    @classmethod
    def _generate_is_methods(cls):
        for member in cls:
            method_name = f'is_{member.name}'
            setattr(cls, method_name, classmethod(lambda cls, value, member=member: value == member))
            
ServiceType._generate_is_methods()


switch=lazyllm.switch(ServiceType.is_order_query, lambda x: 2 * x, 
               ServiceType.is_web_search, lambda x : x, 
               ServiceType.is_text_summary, lambda x : '000',
               'default',lambda x : '00',
               judge_on_full_input=True)
switch("web_search")
```

Right Answer:
web_search


