### PR TITLE
EmptyLauncher lack wait

### DIFF
--- a/lazyllm/launcher.py
+++ b/lazyllm/launcher.py
@@ -186,6 +186,10 @@ class EmptyLauncher(LazyLLMLaunchersBase):
         def get_jobip(self):
             return '0.0.0.0'
 
+        def wait(self):
+            if self.ps:
+                self.ps.wait()
+
     def __init__(self, subprocess=False, ngpus=None, sync=True):
         super().__init__()
         self.subprocess = subprocess


### PR DESCRIPTION
Due to the absence of “wait” in EmptyLauncher, the deployment starts immediately after the training is initiated.