### PR TITLE
Mdify missing vqa name in readme

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -87,7 +87,7 @@ with pipeline() as ppl:
     with switch(judge_on_full_input=False).bind(_0, ppl.input) as ppl.sw:
         ppl.sw.case[chatflow_intent_list[0], chat]
         ppl.sw.case[chatflow_intent_list[1], TrainableModule('SenseVoiceSmall')]
-        ppl.sw.case[chatflow_intent_list[2], TrainableModule('internvl-chat-2b-v1-5').deploy_method(deploy.LMDeploy)]
+        ppl.sw.case[chatflow_intent_list[2], TrainableModule('Mini-InternVL-Chat-2B-V1-5').deploy_method(deploy.LMDeploy)]
         ppl.sw.case[chatflow_intent_list[3], pipeline(base.share().prompt(painter_prompt), TrainableModule('stable-diffusion-3-medium'))]
         ppl.sw.case[chatflow_intent_list[4], pipeline(base.share().prompt(musician_prompt), TrainableModule('musicgen-small'))]
         ppl.sw.case[chatflow_intent_list[5], TrainableModule('ChatTTS')]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ with pipeline() as ppl:
     with switch(judge_on_full_input=False).bind(_0, ppl.input) as ppl.sw:
         ppl.sw.case[chatflow_intent_list[0], chat]
         ppl.sw.case[chatflow_intent_list[1], TrainableModule('SenseVoiceSmall')]
-        ppl.sw.case[chatflow_intent_list[2], TrainableModule('internvl-chat-2b-v1-5').deploy_method(deploy.LMDeploy)]
+        ppl.sw.case[chatflow_intent_list[2], TrainableModule('Mini-InternVL-Chat-2B-V1-5').deploy_method(deploy.LMDeploy)]
         ppl.sw.case[chatflow_intent_list[3], pipeline(base.share().prompt(painter_prompt), TrainableModule('stable-diffusion-3-medium'))]
         ppl.sw.case[chatflow_intent_list[4], pipeline(base.share().prompt(musician_prompt), TrainableModule('musicgen-small'))]
         ppl.sw.case[chatflow_intent_list[5], TrainableModule('ChatTTS')]

--- a/lazyllm/components/utils/downloader/model_downloader.py
+++ b/lazyllm/components/utils/downloader/model_downloader.py
@@ -179,6 +179,9 @@ class ModelManager():
             return model_dir_result
         except Exception as e:
             lazyllm.LOG.error(f"Huggingface: {e}")
+            if not self.token:
+                lazyllm.LOG.error('The token is found to be empty. Please set the token by '
+                                  'the environment variable LAZYLLM_MODEL_SOURCE_TOKEN.')
             if os.path.isdir(model_dir):
                 shutil.rmtree(model_dir)
                 lazyllm.LOG.error(f"{model_dir} removed due to exceptions.")
@@ -194,10 +197,13 @@ class ModelManager():
                 api.login(self.token)
             model_dir_result = snapshot_download(model_id=model_name, cache_dir=model_source_dir)
 
-            print(f"[INFO] model downloaded at {model_dir_result}")
+            lazyllm.LOG.info(f"Model downloaded at {model_dir_result}")
             return model_dir_result
         except Exception as e:
-            print(f"[ERROR] Modelscope:{e}")
+            lazyllm.LOG.error(f"Modelscope:{e}")
+            if not self.token:
+                lazyllm.LOG.error('The token is found to be empty. Please set the token by '
+                                  'the environment variable LAZYLLM_MODEL_SOURCE_TOKEN.')
 
             # unlike Huggingface, Modelscope adds model name as sub-dir to cache_dir.
             # so we need to figure out the exact dir of the model for clearing in case of exceptions.
@@ -205,4 +211,4 @@ class ModelManager():
             full_model_dir = os.path.join(model_source_dir, model_dir)
             if os.path.isdir(full_model_dir):
                 shutil.rmtree(full_model_dir)
-                print(f"[ERROR] {full_model_dir} removed due to exceptions.")
+                lazyllm.LOG.error(f"{full_model_dir} removed due to exceptions.")

--- a/lazyllm/components/utils/downloader/model_mapping.py
+++ b/lazyllm/components/utils/downloader/model_mapping.py
@@ -85,6 +85,10 @@ model_provider = {
         "huggingface": "internlm",
         "modelscope": "Shanghai_AI_Laboratory"
     },
+    "internvl": {
+        "huggingface": "OpenGVLab",
+        "modelscope": "OpenGVLab"
+    },
     "qwen": {
         "huggingface": "Qwen",
         "modelscope": "qwen"
@@ -145,6 +149,13 @@ model_name_mapping = {
         "source": {
             "huggingface": "OpenGVLab/Mini-InternVL-Chat-2B-V1-5",
             "modelscope": "OpenGVLab/Mini-InternVL-Chat-2B-V1-5"
+        },
+        "type": "vlm"
+    },
+    "mini-internvl-chat-4b-v1-5": {
+        "source": {
+            "huggingface": "OpenGVLab/Mini-InternVL-Chat-4B-V1-5",
+            "modelscope": "OpenGVLab/Mini-InternVL-Chat-4B-V1-5"
         },
         "type": "vlm"
     },


### PR DESCRIPTION
- Modify the missing VQA model name in the readme
- Add a print error for the unset token for the mode needed applying.
- Add a new VQA provider to model_mapping.