### PR TITLE
fix bind pickle bug

### DIFF
--- a/lazyllm/common/common.py
+++ b/lazyllm/common/common.py
@@ -74,11 +74,11 @@ class kwargs(dict):
 
 
 class arguments(object):
-    class __None: pass
+    class _None: pass
 
-    def __init__(self, args=__None, kw=__None) -> None:
-        self.args = package() if args is arguments.__None else args
-        self.kw = kwargs() if args is arguments.__None else kw
+    def __init__(self, args=_None, kw=_None) -> None:
+        self.args = package() if args is arguments._None else args
+        self.kw = kwargs() if args is arguments._None else kw
 
 
 setattr(builtins, 'package', package)
@@ -143,18 +143,13 @@ class _MetaBind(type):
         return super(__class__, self).__instancecheck__(__instance)
 
 
-class BindInputNone:
-    pass
-
-
 class Bind(object):
-    class __None: pass
+    class _None: pass
 
     class Input(object):
-        class __None: pass
+        class _None: pass
 
-        def __init__(self):
-            self._item_key, self._attr_key = BindInputNone, BindInputNone
+        def __init__(self): self._item_key, self._attr_key = Bind.Input._None, Bind.Input._None
 
         def __getitem__(self, key):
             self._item_key = key
@@ -171,21 +166,19 @@ class Bind(object):
             self._item_key, self._attr_key = state
 
         def get_input(self, input):
-            if self._item_key is not BindInputNone:
-                return input[self._item_key]
-            elif self._attr_key is not BindInputNone:
-                return getattr(input, self._attr_key)
+            if self._item_key is not Bind.Input._None: return input[self._item_key]
+            elif self._attr_key is not Bind.Input._None: return getattr(input, self._attr_key)
             return input
 
-    def __init__(self, __bind_func=__None, *args, **kw):
-        self._f = __bind_func() if isinstance(__bind_func, type) and __bind_func is not Bind.__None else __bind_func
+    def __init__(self, __bind_func=_None, *args, **kw):
+        self._f = __bind_func() if isinstance(__bind_func, type) and __bind_func is not Bind._None else __bind_func
         self._args = args
         self._kw = kw
         self._has_root = any([isinstance(a, AttrTree) for a in args])
         self._has_root = self._has_root or any([isinstance(v, AttrTree) for k, v in kw.items()])
 
     def __ror__(self, __value: Callable):
-        if self._f is not Bind.__None: self._args = (self._f,) + self._args
+        if self._f is not Bind._None: self._args = (self._f,) + self._args
         self._f = __value
         return self
 

--- a/lazyllm/common/common.py
+++ b/lazyllm/common/common.py
@@ -143,25 +143,36 @@ class _MetaBind(type):
         return super(__class__, self).__instancecheck__(__instance)
 
 
+class BindInputNone:
+    pass
+
+
 class Bind(object):
     class __None: pass
 
     class Input(object):
         class __None: pass
 
-        def __init__(self): self._item_key, self._attr_key = Bind.Input.__None, Bind.Input.__None
+        def __init__(self):
+            self._item_key, self._attr_key = BindInputNone, BindInputNone
 
         def __getitem__(self, key):
-            self._item_key = key
-            return self
+            return None
 
         def __getattr__(self, key):
-            self._attr_key = key
-            return self
+            return None
+
+        def __getstate__(self):
+            return self._item_key, self._attr_key
+
+        def __setstate__(self, state):
+            self._item_key, self._attr_key = state
 
         def get_input(self, input):
-            if self._item_key is not Bind.Input.__None: return input[self._item_key]
-            elif self._attr_key is not Bind.Input.__None: return getattr(input, self._attr_key)
+            if self._item_key is not BindInputNone:
+                return input[self._item_key]
+            elif self._attr_key is not BindInputNone:
+                return getattr(input, self._attr_key)
             return input
 
     def __init__(self, __bind_func=__None, *args, **kw):

--- a/lazyllm/common/common.py
+++ b/lazyllm/common/common.py
@@ -157,10 +157,12 @@ class Bind(object):
             self._item_key, self._attr_key = BindInputNone, BindInputNone
 
         def __getitem__(self, key):
-            return None
+            self._item_key = key
+            return self
 
         def __getattr__(self, key):
-            return None
+            self._attr_key = key
+            return self
 
         def __getstate__(self):
             return self._item_key, self._attr_key


### PR DESCRIPTION
Please use following code for test
```
import lazyllm
from lazyllm import pipeline, bind
import cloudpickle

with pipeline() as ppl:
    ppl.f1 = lambda x: str(len(x))
    ppl.formatter = (lambda length, query: dict(length=length, query=query)) | bind(query=ppl.input)
    ppl.f2 = lambda y: f"The original query is : {y['query']}, length is : {y['length']}"

am = lazyllm.ActionModule(ppl)
pkl_am = cloudpickle.dumps(am)
new_am = cloudpickle.loads(pkl_am)
print(new_am("Hello World"))

sm = lazyllm.ServerModule(ppl)
sm.start()
print(sm("Hello World"))
```