### PR TITLE
Add kill subprocess for EmptyLauncher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ sentencepiece = "^0.2.0"
 modelscope = "^1.17.1"
 psycopg2 = "^2.9.9"
 sqlalchemy = "^2.0.34"
+psutil = "^6.0.0"
 redis = { version = ">=5.0.4", optional = true }
 huggingface-hub = { version = ">=0.23.1", optional = true }
 llama-index = { version = ">=0.10.25", optional = true }

--- a/requirements.full.txt
+++ b/requirements.full.txt
@@ -66,3 +66,4 @@ sortedcontainers
 flash-attn
 lightllm
 lazyllm-llamafactory
+psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ sentencepiece
 modelscope
 psycopg2
 sqlalchemy
+psutil


### PR DESCRIPTION
**Background** 
Using LightLLM to call the process kill in the code can only kill the parent process, and the child process cannot be killed, which will become a zombie process. This issue does not occur in vLLM. 

**Solution**
Recursively traverse all child processes of the parent process to actively kill them.

**Problem**
![image](https://github.com/user-attachments/assets/00b6ad3f-4ed3-4839-9b95-f241512807a2)

**Solved**
![image](https://github.com/user-attachments/assets/00bd68ce-8374-4ff5-bae9-630d17ccf662)
