### PR TITLE
Fixed batch_size_per_device and batch_size misuse in LazyLLM

### DIFF
--- a/lazyllm/components/finetune/llamafactory/sft.yaml
+++ b/lazyllm/components/finetune/llamafactory/sft.yaml
@@ -78,7 +78,7 @@ per_device_train_batch_size: 1
 per_device_eval_batch_size: 1
 per_gpu_train_batch_size: null
 per_gpu_eval_batch_size: null
-gradient_accumulation_steps: 8
+gradient_accumulation_steps: 1
 eval_accumulation_steps: null
 eval_delay: 0
 learning_rate: 1.0e-04

--- a/lazyllm/tools/train_service/client.py
+++ b/lazyllm/tools/train_service/client.py
@@ -79,7 +79,7 @@ class LocalTrainClient:
                 'num_train_epochs': train_config['num_epochs'],
                 'learning_rate': train_config['learning_rate'],
                 'lr_scheduler_type': train_config['lr_scheduler_type'],
-                'per_device_train_batch_size': train_config['batch_size'],
+                'per_device_train_batch_size': train_config['batch_size'] // train_config['num_gpus'],
                 'cutoff_len': train_config['cutoff_len'],
                 'lora_r': train_config['lora_r'],
                 'lora_alpha': train_config['lora_alpha'],


### PR DESCRIPTION
## Background
This PR addresses the issue of the incorrect usage of `batch_size_per_device` and `batch_size`. In the transformers code, the total_train_batch_size is calculated as **total_train_batch_size = _train_batch_size * gradient_accumulation_steps * world_size**.
Here, `_train_batch_size` corresponds to `batch_size_per_device` in Llamafactory, which is similar to a `micro_batch_size`.

Code in Transformers:
![image](https://github.com/user-attachments/assets/e2497991-f811-4fe9-b925-071d7476f417)

Log in Llamafactory and Code in Transformers:
![image](https://github.com/user-attachments/assets/15d7d81b-391c-4fe5-b75b-0422d3448293)

## Solve
To resolve this, in LazyLLM, I have fixed `gradient_accumulation_steps` to 1. Given a `batch_size`, the correct calculation for `batch_size_per_device` should be `batch_size_per_device // n_gpus`. This ensures that the batch size is properly distributed across the available GPUs.

## Verify
- 2 GPUs OOM:
![企业微信截图_17332106802115](https://github.com/user-attachments/assets/a87fa986-6cb3-4a21-91bc-69375fc708e4)

- 4 GPUs OK:
![企业微信截图_17332106059677](https://github.com/user-attachments/assets/847125ba-f3bf-4cad-99cb-27d4ef461c6a)
