### PR TITLE
Unified download progress for huggingface and modelscope

### DIFF
--- a/lazyllm/components/utils/downloader/model_downloader.py
+++ b/lazyllm/components/utils/downloader/model_downloader.py
@@ -153,7 +153,7 @@ class ModelManager():
                 return self._download_model_from_ms(model, full_model_dir, call_back)
         # Use `BaseException` to capture `KeyboardInterrupt` and normal `Exceptioin`.
         except BaseException as e:
-            lazyllm.LOG.warning(f"Huggingface: {e}")
+            lazyllm.LOG.warning(f"Download encountered an error: {e}")
             if not self.token:
                 lazyllm.LOG.warning('Token is empty, which may prevent private models from being downloaded, '
                                     'as indicated by "the model does not exist." Please set the token with the '
@@ -223,7 +223,6 @@ def custom_tqdm_factory(shared_list):
     class CustomTqdm(tqdm.std.tqdm):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
-            print("TTTTTTTTTTTTTTT: ", flush=True)
             if self not in shared_list:
                 shared_list.append(self)
 


### PR DESCRIPTION
# Update:
- Unify the model download progress acquisition of huggingface and modelscope
- Support inserting callback function to obtain the model download progress

# Note:
- Need Upgrade modelscope to 1.21.0 !
   - Because [modelscope](https://github.com/modelscope/modelscope/blob/c09aabc630f9d85a4334d87da1c84cb433168186/modelscope/hub/snapshot_download.py#L395) uses `tqdm` in `tqdm.auto` in this version, which is consistent with [huggingface](https://github.com/huggingface/huggingface_hub/blob/5eef17964897652da99ec829df6354be18c59a07/src/huggingface_hub/utils/tqdm.py#L199), we can get the progress of all threads from the custom base class `tqdm.std.tqdm`.  why use `tqdm.std.tqdm`: 
       - 1. Huggingface provides [`tqdm_class`](https://huggingface.co/docs/huggingface_hub/v0.25.2/en/package_reference/file_download#huggingface_hub.snapshot_download.tqdm_class) in `snapshot_download`, but modelscope does not.
       - 2. The `tqdm_class` provided by huggingface counts the overall progress based on the granularity of subtasks, which is too rough and updates slowly.
   - Because this version includes this modification: https://github.com/modelscope/modelscope/issues/1114
- The callback function is passed to the subprocess for execution.

# Verify and Use Demo:
## huggingface:
Callback function usage example
![image](https://github.com/user-attachments/assets/cd29bfab-635d-42c7-9404-5b4181dc8978)

## modelscope:
Callback function usage example
![image](https://github.com/user-attachments/assets/3c06e6a0-88b4-4ada-828d-cdf85bbf86c2)

# Verify Multi-thread:
![image](https://github.com/user-attachments/assets/e306c897-c6b5-4020-94d8-9bd6ea478716)



