### PR TITLE
Supported Relevance Score after Reranker, and Add Online Reranker of GLM.

### DIFF
--- a/lazyllm/components/deploy/infinity.py
+++ b/lazyllm/components/deploy/infinity.py
@@ -92,4 +92,4 @@ class Infinity(LazyLLMDeployBase):
                 res_list = res_list[0]
             return json.dumps(res_list)
         elif object_type == 'rerank':
-            return [x['index'] for x in res_object['results']]
+            return [(x['index'], x['relevance_score']) for x in res_object['results']]

--- a/lazyllm/components/embedding/embed.py
+++ b/lazyllm/components/embedding/embed.py
@@ -62,10 +62,10 @@ class LazyHuggingFaceRerank(object):
         query, documents, top_n = inps['query'], inps['documents'], inps['top_n']
         query_pairs = [(query, doc) for doc in documents]
         scores = self.reranker.predict(query_pairs)
-        sorted_indices = np.argsort(scores)[::-1]
+        sorted_indices = [(index, scores[index]) for index in np.argsort(scores)[::-1]]
         if top_n > 0:
             sorted_indices = sorted_indices[:top_n]
-        return sorted_indices.tolist()
+        return sorted_indices
 
     @classmethod
     def rebuild(cls, base_rerank, init):

--- a/lazyllm/module/onlineEmbedding/glmEmbed.py
+++ b/lazyllm/module/onlineEmbedding/glmEmbed.py
@@ -1,5 +1,8 @@
+from typing import Any, Dict, List
+
 import lazyllm
 from .onlineEmbeddingModuleBase import OnlineEmbeddingModuleBase
+
 
 class GLMEmbedding(OnlineEmbeddingModuleBase):
     def __init__(self,
@@ -7,3 +10,31 @@ class GLMEmbedding(OnlineEmbeddingModuleBase):
                  embed_model_name: str = "embedding-2",
                  api_key: str = None):
         super().__init__("GLM", embed_url, api_key or lazyllm.config["glm_api_key"], embed_model_name)
+
+class GLMReranking(OnlineEmbeddingModuleBase):
+
+    def __init__(self,
+                 embed_url: str = "https://open.bigmodel.cn/api/paas/v4/rerank",
+                 embed_model_name: str = "rerank",
+                 api_key: str = None):
+        super().__init__("GLM", embed_url, api_key or lazyllm.config["glm_api_key"], embed_model_name)
+
+    @property
+    def type(self):
+        return "ONLINE_RERANK"
+
+    def _encapsulated_data(self, query: str, documents: List[str], top_n: int, **kwargs) -> Dict[str, str]:
+        json_data = {
+            "query": query,
+            "documents": documents,
+            "top_n": top_n,
+            "return_documents": False,
+            "return_raw_scores": True
+        }
+        if len(kwargs) > 0:
+            json_data.update(kwargs)
+
+        return json_data
+
+    def _parse_response(self, response: Dict[str, Any]) -> List[float]:
+        return [(result["index"], result["relevance_score"]) for result in response['results']]

--- a/lazyllm/module/onlineEmbedding/onlineEmbeddingModule.py
+++ b/lazyllm/module/onlineEmbedding/onlineEmbeddingModule.py
@@ -2,7 +2,7 @@ from typing import Any, Dict
 
 import lazyllm
 from .openaiEmbed import OpenAIEmbedding
-from .glmEmbed import GLMEmbedding
+from .glmEmbed import GLMEmbedding, GLMReranking
 from .sensenovaEmbed import SenseNovaEmbedding
 from .qwenEmbed import QwenEmbedding, QwenReranking
 from .onlineEmbeddingModuleBase import OnlineEmbeddingModuleBase
@@ -20,7 +20,8 @@ class OnlineEmbeddingModule(metaclass=__EmbedModuleMeta):
                     'sensenova': SenseNovaEmbedding,
                     'glm': GLMEmbedding,
                     'qwen': QwenEmbedding}
-    RERANK_MODELS = {'qwen': QwenReranking}
+    RERANK_MODELS = {'qwen': QwenReranking,
+                     'glm': GLMReranking}
 
     @staticmethod
     def _encapsulate_parameters(embed_url: str,
@@ -59,6 +60,8 @@ class OnlineEmbeddingModule(metaclass=__EmbedModuleMeta):
                 source = OnlineEmbeddingModule._check_available_source(OnlineEmbeddingModule.EMBED_MODELS)
             return OnlineEmbeddingModule.EMBED_MODELS[source](**params)
         elif kwargs.get("type") == "rerank":
+            if "type" in params:
+                params.pop("type")
             if source is None:
                 source = OnlineEmbeddingModule._check_available_source(OnlineEmbeddingModule.RERANK_MODELS)
             return OnlineEmbeddingModule.RERANK_MODELS[source](**params)

--- a/lazyllm/module/onlineEmbedding/qwenEmbed.py
+++ b/lazyllm/module/onlineEmbedding/qwenEmbed.py
@@ -58,4 +58,4 @@ class QwenReranking(OnlineEmbeddingModuleBase):
 
     def _parse_response(self, response: Dict[str, Any]) -> List[float]:
         results = response['output']['results']
-        return [result["index"] for result in results]
+        return [(result["index"], result["relevance_score"]) for result in results]

--- a/lazyllm/tools/rag/doc_node.py
+++ b/lazyllm/tools/rag/doc_node.py
@@ -36,6 +36,7 @@ class DocNode:
         self._children: Dict[str, List["DocNode"]] = defaultdict(list)
         self._lock = threading.Lock()
         self._embedding_state = set()
+        self.relevance_score = None
 
         if global_metadata and parent:
             raise ValueError('only ROOT node can set global metadata.')

--- a/lazyllm/tools/rag/doc_node.py
+++ b/lazyllm/tools/rag/doc_node.py
@@ -6,6 +6,7 @@ from .global_metadata import RAG_DOC_PATH
 import uuid
 import threading
 import time
+import copy
 
 class MetadataMode(str, Enum):
     ALL = auto()
@@ -204,6 +205,11 @@ class DocNode:
 
     def to_dict(self) -> Dict:
         return dict(content=self._content, embedding=self.embedding, metadata=self.metadata)
+
+    def with_score(self, score):
+        node = copy.copy(self)
+        node.relevance_score = score
+        return node
 
 
 class QADocNode(DocNode):

--- a/lazyllm/tools/rag/rerank.py
+++ b/lazyllm/tools/rag/rerank.py
@@ -110,8 +110,7 @@ class ModuleReranker(Reranker):
             sorted_indices = self._reranker(inps)
         results = []
         for index, relevance_score in sorted_indices:
-            nodes[index].relevance_score = relevance_score
-            results.append(nodes[index])
+            results.append(nodes[index].with_score(relevance_score))
         LOG.debug(f"Rerank use `{self._name}` and get nodes: {results}")
         return self._post_process(results)
 

--- a/lazyllm/tools/rag/rerank.py
+++ b/lazyllm/tools/rag/rerank.py
@@ -108,7 +108,10 @@ class ModuleReranker(Reranker):
         else:
             inps = {'query': query, 'documents': docs, 'top_n': top_n}
             sorted_indices = self._reranker(inps)
-        results = [nodes[i] for i in sorted_indices]
+        results = []
+        for index, relevance_score in sorted_indices:
+            nodes[index].relevance_score = relevance_score
+            results.append(nodes[index])
         LOG.debug(f"Rerank use `{self._name}` and get nodes: {results}")
         return self._post_process(results)
 

--- a/tests/advanced_tests/standard_test/test_reranker.py
+++ b/tests/advanced_tests/standard_test/test_reranker.py
@@ -52,6 +52,7 @@ class TestReranker(unittest.TestCase):
                 self.assertEqual(
                     results[0].get_text(), self.doc3.get_text()
                 )  # highest score
+                assert results[0].relevance_score > results[1].relevance_score
         if original_value:
             os.environ[env_key] = original_value
             lazyllm.config.refresh(env_key)


### PR DESCRIPTION
- Supported relevance score after reranker by addied it to instance of DocNode;
    - https://github.com/LazyAGI/LazyLLM/issues/381
    - 8 of https://github.com/LazyAGI/LazyLLM/issues/155
- Add online reranker of GLM.