### PR TITLE
fix(ImageDocNode): Add missing `content` parameter in super().__init__()

### DIFF
--- a/lazyllm/tools/rag/doc_node.py
+++ b/lazyllm/tools/rag/doc_node.py
@@ -238,7 +238,7 @@ class ImageDocNode(DocNode):
                  embedding: Optional[Dict[str, List[float]]] = None, parent: Optional["DocNode"] = None,
                  metadata: Optional[Dict[str, Any]] = None, global_metadata: Optional[Dict[str, Any]] = None,
                  *, text: Optional[str] = None):
-        super().__init__(uid, group, embedding, parent, metadata, global_metadata=global_metadata, text=text)
+        super().__init__(uid, None, group, embedding, parent, metadata, global_metadata=global_metadata, text=text)
         self._image_path = image_path.strip()
         self._modality = "image"
 


### PR DESCRIPTION
## Description
Fixed a parameter misalignment issue in `ImageDocNode.__init__()` where the `content` parameter was missing when calling `super().__init__()`

## Changes Made
- Added `None` as the `content` argument in `super().__init__()` to match `DocNode`'s parameter order:
  ```python
  # Before (missing content)
  super().__init__(uid, group, embedding, parent, metadata, global_metadata=global_metadata, text=text)
  
  # After (fixed)
  super().__init__(uid, None, group, embedding, parent, metadata, global_metadata=global_metadata, text=text)