### PR TITLE
modify prompter replace key for value

### DIFF
--- a/lazyllm/components/prompter/builtinPrompt.py
+++ b/lazyllm/components/prompter/builtinPrompt.py
@@ -115,7 +115,7 @@ class LazyLLMPrompterBase(metaclass=LazyLLMRegisterMetaClass):
         prompt_keys = list(set(re.findall(r'\{(\w+)\}', self._instruction_template)))
         if isinstance(input, (str, int)):
             if len(prompt_keys) == 1:
-                return self._instruction_template.format(**{prompt_keys[0]: input}), ''
+                return self._instruction_template.replace('{' + prompt_keys[0] + '}', input), ''
             else:
                 assert len(prompt_keys) == 0
                 return self._instruction_template, input


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/110638de-627b-47ce-8e17-7fd94e92a95d)
![image](https://github.com/user-attachments/assets/94b83a4b-de9e-4cdf-bfea-95ba08eba113)
![image](https://github.com/user-attachments/assets/fff34db4-af4c-418a-a9cd-e814e3207e55)
这里提取格式化占位符时，提取的是query，但是在使用input进行替换时，format找到了前面的花括号开始的一个部分 \nnextTopic，它被当作格式化占位符处理了，但是它没出现在prompt_keys中，所以报错了