### PR TITLE
Fix: Error in make_local_llm When deploy_method is Set to "auto"

### DIFF
--- a/lazyllm/engine/engine.py
+++ b/lazyllm/engine/engine.py
@@ -366,14 +366,17 @@ def make_ifs(cond: str, true: List[dict], false: List[dict], judge_on_full_input
 
 @NodeConstructor.register('LocalLLM')
 def make_local_llm(base_model: str, target_path: str = '', prompt: str = '', stream: bool = False,
-                   return_trace: bool = False, deploy_method: str = 'vllm', url: Optional[str] = None,
+                   return_trace: bool = False, deploy_method: str = 'auto', url: Optional[str] = None,
                    history: Optional[List[List[str]]] = None):
     if history and not (isinstance(history, list) and all(len(h) == 2 and isinstance(h, list) for h in history)):
         raise TypeError('history must be List[List[str, str]]')
     deploy_method = getattr(lazyllm.deploy, deploy_method)
     m = lazyllm.TrainableModule(base_model, target_path, stream=stream, return_trace=return_trace)
     m.prompt(prompt, history=history)
-    m.deploy_method(deploy_method, url=url)
+    if deploy_method is lazyllm.deploy.AutoDeploy:
+        m.deploy_method(deploy_method)
+    else:
+        m.deploy_method(deploy_method, url=url)
     return m
 
 


### PR DESCRIPTION
Modify the situation when using local models in the engine, if deploy is set to auto, the URL cannot be passed
![企业微信截图_17460055682825](https://github.com/user-attachments/assets/283b766c-5e49-497c-918e-f1791e41f008)
![企业微信截图_17460055328466](https://github.com/user-attachments/assets/76177771-d8be-492b-948f-e82b75dd5b8c)
