### PR TITLE
The result data obtained from embedding is 1024-dimensional, and in certain scenarios, ast.literal_eval(result) throws an error. This PR fixes the issue.

### DIFF
--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -39,19 +39,19 @@ def embed_wrapper(func: Optional[Callable[..., Any]]) -> Optional[Callable[..., 
                 # Fallback or raise error if json.loads also fails
                 # For example, if ast.literal_eval was truly necessary for some non-JSON compatible Python literal
                 try:
-                    LOG.warning("json.loads failed, attempting ast.literal_eval as a fallback (might hit recursion limit).")
+                    LOG.warning("json.loads failed, attempting ast.literal_eval as a "
+                                "fallback (might hit recursion limit).")
                     return ast.literal_eval(result)
                 except Exception as e:
                     LOG.error(f"Both json.loads and ast.literal_eval failed. Error: {e}")
-                    raise # Re-raise the original or a new error
-        elif isinstance(result, list): # Explicitly check if it's already a list
+                    raise  # Re-raise the original or a new error
+        elif isinstance(result, list):  # Explicitly check if it's already a list
             return result
         else:
             # Handle unexpected types by raising an error
             error_message = f"Expected List[float] or str (convertible to List[float]), but got {type(result)}"
             LOG.error(f"{error_message}")
             raise TypeError(error_message)
-
 
     return wrapper
 


### PR DESCRIPTION
embedding出来的result数据是1024维的，在某些场景ast.literal_eval(result) 会报错 『AST constructor recursion depth mismatch (before=75, after=72)』.但是 json.loads(result)  处理这种数据不会有问题
The result data obtained from embedding is 1024-dimensional. In some scenarios, `ast.literal_eval(result)` throws an error "AST constructor recursion depth mismatch (before=75, after=72)" when processing this data, whereas `json.loads(result)` can handle it without any issues.

解决这种报错，使得lazyllm在处理embedding得到的向量时更健壮
To make LazyLLM more robust when handling vectors obtained from embedding, this error needs to be addressed.

![企业微信截图_f6efa900-a3aa-4aba-8c5a-70ea1768cd90](https://github.com/user-attachments/assets/e771a9bb-d256-49ee-a8e9-e6f979b1948e)
![企业微信截图_d9c02f42-98cb-4c14-84dd-41eb8bf259d6](https://github.com/user-attachments/assets/f0bfad1f-576c-437e-8a81-04fe4227fb14)
