### PR TITLE
Add support for text-to-video(Wan2.1) capability and new diffusion models(Flux.1, CogView, sd3.5) 

### DIFF
--- a/lazyllm/components/utils/downloader/model_mapping.py
+++ b/lazyllm/components/utils/downloader/model_mapping.py
@@ -265,5 +265,33 @@ model_name_mapping = {
             "modelscope": "AI-ModelScope/stable-diffusion-3-medium-diffusers"
         },
         "type": "sd"
+    },
+    "stable-diffusion-3_5-large": {
+        "source": {
+            "huggingface": "stabilityai/stable-diffusion-3.5-large",
+            "modelscope": "AI-ModelScope/stable-diffusion-3.5-large"
+        },
+        "type": "sd"
+    },
+    "flux.1-dev": {
+        "source": {
+            "huggingface": "black-forest-labs/FLUX.1-dev",
+            "modelscope": "MusePublic/489_ckpt_FLUX_1"
+        },
+        "type": "sd"
+    },
+    "cogview4-6b": {
+        "source": {
+            "huggingface": "THUDM/CogView4-6B",
+            "modelscope": "ZhipuAI/CogView4-6B"
+        },
+        "type": "sd"
+    },
+    "wan2_1-t2v-1_3b-diffusers": {
+        "source": {
+            "huggingface": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
+            "modelscope": "Wan-AI/Wan2.1-T2V-1.3B-Diffusers"
+        },
+        "type": "sd"
     }
 }

--- a/lazyllm/tools/webpages/webmodule.py
+++ b/lazyllm/tools/webpages/webmodule.py
@@ -355,6 +355,8 @@ class WebModule(ModuleBase):
                         file = gr.Image(file_path)
                     elif suffix in ('.mp3', '.wav'):
                         file = gr.Audio(file_path)
+                    elif suffix in ('.mp4'):
+                        file = gr.Video(file_path)
                     else:
                         LOG.error(f'Not supported typr: {suffix}, for file: {file}')
                     if i == 0:


### PR DESCRIPTION
## Summary:
This PR introduces support for additional diffusion models (Flux, CogView) and adds text-to-video functionality through Wan2.1 implementation. The core architecture has been refactored using a registry pattern for better extensibility.

## New Features:
🎥 Text-to-video support via Wan2.1_t2v pipeline
🖼️ Expanded image generation with FLUX.1-dev, SD3.5 and CogView4-6B models
🧩 Registry-based architecture for model handling

## Usage Example:
```python
import lazyllm
from lazyllm import pipeline
with pipeline() as ppl:
    # ppl.sd3 = lazyllm.TrainableModule('path/to/stable-diffusion-3_5-large')
    # ppl.sd3 = lazyllm.TrainableModule('path/to/FLUX.1-dev')
    # ppl.sd3 = lazyllm.TrainableModule('path/to/CogView4-6B')
    ppl.sd3 = lazyllm.TrainableModule('path/to/Wan2_1-T2V-1_3B-Diffusers')

if __name__ == '__main__':
    lazyllm.WebModule(ppl, port=23458).start().wait()
```
## Show:
### FLUX.1-dev
![image](https://github.com/user-attachments/assets/19ba65a3-af4c-4a69-b617-1efc79d83c3b)

### CogView4
![image](https://github.com/user-attachments/assets/e3a96836-15ad-4955-8487-23dc5c0fb6e4)

### SD3.5
![image](https://github.com/user-attachments/assets/27e64985-8b69-4640-b1f4-9f8cc55bd988)

### Wan2_1
![image](https://github.com/user-attachments/assets/c450c242-9ab0-4f9b-9111-665f9d32bb2f)
