### PR TITLE
Prevent multithreading race conflicts in module hooks

### DIFF
--- a/lazyllm/module/module.py
+++ b/lazyllm/module/module.py
@@ -13,8 +13,8 @@ from ..hook import LazyLLMHook
 from lazyllm import FileSystemQueue
 from contextlib import contextmanager
 from typing import Optional, Union, Dict
-
 import copy
+
 # use _MetaBind:
 # if bind a ModuleBase: x, then hope: isinstance(x, ModuleBase)==True,
 # example: ActionModule.submodules:: isinstance(x, ModuleBase) will add submodule.


### PR DESCRIPTION
多线程下，对hook对象读写会有竞争冲突，因此需要每个线程各自copy一份