### PR TITLE
[Bugfix]: Fix online chat module stream bug when turning off think mode

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -154,7 +154,7 @@ class OnlineChatModuleBase(LLMBase):
         elif isinstance(src[0], list):
             assert len(set(map(len, src))) == 1, f"The lists of elements: {src} have different lengths."
             ret = list(map(self._merge_stream_result, zip(*src)))
-            return ret[0] if isinstance(ret[0], list) else ret
+            return ret[0] if (len(ret)>0 and isinstance(ret[0], list)) else ret
         elif isinstance(src[0], dict):  # list of dicts
             if 'index' in src[-1]:
                 grouped = [list(g) for _, g in groupby(sorted(src, key=itemget('index')), key=itemget("index"))]

--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -154,7 +154,7 @@ class OnlineChatModuleBase(LLMBase):
         elif isinstance(src[0], list):
             assert len(set(map(len, src))) == 1, f"The lists of elements: {src} have different lengths."
             ret = list(map(self._merge_stream_result, zip(*src)))
-            return ret[0] if (len(ret)>0 and isinstance(ret[0], list)) else ret
+            return ret[0] if (len(ret) > 0 and isinstance(ret[0], list)) else ret
         elif isinstance(src[0], dict):  # list of dicts
             if 'index' in src[-1]:
                 grouped = [list(g) for _, g in groupby(sorted(src, key=itemget('index')), key=itemget("index"))]


### PR DESCRIPTION
# Pull Request

## Description
online chat module meets stream output bug when turns of the think mode.

```pyhton
import lazyllm
llm = lazyllm.OnlineChatModule(base_url="http://10.119.21.242:25121/v1/",
                               model='Qwen3-32B',
                               stream=True)
print(llm("hello, who are you", enable_thinking=False))
```

报错如下
```bash
RuntimeError: 
An error occured in <class 'lazyllm.module.llms.onlinemodule.supplier.openai.OpenAIModule'> with name None.
Args:
('hello, who are you',)
Kwargs
{}
Error messages:
list index out of range
Original traceback:
  File "/home/LazyLLM/lazyllm/module/module.py", line 96, in __call__
    r = self.forward(**args[0], **kw) if args and isinstance(args[0], kwargs) else self.forward(*args, **kw)
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 196, in forward
    extractor = self._extract_specified_key_fields(self._merge_stream_result(msg_json))
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in _merge_stream_result
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in <dictcomp>
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 156, in _merge_stream_result
    ret = list(map(self._merge_stream_result, zip(*src)))
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in _merge_stream_result
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in <dictcomp>
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in _merge_stream_result
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 162, in <dictcomp>
    return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
  File "/home/LazyLLM/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py", line 157, in _merge_stream_result
    return ret[0] if isinstance(ret[0], list) else ret
```

## Type of Change
- [ ] Feature addition
- [x] Bug fix
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Testing related
- [ ] Security fix

## Impact Scope
- [ ] User interface
- [ ] API interface
- [ ] Database
- [ ] Configuration files
- [ ] Dependencies

## Priority
- [ ] High - Release immediately
- [ ] Medium - Next version
- [ ] Low - Future version

## Changes Made
- [ ] Change 1
- [ ] Change 2
- [ ] Change 3

## Testing
- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Performance testing (if applicable)

## Documentation
- [ ] Code comments added/updated
- [ ] README updated (if applicable)
- [ ] API documentation updated (if applicable)

## Breaking Changes
- [ ] No breaking changes
- [ ] Breaking changes documented
- [ ] Migration guide provided

## Related Issues
Closes #123, Related to #456

## Additional Notes
Any additional information or context

---

## Release Notes Points
- User-visible changes
- Configuration change instructions
- Migration steps
- Known issues 