### PR TITLE
Fixed staticmethod cannot attach doc.

### DIFF
--- a/lazyllm/docs/utils.py
+++ b/lazyllm/docs/utils.py
@@ -72,7 +72,7 @@ def add_doc(obj_name, docstr, module, append=''):
     for n in obj_name.split('.'):
         if isinstance(obj, type): obj = obj.__dict__[n]
         else: obj = getattr(obj, n)
-    if isinstance(obj, (classmethod, lazyllm.DynamicDescriptor)): obj = obj.__func__
+    if isinstance(obj, (classmethod, staticmethod, lazyllm.DynamicDescriptor)): obj = obj.__func__
     try:
         if append:
             if isinstance(docstr, str):


### PR DESCRIPTION
# Live Demo: 
https://lazyllm-show.readthedocs.io/en/latest/API%20Reference/components/#lazyllm.components.deploy.Lightllm.extract_result

# Before Fixed:
<img width="912" height="410" alt="企业微信截图_1756110461834" src="https://github.com/user-attachments/assets/1097d7b8-f9ba-490d-bea0-e53264b10547" />

# After Fixed:
<img width="911" height="457" alt="企业微信截图_17561106002235" src="https://github.com/user-attachments/assets/7501d37e-99bc-4887-868b-138b132e4680" />
