### PR TITLE
[Bug fix] Tiktoken path loads wrong

### DIFF
--- a/lazyllm/tools/rag/transform/base.py
+++ b/lazyllm/tools/rag/transform/base.py
@@ -185,9 +185,10 @@ class _TextSplitterBase(NodeTransform):
             if 'TIKTOKEN_CACHE_DIR' not in os.environ and 'DATA_GYM_CACHE_DIR' not in os.environ:
                 try:
                     model_path = config['model_path']
-                    if not model_path:
-                        model_path = os.path.join(os.path.expanduser('~'), '.lazyllm')
                 except (RuntimeError, KeyError, PermissionError):
+                    model_path = None
+
+                if not model_path:
                     model_path = os.path.join(os.path.expanduser('~'), '.lazyllm')
 
                 path = os.path.join(model_path, 'tiktoken')


### PR DESCRIPTION
## 📌 PR 内容 / PR Description
<!-- 简要描述本次 PR 的改动点 / Briefly describe the changes in this PR -->
- 修复未设置model_path和tiktoken_cache_dir情况下tiktoken文件夹位置错误的情况

## 🔍 相关 Issue / Related Issue
<!-- 例如：Fix #123 / Close #456 -->
- https://github.com/LazyAGI/LazyLLM/issues/868

## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [x] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [ ] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization


## 📷 截图 / Demo (Optional)
<!-- 如果是文档改动或者性能优化 / If document changes or performance optimization, please attach screenshots -->
<img width="713" height="205" alt="image" src="https://github.com/user-attachments/assets/5933302a-2d59-4836-a8d5-71b476871ace" />
- 添加model_path为空时的处理
