### PR TITLE
Fix CI doc deployment failure due to disk space exhaustion from redundant dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,15 +18,10 @@ httpcore
 httpx 
 idna 
 libcst==1.4.0 
-openai 
 pydantic-core 
 pydantic 
 pyyaml 
 sniffio
 tqdm 
 typing-extensions
-redis
-funasr
-transformers
-ChatTTS
 nbformat


### PR DESCRIPTION
## 📌 PR 内容 / PR Description
Resolves CI doc deployment failure by removing redundant dependencies that consumed excessive disk space.

- Base deps only: ~700 MB
- Docs deps (+Base deps): 8.8 GB (mainly from AI-related packages)
- Docs content + code: ~2.2 GB (incl. 1.1 GB .git, 1 GB videos)

After pruning redundant/AI-related packages, docs env reduced to ~944 MB.

## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [x] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [ ] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## 🧪 如何测试 / How Has This Been Tested?
CI pass.

## 📷 截图 / Demo (Optional)
<img width="814" height="476" alt="企业微信截图_1765884563402" src="https://github.com/user-attachments/assets/6a982fd1-ff24-4dea-94ff-536615044390" />

