### PR TITLE
Add New Args 'use_model_map' for TrainableModule

### DIFF
--- a/lazyllm/module/llms/trainablemodule.py
+++ b/lazyllm/module/llms/trainablemodule.py
@@ -76,7 +76,8 @@ class _TrainableModuleImpl(ModuleBase, _UrlHelper):
     def __init__(self, base_model: str = '', target_path: str = '', stream: bool = False, train: Optional[type] = None,
                  finetune: Optional[LazyLLMFinetuneBase] = None, deploy: Optional[LazyLLMDeployBase] = None,
                  template: Optional[_UrlTemplateStruct] = None, url_wrapper: Optional[_UrlHelper._Wrapper] = None,
-                 trust_remote_code: bool = True, type: Optional[LLMType] = None, source: Optional[str] = None):
+                 trust_remote_code: bool = True, type: Optional[LLMType] = None, source: Optional[str] = None,
+                 use_model_map: bool = True):
         super().__init__()
         # TODO(wangzhihong): Update ModelDownloader to support async download, and move it to deploy.
         #                    Then support Option for base_model
@@ -95,6 +96,7 @@ class _TrainableModuleImpl(ModuleBase, _UrlHelper):
         self._specific_target_path = target_path or None
         self._train, self._finetune = train, finetune
         self._template = template
+        self._use_model_map = use_model_map
         _UrlHelper.__init__(self, url=url_wrapper)
         if base_model and deploy: self.deploy_method(deploy)
         self._prepare_deploy = lambda target_path, base_model: lazyllm.package(target_path, base_model)
@@ -201,7 +203,8 @@ class _TrainableModuleImpl(ModuleBase, _UrlHelper):
         if hasattr(self._deploy, 'auto_map') and self._deploy.auto_map:
             self._deploy_args = map_kw_for_framework(self._deploy_args, self._deploy.auto_map)
 
-        trainable_module_config_map = get_trainable_module_config_map(lazyllm.config['trainable_module_config_map_path'])
+        trainable_module_config_map = get_trainable_module_config_map(
+            lazyllm.config['trainable_module_config_map_path']) if self._use_model_map else {}
 
         base_model_name = os.path.basename(self._base_model)
         if base_model_name in trainable_module_config_map:
@@ -267,12 +270,13 @@ class TrainableModule(UrlModule):
 
     def __init__(self, base_model: Option = '', target_path='', *, stream: Union[bool, Dict[str, str]] = False,
                  return_trace: bool = False, trust_remote_code: bool = True,
-                 type: Optional[Union[str, LLMType]] = None, source: Optional[str] = None):
+                 type: Optional[Union[str, LLMType]] = None, source: Optional[str] = None,
+                 use_model_map: bool = True):
         super().__init__(url=None, stream=stream, return_trace=return_trace, init_prompt=False)
         self._template = _UrlTemplateStruct()
         self._impl = _TrainableModuleImpl(base_model, target_path, stream, None, lazyllm.finetune.auto,
                                           lazyllm.deploy.auto, self._template, self._url_wrapper,
-                                          trust_remote_code, type, source=source)
+                                          trust_remote_code, type, source=source, use_model_map=use_model_map)
         self._stream = stream
         self.prompt()
         if config['cache_local_module']:

--- a/lazyllm/tools/infer_service/serve.py
+++ b/lazyllm/tools/infer_service/serve.py
@@ -146,7 +146,8 @@ class InferServer(ServerBase):
         os.makedirs(save_root, exist_ok=True)
         # wait 5 minutes for launch cmd
         hypram = dict(launcher=lazyllm.launchers.remote(sync=False, ngpus=job.num_gpus, retry=30), log_path=save_root)
-        m = lazyllm.TrainableModule(job.model_name).deploy_method((getattr(lazyllm.deploy, job.framework), hypram))
+        m = lazyllm.TrainableModule(job.model_name, use_model_map=False)\
+            .deploy_method((getattr(lazyllm.deploy, job.framework), hypram))
 
         # Launch Deploy:
         thread = threading.Thread(target=m.start)

--- a/tests/advanced_tests/Deploy/test_deploy.py
+++ b/tests/advanced_tests/Deploy/test_deploy.py
@@ -73,7 +73,8 @@ class TestDeploy(object):
         'lazyllm/components/deploy/vllm.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_deploy_vllm(self):
-        m = lazyllm.TrainableModule(self.model_path, '').deploy_method(deploy.vllm)
+        m = lazyllm.TrainableModule(self.model_path, '', use_model_map=False)\
+            .deploy_method(deploy.vllm)
         m.evalset(self.inputs)
         m.update_server()
         m.eval()
@@ -88,7 +89,8 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_embedding(self, set_enviroment):
-        m = lazyllm.TrainableModule('bge-large-zh-v1.5').deploy_method(deploy.AutoDeploy)
+        m = lazyllm.TrainableModule('bge-large-zh-v1.5', use_model_map=False)\
+            .deploy_method(deploy.AutoDeploy)
         m.update_server()
         res = m('你好')
         assert len(json.loads(res)) == 1024
@@ -102,7 +104,8 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_sparse_embedding(self):
-        m = lazyllm.TrainableModule('bge-m3').deploy_method((deploy.AutoDeploy, {'embed_type': 'sparse'}))
+        m = lazyllm.TrainableModule('bge-m3', use_model_map=False)\
+            .deploy_method((deploy.AutoDeploy, {'embed_type': 'sparse'}))
         m.update_server()
         res = m('你好')
         assert isinstance(json.loads(res), dict)
@@ -116,7 +119,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_cross_modal_embedding(self):
-        m = lazyllm.TrainableModule('siglip')
+        m = lazyllm.TrainableModule('siglip', use_model_map=False)
         m.update_server()
         res = m('你好')
         assert len(json.loads(res)) == 1152
@@ -141,7 +144,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_sd3(self):
-        m = lazyllm.TrainableModule('stable-diffusion-3-medium')
+        m = lazyllm.TrainableModule('stable-diffusion-3-medium', use_model_map=False)
         m.update_server()
         r = m('a little cat')
         res = decode_query_with_filepaths(r)
@@ -153,7 +156,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_musicgen(self):
-        m = lazyllm.TrainableModule('musicgen-stereo-small')
+        m = lazyllm.TrainableModule('musicgen-stereo-small', use_model_map=False)
         m.update_server()
         r = m('lo-fi music with a soothing melody')
         res = decode_query_with_filepaths(r)
@@ -166,7 +169,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_chattts(self):
-        m = lazyllm.TrainableModule('ChatTTS-new')
+        m = lazyllm.TrainableModule('ChatTTS-new', use_model_map=False)
         m.update_server()
         r = m('你好啊，很高兴认识你。')
         res = decode_query_with_filepaths(r)
@@ -178,7 +181,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_stt_sensevoice(self):
-        chat = lazyllm.TrainableModule('sensevoicesmall')
+        chat = lazyllm.TrainableModule('sensevoicesmall', use_model_map=False)
         m = lazyllm.ServerModule(chat)
         m.update_server()
         audio_path = os.path.join(lazyllm.config['data_path'], 'ci_data/shuidiaogetou.mp3')
@@ -224,7 +227,8 @@ class TestDeploy(object):
     def test_stt_bind(self):
         audio_path = os.path.join(lazyllm.config['data_path'], 'ci_data/shuidiaogetou.mp3')
         with lazyllm.pipeline() as ppl:
-            ppl.m = lazyllm.TrainableModule('sensevoicesmall') | lazyllm.bind('No use inputs', lazyllm_files=ppl.input)
+            ppl.m = lazyllm.TrainableModule('sensevoicesmall', use_model_map=False) | \
+                lazyllm.bind('No use inputs', lazyllm_files=ppl.input)
         m = lazyllm.ActionModule(ppl)
         m.update_server()
         res = m(audio_path)
@@ -241,7 +245,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_vlm_and_lmdeploy(self):
-        chat = lazyllm.TrainableModule('InternVL3_5-1B')
+        chat = lazyllm.TrainableModule('InternVL3_5-1B', use_model_map=False)
         m = lazyllm.ServerModule(chat)
         m.update_server()
         query = '这是啥？'

--- a/tests/advanced_tests/Deploy/test_deploy_full.py
+++ b/tests/advanced_tests/Deploy/test_deploy_full.py
@@ -93,7 +93,8 @@ class TestDeploy(object):
         'lazyllm/components/deploy/lightllm.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_deploy_lightllm(self):
-        m = lazyllm.TrainableModule(self.model_path, '').deploy_method(deploy.lightllm)
+        m = lazyllm.TrainableModule(self.model_path, '', use_model_map=False)\
+            .deploy_method(deploy.lightllm)
         m.evalset(self.inputs)
         m.update_server()
         m.eval()
@@ -107,7 +108,8 @@ class TestDeploy(object):
         'lazyllm/components/auto/autodeploy.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_deploy_auto(self):
-        m = lazyllm.TrainableModule(self.model_path, '').deploy_method(deploy.AutoDeploy)
+        m = lazyllm.TrainableModule(self.model_path, '', use_model_map=False)\
+            .deploy_method(deploy.AutoDeploy)
         assert m._deploy_type != lazyllm.deploy.AutoDeploy
         m.evalset(self.inputs)
         m.update_server()
@@ -119,7 +121,7 @@ class TestDeploy(object):
         'lazyllm/components/auto/auto_helper.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_deploy_auto_without_calling_method(self):
-        m = lazyllm.TrainableModule(self.model_path, '')
+        m = lazyllm.TrainableModule(self.model_path, '', use_model_map=False)
         m.evalset(self.inputs)
         m.update_server()
         m.eval()
@@ -129,7 +131,7 @@ class TestDeploy(object):
         'lazyllm/components/deploy/text_to_speech/bark.py',
         'lazyllm/module/llms/trainablemodule.py')
     def test_bark(self):
-        m = lazyllm.TrainableModule('bark')
+        m = lazyllm.TrainableModule('bark', use_model_map=False)
         m.update_server()
         r = m('你好啊，很高兴认识你。')
         res = decode_query_with_filepaths(r)

--- a/tests/engine_tests/test_infer_server.py
+++ b/tests/engine_tests/test_infer_server.py
@@ -74,7 +74,7 @@ class TestInferServer:
         'lazyllm/engine/lightengine.py')
     def test_engine_infer_server_vqa(self):
         model_name = 'InternVL3_5-1B'
-        model_name, deploy_method, url = self.deploy_inference_service(model_name, deploy_method='vllm', num_gpus=1)
+        model_name, deploy_method, url = self.deploy_inference_service(model_name, deploy_method='lmdeploy', num_gpus=1)
         model = lazyllm.TrainableModule(model_name).deploy_method(getattr(lazyllm.deploy, deploy_method), url=url)
         assert model._impl._get_deploy_tasks.flag
         r = model('这张图片描述的是什么？', lazyllm_files=os.path.join(lazyllm.config['data_path'], 'ci_data/ji.jpg'))


### PR DESCRIPTION
## 📌 PR 内容 / PR Description

This PR introduces a new argument `use_model_map` for `TrainableModule`, defaulting to `True`. 

When `use_model_map` is `True` and `LAZYLLM_TRAINABLE_MODULE_CONFIG_MAP_PATH` is configured, the module will directly load and use the deployed model from the map instead of initiating a new deployment. This improves efficiency by reusing available model deployments.

If `use_model_map` is `False` or the environment variable is not set, the module will proceed with a fresh deployment as usual.

This change provides better control over model deployment behavior, especially in environments with pre-configured model resources.


## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [ ] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [X] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## 🧪 如何测试 / How Has This Been Tested?
```bash
python -m pytest tests/engine_tests/test_infer_server.py::TestInferServer::test_engine_infer_server_vqa -vs
python -m pytest tests/engine_tests/test_infer_server.py::TestInferServer::test_engine_infer_server_tts -vs
python -m pytest tests/engine_tests/test_infer_server.py::TestInferServer::test_engine_infer_server -vs
```

## 📷 截图 / Demo (Optional)
<img width="1269" height="483" alt="image" src="https://github.com/user-attachments/assets/a6a6cf00-404c-4a8e-8374-4ca967615f84" />

<img width="1270" height="467" alt="image" src="https://github.com/user-attachments/assets/b662dd34-1a71-452d-a9fd-046823b243c7" />

<img width="1276" height="483" alt="image" src="https://github.com/user-attachments/assets/9b4b5fcc-821e-4f39-a21e-72bd9df74ada" />
