### PR TITLE
support config-prefix for lazyllm extension

### DIFF
--- a/lazyllm/__init__.py
+++ b/lazyllm/__init__.py
@@ -4,8 +4,7 @@ __version__ = '0.7.2'
 
 import importlib
 import builtins
-from .configs import config, refresh_config
-from .configs import * # noqa F401 of Config
+from .configs import config, refresh_config, Mode, Config, Namespace as namespace
 from .common import *  # noqa F403
 from .launcher import LazyLLMLaunchersBase
 from .flow import *  # noqa F403
@@ -63,8 +62,10 @@ __all__ = [
 
     # configs
     'Mode',
+    'Config',
     'config',
     'refresh_config',
+    'namespace',
 
     # module
     'ModuleBase',

--- a/lazyllm/__init__.py
+++ b/lazyllm/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.7.2'
 
 import importlib
 import builtins
-from .configs import config
+from .configs import config, refresh_config
 from .configs import * # noqa F401 of Config
 from .common import *  # noqa F403
 from .launcher import LazyLLMLaunchersBase
@@ -26,7 +26,7 @@ from .patch import patch_os_env
 from .docs import add_doc
 config.done()
 
-patch_os_env(lambda key, value: config.refresh(key), config.refresh)
+patch_os_env(lambda key, value: refresh_config(key), refresh_config)
 
 del LazyLLMRegisterMetaClass  # noqa F821
 del LazyLLMRegisterMetaABCClass  # noqa F821
@@ -63,6 +63,8 @@ __all__ = [
 
     # configs
     'Mode',
+    'config',
+    'refresh_config',
 
     # module
     'ModuleBase',

--- a/lazyllm/configs.py
+++ b/lazyllm/configs.py
@@ -264,11 +264,18 @@ def refresh_config(key):
 
 
 class Namespace(object):
-    supported = ['AutoModel', 'OnlineModule', 'OnlineChatModule', 'OnlineEmbeddingModule', 'OnlineMultiModalModule']
+    supported = set()
 
     def __init__(self, space: str):
         self._space = space
         self._cm = None
+
+    @staticmethod
+    def register_module(module: Union[str, List[str]]):
+        if isinstance(module, str):
+            Namespace.supported.add(module)
+        else:
+            Namespace.supported.update(module)
 
     def __getattr__(self, __key):
         def wrapper(*args, **kw):

--- a/lazyllm/configs.py
+++ b/lazyllm/configs.py
@@ -204,7 +204,7 @@ class _NamespaceConfig(object):
 
     @contextmanager
     def temp(self, name, value):
-        with self._config.temp:
+        with self._config.temp(name, value):
             yield
 
     def done(self):

--- a/lazyllm/configs.py
+++ b/lazyllm/configs.py
@@ -1,9 +1,9 @@
 import os
 from enum import Enum
 import json
+import threading
 from typing import List, Union, Optional
 from contextlib import contextmanager
-import logging
 
 
 class Mode(Enum):
@@ -12,15 +12,26 @@ class Mode(Enum):
     Debug = 2,
 
 
-class _MetaDoc(type):
-    _description = dict()
+class _ConfigMeta(type):
+    _registered_cfgs = dict()
+    _env_name_map = dict()
     _doc = ''
+    _instances = dict()
+    _lock = threading.RLock()
+
+    def __call__(cls, prefix: str = 'LAZYLLM', *args, **kwargs):
+        if prefix.lower() not in cls._instances:
+            with cls._lock:
+                if prefix.lower() not in cls._instances:
+                    cls._instances[prefix.lower()] = super().__call__(prefix, *args, **kwargs)
+        return cls._instances[prefix.lower()]
 
     @staticmethod
     def _get_description(name):
-        desc = _MetaDoc._description[name]
+        desc = _ConfigMeta._registered_cfgs[name]
         if not desc: raise ValueError(f'Description for {name} is not found')
-        doc = (f'  - Description: {desc["description"]}, type: `{desc["type"]}`, default: `{desc["default"]}`<br>\n')
+        doc = (f'  - Description: {desc["description"]}, type: `{desc["type"].__name__}`, '
+               'default: `{desc["default"]}`<br>\n')
         if (options := desc.get('options')):
             doc += f'  - Options: {", ".join(options)}<br>\n'
         if (env := desc.get('env')):
@@ -36,31 +47,32 @@ class _MetaDoc(type):
     def __doc__(self):
         doc = f'{self._doc}\n**LazyLLM Configurations:**\n\n'
         return doc + '<br>\n'.join([f'- **{name}**:<br>\n{self._get_description(name)}'
-                                    for name in self._description.keys()])
+                                    for name in self._registered_cfgs.keys()])
 
     @__doc__.setter
     def __doc__(self, value):
         self._doc = value
 
+    def __contains__(self, key):
+        return key.lower() in self._instances or '_' in key and key.split('_')[0].lower() in self._instances
 
-class Config(metaclass=_MetaDoc):
-    def __init__(self, prefix='LAZYLLM', home: Optional[str] = None, config_file: str = 'config.json'):
-        self._config_params = dict()
-        self._env_map_name = dict()
-        self._prefix = prefix
-        self.impl, self.cfgs = dict(), dict()
+
+class Config(metaclass=_ConfigMeta):
+    def __init__(self, prefix: str = 'LAZYLLM', home: Optional[str] = None, config_file: str = 'config.json'):
+        self._prefix = prefix.upper()
+        self._impl, self._cfgs = dict(), dict()
         if not home:
-            home = '.lazyllm' if prefix == 'LAZYLLM' else f'.lazyllm_{prefix.lower()}'
+            home = '.lazyllm' if self._prefix == 'LAZYLLM' else f'.lazyllm_{prefix.lower()}'
             home = os.path.join(os.path.expanduser('~'), home)
         self.add('home', str, os.path.expanduser(home), 'HOME', description='The default home directory for LazyLLM.')
         os.makedirs(home, exist_ok=True)
         self._cgf_path = os.path.join(self['home'], config_file)
         if os.path.exists(self._cgf_path):
             with open(self._cgf_path, 'r+') as f:
-                self.cfgs = Config.get_config(json.loads(f))
+                self._cfgs = Config.get_config(json.loads(f))
 
     def done(self):
-        assert len(self.cfgs) == 0, f'Invalid cfgs ({"".join(self.cfgs.keys())}) are given in {self._cgf_path}'
+        assert len(self._cfgs) == 0, f'Invalid cfgs ({"".join(self._cfgs.keys())}) are given in {self._cgf_path}'
         return self
 
     def getenv(self, name, type, default=None):
@@ -74,73 +86,81 @@ class Config(metaclass=_MetaDoc):
         return cfg
 
     def get_all_configs(self):
-        return self.impl
+        return self._impl
 
     @contextmanager
     def temp(self, name, value):
         old_value = self[name]
-        self.impl[name] = value
+        self._impl[name] = value
         yield
-        self.impl[name] = old_value
+        self._impl[name] = old_value
 
     def add(self, name: str, type: type, default: Optional[Union[int, str, bool]] = None, env: Union[str, dict] = None,
             *, options: Optional[List] = None, description: Optional[str] = None):
-        update_params = (type, default, env)
-        if name not in self._config_params or self._config_params[name] != update_params:
-            if name in self._config_params:
-                logging.warning(f'The default configuration parameter {name}({self._config_params[name]}) '
-                                f'has been added, but a new {name}({update_params}) has been added repeatedly.')
-            self._config_params.update({name: update_params})
-            envs = [env] if isinstance(env, str) else env.keys() if isinstance(env, dict) else env
-            for k in envs: self._env_map_name[(f'{self._prefix.lower()}_' + k).upper()] = name
+        if name in Config.__dict__.keys():
+            raise RuntimeError(f'{name} is attribute of Config, please change it!')
+        update_params = dict(type=type, default=default, env=env, options=options, description=description)
+        if name not in _ConfigMeta._registered_cfgs or _ConfigMeta._registered_cfgs[name] != update_params:
+            _ConfigMeta._registered_cfgs[name] = update_params
+            if not env: env = name.lower()
+            for k in ([env] if isinstance(env, str) else env.keys() if isinstance(env, dict) else env):
+                _ConfigMeta._env_name_map[k.lower()] = name
         self._update_impl(name, type, default, env)
-        if self._prefix == 'LAZYLLM':
-            _MetaDoc._description[name] = dict(type=type.__name__, default=default,
-                                               env=env, options=options, description=description)
         return self
 
     def _update_impl(self, name: str, type: type, default: Optional[Union[int, str, bool]] = None,
-                     env: Union[str, dict] = None):
-        self.impl[name] = self.cfgs.pop(name) if name in self.cfgs else default
+                     env: Union[str, dict, list] = None):
+        self._impl[name] = self._cfgs.pop(name) if name in self._cfgs else default
         if isinstance(env, dict):
             for k, v in env.items():
                 if self.getenv(k, bool):
-                    self.impl[name] = v
+                    self._impl[name] = v
                     break
         elif isinstance(env, list):
             for k in env:
-                if (v := self.getenv(k, bool)):
-                    self.impl[name] = v
+                if (v := self.getenv(k, type)):
+                    self._impl[name] = v
                     break
         elif env:
-            self.impl[name] = self.getenv(env, type, self.impl[name])
-        if not isinstance(self.impl[name], type) and self.impl[name] is not None: raise TypeError(
+            self._impl[name] = self.getenv(env, type, self._impl[name])
+        if not isinstance(self._impl[name], type) and self._impl[name] is not None: raise TypeError(
             f'Invalid config type for {name}, type is {type}')
 
     def __getitem__(self, name):
         try:
             if isinstance(name, bytes): name = name.decode('utf-8')
-            return self.impl[name]
+            name = name.lower()
+            if name.startswith(f'{self._prefix.lower()}_'): name = name[len(self._prefix) + 1:]
+            return self._impl[name]
         except KeyError:
             raise RuntimeError(f'Key `{name}` is not in lazyllm global config')
 
+    def __getattr__(self, __key: str):
+        try:
+            return self[__key]
+        except (RuntimeError, KeyError):
+            raise AttributeError(f'class {self.__class__.__name__} has no attribute {__key}')
+
     def __str__(self):
-        return str(self.impl)
+        return str(self._impl)
+
+    @property
+    def _envs(self):
+        return [f'{self._prefix}_{e}'.lower() for e in _ConfigMeta._env_name_map.keys()]
 
     def refresh(self, targets: Union[bytes, str, List[str]] = None) -> None:
-        names = targets
+        names, all_envs = targets, self._envs
         if isinstance(targets, bytes): targets = targets.decode('utf-8')
         if isinstance(targets, str):
-            names = targets.lower()
-            if names.startswith(f'{self._prefix.lower()}_'):
-                names = names[(len(self._prefix) + 1):]
-            names = [names]
+            names = [targets.lower()]
         elif targets is None:
-            curr_envs = [key for key in os.environ.keys() if key.startswith(f'{self._prefix}_')]
-            names = list(set([self._env_map_name[key] for key in curr_envs if key in self._env_map_name]))
+            names = [key.lower() for key in os.environ.keys() if key.lower() in all_envs]
         assert isinstance(names, list)
         for name in names:
-            if name in self.impl: self._update_impl(name, *self._config_params[name])
+            if name.lower() in all_envs:
+                name = _ConfigMeta._env_name_map[name[len(self._prefix) + 1:]]
+            cfg = _ConfigMeta._registered_cfgs[name]
+            if name in self._impl: self._update_impl(name, cfg['type'], cfg['default'], cfg['env'])
 
 config = Config().add('mode', Mode, Mode.Normal, dict(DISPLAY=Mode.Display, DEBUG=Mode.Debug),
                       description='The default mode for LazyLLM.'

--- a/lazyllm/configs.py
+++ b/lazyllm/configs.py
@@ -151,14 +151,14 @@ class Config(metaclass=_ConfigMeta):
     def refresh(self, targets: Union[bytes, str, List[str]] = None) -> None:
         names, all_envs = targets, self._envs
         if isinstance(targets, bytes): targets = targets.decode('utf-8')
-        if isinstance(targets, str):
-            names = [targets.lower()]
+        if isinstance(targets, str): names = [targets.lower()]
         elif targets is None:
             names = [key.lower() for key in os.environ.keys() if key.lower() in all_envs]
         assert isinstance(names, list)
         for name in names:
             if name.lower() in all_envs:
                 name = _ConfigMeta._env_name_map[name[len(self._prefix) + 1:]]
+            elif name in Config: continue
             cfg = _ConfigMeta._registered_cfgs[name]
             if name in self._impl: self._update_impl(name, cfg['type'], cfg['default'], cfg['env'])
 
@@ -182,3 +182,7 @@ config = Config().add('mode', Mode, Mode.Normal, dict(DISPLAY=Mode.Display, DEBU
                 ).add('allow_internal_network', bool, False, 'ALLOW_INTERNAL_NETWORK',
                       description='Whether to allow loading images from internal network addresses. '
                                   'Set to False for security in production environments.')
+
+def refresh_config(key):
+    if key in Config:
+        Config._instances[key.split('_')[0].lower()].refresh(key)

--- a/lazyllm/docs/configs.py
+++ b/lazyllm/docs/configs.py
@@ -203,30 +203,20 @@ AutoModel, OnlineModule, OnlineChatModule, OnlineEmbeddingModule, and OnlineMult
   create a separate instance per thread even if they share the same space name.
 ''')
 
-add_example('Namespace', '''\
+add_example('namespace', '''\
 >>> import os
 >>> import lazyllm
->>> from lazyllm import Namespace
->>>
+>>> from lazyllm import namespace
 >>> with lazyllm.namespace('my'):
 ...     assert lazyllm.config['gpu_type'] == 'A100'
 ...     os.environ['MY_GPU_TYPE'] = 'H100'
 ...     assert lazyllm.config['gpu_type'] == 'H100'
+...
+>>>
 >>> assert lazyllm.config['gpu_type'] == 'A100'
 >>>
->>> class DummyChat(object):
-...     def __init__(self, *args, **kw):
-...         self._api = lazyllm.config['gpu_type']
->>>
->>> lazyllm.OnlineChatModule = DummyChat
->>>
->>> lazyllm.OnlineChatModule()._api
-'A100'
->>>
 >>> with lazyllm.namespace('my'):
-...     lazyllm.OnlineChatModule()._api
-'H100'
->>>
->>> Namespace('my').OnlineChatModule()._api
-'H100'
+...     m = lazyllm.OnlineChatModule()
+...
+>>> m = lazyllm.namespace('my').OnlineChatModule()
 ''')

--- a/lazyllm/docs/configs.py
+++ b/lazyllm/docs/configs.py
@@ -129,9 +129,7 @@ Args:
 ''')
 
 add_chinese_doc('Config.temp', '''
-临时修改配置项的上下文管理器。
-
-在with语句块内临时修改指定配置项的值，退出语句块后自动恢复原值。
+临时修改配置项的上下文管理器。在with语句块内临时修改指定配置项的值，退出语句块后自动恢复原值。注意，此函数并非线程安全，请勿在多线程或者多协程的环境下使用。
 
 Args:
     name (str): 要临时修改的配置项名称。
@@ -140,8 +138,8 @@ Args:
 
 add_english_doc('Config.temp', '''
 Context manager for temporary configuration modification.
-
 Temporarily modifies the value of the specified configuration item within the with statement block, and automatically restores the original value when exiting the block.
+Attention: this function is not thread-safe, you should not use it in multi-thread or multi-coroutine environment.
 
 Args:
     name (str): The name of the configuration item to temporarily change.

--- a/lazyllm/docs/configs.py
+++ b/lazyllm/docs/configs.py
@@ -166,7 +166,7 @@ Args:
 add_chinese_doc('namespace', '''\
 命名空间包装器，用于在指定的配置命名空间（namespace）中调用 LazyLLM 的模块构造函数。
 
-`Namespace` 既可以作为上下文管理器使用，也可以直接通过属性访问的方式，
+`namespace` 既可以作为上下文管理器使用，也可以直接通过属性访问的方式，
 在不显式使用 `with` 的情况下，将某一次模块构造绑定到指定的 namespace 中。
 
 支持的模块包括：
@@ -179,13 +179,13 @@ AutoModel、OnlineModule、OnlineChatModule、OnlineEmbeddingModule、OnlineMult
   仅对单次模块构造生效，不影响全局状态。
 
 **注意事项：**\n
-- `Namespace` 实例本身不是线程安全的，多线程环境中应为每个线程创建独立实例。
+- `namespace` 实例本身不是线程安全的，多线程环境中应为每个线程创建独立实例。
 ''')
 
 add_english_doc('namespace', '''\
 A namespace wrapper used to invoke LazyLLM module constructors under a specified configuration namespace.
 
-`Namespace` can be used either as a context manager or as a lightweight wrapper for single calls.
+`namespace` can be used either as a context manager or as a lightweight wrapper for single calls.
 It allows binding LazyLLM configuration and module construction to a specific namespace
 without affecting the global configuration.
 
@@ -199,7 +199,7 @@ AutoModel, OnlineModule, OnlineChatModule, OnlineEmbeddingModule, and OnlineMult
   only to that single constructor call.
 
 **Notes:**\n
-- A `Namespace` instance is not thread-safe. In multi-threaded environments,
+- A `namespace` instance is not thread-safe. In multi-threaded environments,
   create a separate instance per thread even if they share the same space name.
 ''')
 
@@ -220,3 +220,48 @@ add_example('namespace', '''\
 ...
 >>> m = lazyllm.namespace('my').OnlineChatModule()
 ''')
+
+add_chinese_doc('namespace.register_module', """\
+向 `namespace` 注册可被代理调用的 LazyLLM 模块名称。
+
+被注册的模块名将被加入 `namespace.supported` 集合中，
+之后即可通过 `namespace(space).<ModuleName>(...)` 的形式，
+在指定的 namespace 下构造对应模块。
+
+该方法是一个类级别的注册接口，对所有 `namespace` 实例生效。
+
+**Parameters:**\n
+- module (str | List[str]): 需要注册的模块名称。
+  - 当为字符串时，注册单个模块名；
+  - 当为列表时，批量注册多个模块名。
+""")
+
+add_english_doc('namespace.register_module', """\
+Register LazyLLM module names that can be proxied by `namespace`.
+
+Registered module names will be added to the class-level `namespace.supported` set,
+allowing them to be constructed via `namespace(space).<ModuleName>(...)`
+under the specified namespace.
+
+This is a class-level registration method and affects all `namespace` instances.
+
+**Parameters:**\n
+- module (str | List[str]): The module name(s) to register.
+  - A string registers a single module name;
+  - A list of strings registers multiple module names at once.
+""")
+
+add_example('namespace.register_module', """\
+>>> import lazyllm
+>>> from lazyllm import namespace
+>>> namespace.register_module('OnlineChatModule')
+>>> 'OnlineChatModule' in namespace.supported
+True
+>>> namespace.register_module(['AutoModel', 'OnlineEmbeddingModule'])
+>>> 'AutoModel' in namespace.supported
+True
+>>> 'OnlineEmbeddingModule' in namespace.supported
+True
+>>> namespace('my').OnlineChatModule().space
+'my'
+""")

--- a/lazyllm/docs/utils.py
+++ b/lazyllm/docs/utils.py
@@ -131,7 +131,7 @@ def rewrite_lines(doc_lines: list[str]) -> list[str]:
             new_doc_lines.append(doc_line)
             continue
         assert_expr, assert_val, err_msg = triples[0]
-        if ast.literal_eval(err_msg) == CODE_CHCHECK_MSG:
+        if err_msg and ast.literal_eval(err_msg) == CODE_CHCHECK_MSG:
             new_doc_lines += [f'{CODE_STARTS}{assert_expr}', f'{assert_val}']
         else:
             new_doc_lines.append(doc_line)

--- a/lazyllm/module/llms/__init__.py
+++ b/lazyllm/module/llms/__init__.py
@@ -6,7 +6,10 @@ from .onlinemodule import (
 )
 from .online_module import OnlineModule
 from .trainablemodule import TrainableModule
-from lazyllm import config
+from lazyllm import config, namespace
+
+namespace.register_module(['AutoModel', 'OnlineModule', 'OnlineChatModule',
+                           'OnlineEmbeddingModule', 'OnlineMultiModalModule'])
 
 
 __all__ = [

--- a/lazyllm/patch.py
+++ b/lazyllm/patch.py
@@ -121,14 +121,14 @@ def patch_os_env(set_action: Callable[[str, str], None], unset_action: Callable[
     def new_setitem(self, key, value):
         old_setitem(self, key, value)
         if isinstance(key, bytes): key = key.decode('utf-8')
-        if key.lower().startswith('lazyllm_'): set_action(key, value)
+        set_action(key, value)
 
     old_delitem = os._Environ.__delitem__
 
     def new_delitem(self, key):
         old_delitem(self, key)
         if isinstance(key, bytes): key = key.decode('utf-8')
-        if key.lower().startswith('lazyllm_'): unset_action(key)
+        unset_action(key)
 
     os._Environ.__setitem__ = new_setitem
     os._Environ.__delitem__ = new_delitem

--- a/tests/basic_tests/test_config.py
+++ b/tests/basic_tests/test_config.py
@@ -7,7 +7,7 @@ import contextlib
 import inspect
 
 
-isolate_env = "PARROTS_ISOLATE_STATUS"
+isolate_env = 'PARROTS_ISOLATE_STATUS'
 
 
 def isolated(func):
@@ -18,23 +18,22 @@ def isolated(func):
         method_name = func.__name__
         test_func = file_path + '::' + class_name + '::' + method_name
         with clear_env():
-            with set_env(isolate_env, "IN_SUBPROCESS"):
+            with set_env(isolate_env, 'IN_SUBPROCESS'):
                 result = pytester.runpytest_subprocess(test_func)
         assert result.ret == 0
 
     if not inspect.isfunction(func):
-        raise TypeError("Decorator 'isolated' can only decorate functions.")
+        raise TypeError('Decorator "isolated" can only decorate functions.')
 
     fn_code = func.__code__
     if 'self' not in fn_code.co_varnames or fn_code.co_argcount != 1:
-        raise TypeError("Decorated function should be method and "
-                        "have exactly one argument 'self'.")
+        raise TypeError('Decorated function should be method and have exactly one argument "self".')
 
     isolate_status = os.getenv(isolate_env)
-    if isolate_status == "IN_SUBPROCESS":
+    if isolate_status == 'IN_SUBPROCESS':
         return func
     # set environ variable to 'OFF' to skip all isolated tests.
-    elif isolate_status == "OFF":
+    elif isolate_status == 'OFF':
         return pytest.mark.skip(func)
     else:
         return pytest.mark.isolate(run_subprocess)
@@ -42,13 +41,13 @@ def isolated(func):
 
 class TestConfig(object):
     def test_refresh(self):
-        origin = copy.deepcopy(lazyllm.config.impl)
+        origin = copy.deepcopy(lazyllm.config._impl)
         os.environ['LAZYLLM_GPU_TYPE'] = 'H100'
-        assert lazyllm.config.impl['gpu_type'] == 'H100'
+        assert lazyllm.config._impl['gpu_type'] == 'H100'
         os.environ['LAZYLLM_GPU_TYPE'] = origin['gpu_type']
-        assert lazyllm.config.impl['gpu_type'] == origin['gpu_type']
+        assert lazyllm.config._impl['gpu_type'] == origin['gpu_type']
         lazyllm.config.refresh()
-        assert lazyllm.config.impl == origin
+        assert lazyllm.config._impl == origin
 
     def test_config_mode(self):
         print(os.environ.get('LAZYLLM_DISPLAY'))
@@ -61,7 +60,7 @@ class TestConfig(object):
 
 @contextlib.contextmanager
 def clear_env():
-    LAZYLLM_DISPLAY = "LAZYLLM_DISPLAY"
+    LAZYLLM_DISPLAY = 'LAZYLLM_DISPLAY'
 
     env_list = [
         LAZYLLM_DISPLAY,
@@ -70,7 +69,7 @@ def clear_env():
     print(env_flags)
     for env, flag in zip(env_list, env_flags):
         if flag is not None:
-            os.environ[env] = ""
+            os.environ[env] = ''
             if os.getenv(env) is not None:
                 del os.environ[env]
 

--- a/tests/basic_tests/test_config.py
+++ b/tests/basic_tests/test_config.py
@@ -50,14 +50,14 @@ class TestConfig(object):
         assert lazyllm.config._impl == origin
 
     def test_config_mode(self):
-        print(os.environ.get('LAZYLLM_DISPLAY'))
         assert lazyllm.config['mode'] == Mode.Normal
 
     @isolated
     def test_config_disp(self):
-        print(os.environ.get('LAZYLLM_DISPLAY'))
+        os.environ['LAZYLLM_DISPLAY'] = '1'
         assert lazyllm.config['mode'] == Mode.Display
 
+class TestConfigNamespace(object):
     @isolated
     def test_config_namespace(self):
         os.environ['MY_GPU_TYPE'] = 'A10000'
@@ -74,6 +74,8 @@ class TestConfig(object):
         assert lazyllm.config['gpu_type'] == 'A100'
         with lazyllm.namespace('my'):
             assert lazyllm.config['gpu_type'] == 'H100'
+        assert lazyllm.config['gpu_type'] == 'A100'
+        os.environ['MY_GPU_TYPE'] = 'A100'
 
     @isolated
     def test_namespace(self, monkeypatch):
@@ -122,7 +124,6 @@ def clear_env():
 def set_env(environ, value):
     assert isinstance(value, str)
     original_value = os.getenv(environ)
-    os.environ['LAZYLLM_DISPLAY'] = '1'
 
     os.environ[environ] = value
     yield

--- a/tests/basic_tests/test_config.py
+++ b/tests/basic_tests/test_config.py
@@ -7,7 +7,7 @@ import contextlib
 import inspect
 
 
-isolate_env = 'PARROTS_ISOLATE_STATUS'
+isolate_env = 'LAZYLLM_ISOLATE_STATUS'
 
 
 def isolated(func):

--- a/tests/basic_tests/test_launcher.py
+++ b/tests/basic_tests/test_launcher.py
@@ -32,37 +32,37 @@ class TestLauncher(object):
 
     def test_k8s(self):
         launcher = launchers.k8s(
-            kube_config_path="~/.kube/config",
-            namespace="lazyllm",
-            host="myapp.lazyllm.com"
+            kube_config_path='~/.kube/config',
+            namespace='lazyllm',
+            host='myapp.lazyllm.com'
         )
-        assert launcher.namespace == "lazyllm"
+        assert launcher.namespace == 'lazyllm'
 
     def test_remote(self):
         # empty launcher
-        origin_launcher = lazyllm.config.impl['launcher']
-        os.environ["LAZYLLM_DEFAULT_LAUNCHER"] = 'empty'
+        origin_launcher = lazyllm.config._impl['launcher']
+        os.environ['LAZYLLM_DEFAULT_LAUNCHER'] = 'empty'
         lazyllm.config.add('launcher', str, 'empty', 'DEFAULT_LAUNCHER')
         launcher = launchers.remote(
             sync=False
         )
         assert type(launcher) is launchers.empty
         assert not launcher.sync
-        os.environ["LAZYLLM_DEFAULT_LAUNCHER"] = 'slurm'
+        os.environ['LAZYLLM_DEFAULT_LAUNCHER'] = 'slurm'
         lazyllm.config.add('launcher', str, 'empty', 'DEFAULT_LAUNCHER')
         launcher = launchers.remote(
             sync=False
         )
         assert type(launcher) is launchers.slurm
         assert not launcher.sync
-        os.environ["LAZYLLM_DEFAULT_LAUNCHER"] = 'sco'
+        os.environ['LAZYLLM_DEFAULT_LAUNCHER'] = 'sco'
         lazyllm.config.add('launcher', str, 'empty', 'DEFAULT_LAUNCHER')
         launcher = launchers.remote(
             sync=False
         )
         assert type(launcher) is launchers.sco
         assert not launcher.sync
-        os.environ["LAZYLLM_DEFAULT_LAUNCHER"] = 'k8s'
+        os.environ['LAZYLLM_DEFAULT_LAUNCHER'] = 'k8s'
         lazyllm.config.add('launcher', str, 'empty', 'DEFAULT_LAUNCHER')
         launcher = launchers.remote(
             sync=True
@@ -70,5 +70,5 @@ class TestLauncher(object):
         assert type(launcher) is launchers.k8s
         assert launcher.sync
 
-        os.environ["LAZYLLM_DEFAULT_LAUNCHER"] = origin_launcher
+        os.environ['LAZYLLM_DEFAULT_LAUNCHER'] = origin_launcher
         lazyllm.config.add('launcher', str, 'empty', 'DEFAULT_LAUNCHER')

--- a/tests/charge_tests/Models/test_automodel.py
+++ b/tests/charge_tests/Models/test_automodel.py
@@ -37,7 +37,7 @@ def set_sensenova_env(monkeypatch, value):
 def reset_env(monkeypatch):
     monkeypatch.delenv('LAZYLLM_TRAINABLE_MODULE_CONFIG_MAP_PATH', raising=False)
     monkeypatch.delenv('LAZYLLM_SENSENOVA_API_KEY', raising=False)
-    monkeypatch.setitem(lazyllm.config.impl, 'auto_model_config_map_path', CONFIG_PATH)
+    monkeypatch.setitem(lazyllm.config._impl, 'auto_model_config_map_path', CONFIG_PATH)
     lazyllm.config.refresh('sensenova_api_key')
 
 


### PR DESCRIPTION
## 📌 PR 内容 / PR Description
<!-- 简要描述本次 PR 的改动点 / Briefly describe the changes in this PR -->
- 支持config传入prefix，为后续其他框架使用LazyLLM的能力，并能够独立定义环境变量做准备

## 🔍 相关 Issue / Related Issue
<!-- 例如：Fix #123 / Close #456 -->
- 

## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [ ] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [x] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## 🧪 如何测试 / How Has This Been Tested?
<!-- 描述测试步骤 / Describe the tests that you ran to verify your changes -->
1. 单元测试

## ⚡ 更新后的用法示例 / Usage After Update
<!-- 请提供更新后的调用示例 / Provide example(s) of usage after your changes -->
```python
>>> import os
>>> import lazyllm
>>> from lazyllm import namespace
>>>
>>> with lazyllm.namespace('my'):
...     assert lazyllm.config['gpu_type'] == 'A100'
...     os.environ['MY_GPU_TYPE'] = 'H100'
...     assert lazyllm.config['gpu_type'] == 'H100'
>>> assert lazyllm.config['gpu_type'] == 'A100'
>>>
>>> class DummyChat(object):
...     def __init__(self, *args, **kw):
...         self._api = lazyllm.config['gpu_type']
>>>
>>> lazyllm.OnlineChatModule = DummyChat
>>>
>>> lazyllm.OnlineChatModule()._api
'A100'
>>>
>>> with lazyllm.namespace('my'):
...     lazyllm.OnlineChatModule()._api
'H100'
>>>
>>> namespace('my').OnlineChatModule()._api
'H100'
```