### PR TITLE
Bug Fix: Fix milvus batch upsert error when sparse embedding got empty dict

### DIFF
--- a/lazyllm/tools/rag/embed_wrapper.py
+++ b/lazyllm/tools/rag/embed_wrapper.py
@@ -6,6 +6,8 @@ from functools import update_wrapper
 
 
 class _EmbedWrapper:
+    SPARSE_FLOAT_VECTOR_DEFAULT_VALUE = {0: 0.0}
+
     def __init__(self, func: Callable[..., Any]):
         self.func = func
         try:
@@ -39,7 +41,9 @@ class _EmbedWrapper:
                     raise ValueError('Embedding string is neither valid JSON nor'
                                      ' valid Python code for ast.literal_eval.')
 
-        if isinstance(res, (dict, list)):
+        if isinstance(res, dict):
+            return res or self.SPARSE_FLOAT_VECTOR_DEFAULT_VALUE
+        if isinstance(res, list):
             return res
         # TODO (chenjiahao): support specific embedding item type check
         raise TypeError(f'Unexpected embedding type: {type(res)}')

--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -35,7 +35,6 @@ MILVUS_INDEX_TYPE_DEFAULTS = {
     'SPARSE_INVERTED_INDEX': {'metric_type': 'IP', 'params': {'inverted_index_algo': 'DAAT_MAXSCORE'}},
     'AUTOINDEX': {'metric_type': 'COSINE', 'params': {'nlist': 128}},
 }
-MILVUS_SPARSE_FLOAT_VECTOR_DEFAULT_VALUE = {0: 0.0}
 
 class _ClientPool:
     def __init__(self, maker, max_size: int = 8):
@@ -421,9 +420,6 @@ class MilvusStore(LazyLLMStoreBase):
             self._primary_key: d.get(self._primary_key, '')
         }
         for embed_key, value in d.get('embedding', {}).items():
-            # set default value for SPARSE_FLOAT_VECTOR type
-            if self._embed_datatypes.get(embed_key) == DataType.SPARSE_FLOAT_VECTOR:
-                value = value or MILVUS_SPARSE_FLOAT_VECTOR_DEFAULT_VALUE
             res[self._gen_embed_key(embed_key)] = value
         global_meta = d.get('global_meta', {})
         for name, desc in self._global_metadata_desc.items():


### PR DESCRIPTION
When using sparsing embedding, if the content words to be encoded does not match any entry in the vocabulary, the resulting vector will be an empty dict. However, in Milvus, an empty dictionary is considered an invalid value for fields of the SPARSE_FLOAT_VECTOR type—even if the field is configured to allow null values.

How to fix: Add a default value {0: 0} when an empty dictionary is detected.

<!-- 
在提交PR之前，请认真阅读以下规则。
1. 我们每行的字符限制是120，提交代码前请在保持语义清晰的基础上，尽你所能的压缩代码行数
2. 我们强制要求单引号优先；但由于一些历史提交的文件并没有做相关要求，因此代码仓库中还存在一些不规范的代码，如果你修改到某个文件，请顺便处理整个文件，变成单引号优先。
3. 我们禁止在代码中使用print，请在提交之前删除所有的print语句
4. 我们禁止无意义的注释，包括重复一遍函数名，翻译代码，显而易见。注释应该讲“为什么这么写”，即对一大段代码讲解执行逻辑、设计思路、参考来源或解决了什么问题。
5. 在提交PR之前，请在你的分支上执行如下命令
```bash
pip install flake8-quotes
pip install flake8-bugbear
make lint-only-diff
```

Please read the following rules carefully before submitting a PR.
1. We have a character limit of 120 per line. Please compress the code lines as much as possible while maintaining semantic clarity before submitting code.
2. We enforce single quotes priority; however, due to some historical commits that didn't follow this requirement, there are still some non-standard codes in the codebase. If you modify a file, please also process the entire file to use single quotes priority.
3. We prohibit the use of print in code. Please delete all print statements before submitting.
4. We prohibit meaningless comments, including repeating function names, translating code, or stating the obvious. Comments should explain "why it's written this way", i.e., explain the execution logic, design ideas, reference sources, or problems solved for a large block of code.
5. Before submitting a PR, please execute the following commands on your branch
```bash
pip install flake8-quotes
pip install flake8-bugbear
make lint-only-diff
```
-->

## 📌 PR 内容 / PR Description
<!-- 简要描述本次 PR 的改动点 / Briefly describe the changes in this PR -->
Bug 修复：在使用稀疏向量编码时，当编码内容未命中任何词表时，向量化结果为空字典。而在milvus中类型为SPARSE_FLOAT_VECTOR的字段，空字典是非法值（即使将字段设置为可以为null也不行)
## 🔍 相关 Issue / Related Issue
<!-- 例如：Fix #123 / Close #456 -->
- 

## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [ ] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [ ] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## 🧪 如何测试 / How Has This Been Tested?
<!-- 描述测试步骤 / Describe the tests that you ran to verify your changes -->

由于此问题不太好简单测试，因此给出如下仿真代码，可验证

```
# 环境准备
from pymilvus import MilvusClient, DataType

client = MilvusClient(uri="http://localhost:19530", db_name="test_sparse")

schema = client.create_schema(
    auto_id=True,
    enable_dynamic_fields=True,
)

schema.add_field(field_name="pk", datatype=DataType.VARCHAR, is_primary=True, max_length=100)
schema.add_field(field_name="sparse_vector", datatype=DataType.SPARSE_FLOAT_VECTOR)
schema.add_field(field_name="text", datatype=DataType.VARCHAR, max_length=65535, enable_analyzer=True)


index_params = client.prepare_index_params()

index_params.add_index(
    field_name="sparse_vector",
    index_name="sparse_inverted_index",
    index_type="SPARSE_INVERTED_INDEX",
    metric_type="IP",
    params={"inverted_index_algo": "DAAT_MAXSCORE"}, # or "DAAT_WAND" or "TAAT_NAIVE"
)


client.create_collection(
    collection_name="my_collection",
    schema=schema,
    index_params=index_params
)


# 正常插入数据
data = [
    {
        "text": "TEXT 1",
        "sparse_vector": {1: 0.5, 100: 0.3, 500: 0.8}
    },
]
client.insert(
    collection_name="my_collection",
    data=data
)

# 模拟异常
data = [
    {
        "text": "ЁЖЗИЙКЛ",
        "sparse_vector": {}
    }
]

try:
    client.insert(
        collection_name="my_collection",
        data=data
    )
except Exception as e:
    print(str(e))

# 修复方式
data = [
    {
        "text": "ЁЖЗИЙКЛ",
        "sparse_vector": {0: 0.0}
    }
]


# 展示插入的0值不会影响检索
query_data = [{1: 0.2, 50: 0.4, 1000: 0.7}]

res = client.search(
    collection_name="my_collection",
    data=query_data,
    limit=3,
    output_fields=["text"],
    consistency_level="Strong"
)

print(res)
```

## 📷 截图 / Demo (Optional)
<!-- 如果是文档改动或者性能优化 / If document changes or performance optimization, please attach screenshots -->
- 

## ⚡ 更新后的用法示例 / Usage After Update
<!-- 请提供更新后的调用示例 / Provide example(s) of usage after your changes -->
```python
# 示例 / Example
```

## 🔄 重构前 / 重构后对比 (仅当 Type 为 Refactor) / Refactor Before & After (only for Refactor)
<!-- 请提供重构前后的调用对比 / Provide before & after usage for refactor -->

### 重构前 / Before:


### 重构后 / After:


## ⚠️ 注意事项 / Additional Notes
<!-- 是否有依赖更新、迁移步骤或其他注意点 / Mention dependencies, migration steps, or any other concerns -->
