### PR TITLE
modify registry to support `__lazyllm_registry_key__` and `__lazyllm_registry_disable__`

### DIFF
--- a/lazyllm/common/registry.py
+++ b/lazyllm/common/registry.py
@@ -88,8 +88,9 @@ class LazyLLMRegisterMetaClass(_MetaBind):
 
     def __new__(metas, name, bases, attrs):
         new_cls = type.__new__(metas, name, bases, attrs)
+        if new_cls.__dict__.get('__lazyllm_registry_disable__'): return new_cls
         if name.startswith('LazyLLM') and name.endswith('Base'):
-            ori = re.match('(LazyLLM)(.*)(Base)', name.split('.')[-1])[2]
+            ori = new_cls.__dict__.get('__lazyllm_registry_key__', re.match('(LazyLLM)(.*)(Base)', name)[2])
             group = ori.lower()
             new_cls._lazy_llm_group = f'{getattr(new_cls, "_lazy_llm_group", "")}.{group}'.strip('.')
             ld = LazyDict(group, new_cls)

--- a/tests/basic_tests/Common/test_registry.py
+++ b/tests/basic_tests/Common/test_registry.py
@@ -1,5 +1,6 @@
 import lazyllm
 from lazyllm.components import register as comp_register
+from lazyllm.common.registry import LazyLLMRegisterMetaClass
 from lazyllm.components.core import ComponentBase
 from lazyllm.tools import fc_register
 
@@ -103,3 +104,64 @@ class TestRegistry:
         registered_func = fc_register('tool')(orig_func, new_func_name)
         assert registered_func != orig_func
         assert registered_func.__name__ == new_func_name
+
+
+class TestRegistryWithKey(object):
+    def test_registry_with_key(self):
+        class LazyLLMOnlineModuleBase(object, metaclass=LazyLLMRegisterMetaClass):
+            __lazyllm_registry_key__ = 'online'
+
+            def __init__(self, *args, **kw):
+                pass
+
+        class OnlineMultiModalBase(LazyLLMOnlineModuleBase):
+            __lazyllm_registry_disable__ = True
+
+        class LazyLLMOnlineSTTModuleBase(OnlineMultiModalBase):
+            __lazyllm_registry_key__ = 'STT'
+
+        class LazyLLMOnlineTTSModuleBase(OnlineMultiModalBase):
+            __lazyllm_registry_key__ = 'TTS'
+
+        class LazyLLMOnlineTextaoImageModuleBase(OnlineMultiModalBase):
+            __lazyllm_registry_key__ = 'TextToImage'
+
+        class LazyLLMOnlineImageEditingBase(OnlineMultiModalBase):
+            __lazyllm_registry_key__ = 'ImageEditing'
+
+        class AbcBase():
+            def __init__(self, api_key: str = None, base_url: str = 'base_url'):
+                self._client = 'abc(api_key=api_key, base_url=base_url'
+
+        class AbcSTT(LazyLLMOnlineSTTModuleBase, AbcBase):
+            def __init__(self, api_key=None, base_url='base_url'):
+                super().__init__(api_key, base_url)
+                AbcBase.__init__(self, api_key=api_key, base_url=base_url)
+
+        class AbcTTS(LazyLLMOnlineTTSModuleBase, AbcBase):
+            def __init__(self, api_key=None, base_url='base_url'):
+                super().__init__(api_key, base_url)
+                AbcBase.__init__(self, api_key=api_key, base_url=base_url)
+
+        class AbcTextToImage(LazyLLMOnlineTextaoImageModuleBase, AbcBase):
+            def __init__(self, api_key=None, base_url='base_url'):
+                super().__init__(api_key, base_url)
+                AbcBase.__init__(self, api_key=api_key, base_url=base_url)
+
+        class AbcImageEditing(LazyLLMOnlineImageEditingBase, AbcBase):
+            def __init__(self, api_key=None, base_url='base_url'):
+                super().__init__(api_key, base_url)
+                AbcBase.__init__(self, api_key=api_key, base_url=base_url)
+
+        assert hasattr(lazyllm, 'online')
+        assert hasattr(lazyllm.online, 'base')
+        assert hasattr(lazyllm.online, 'stt')
+        assert hasattr(lazyllm.online, 'tts')
+        assert hasattr(lazyllm.online, 'TextToImage')
+        assert hasattr(lazyllm.online, 'ImageEditing')
+        assert len(lazyllm.online) == 4
+
+        assert hasattr(lazyllm.online.stt, 'abc')
+        assert hasattr(lazyllm.online.tts, 'abc')
+        assert hasattr(lazyllm.online.TextToImage, 'abc')
+        assert hasattr(lazyllm.online.ImageEditing, 'abc')


### PR DESCRIPTION
## 📌 PR 内容 / PR Description
<!-- 简要描述本次 PR 的改动点 / Briefly describe the changes in this PR -->
- 注册支持`__lazyllm_registry_key__` and `__lazyllm_registry_disable__`参数

## 🔍 相关 Issue / Related Issue
<!-- 例如：Fix #123 / Close #456 -->
- 

## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [ ] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [x] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## ⚡ 更新后的用法示例 / Usage After Update
<!-- 请提供更新后的调用示例 / Provide example(s) of usage after your changes -->
```python
        class LazyLLMOnlineModuleBase(object, metaclass=LazyLLMRegisterMetaClass):
            __lazyllm_registry_key__ = 'online'

            def __init__(self, *args, **kw):
                pass

        class OnlineMultiModalBase(LazyLLMOnlineModuleBase):
            __lazyllm_registry_disable__ = True

        class LazyLLMOnlineSTTModuleBase(OnlineMultiModalBase):
            __lazyllm_registry_key__ = 'STT'

        class LazyLLMOnlineTTSModuleBase(OnlineMultiModalBase):
            __lazyllm_registry_key__ = 'TTS'

        class LazyLLMOnlineTextaoImageModuleBase(OnlineMultiModalBase):
            __lazyllm_registry_key__ = 'TextToImage'

        class LazyLLMOnlineImageEditingBase(OnlineMultiModalBase):
            __lazyllm_registry_key__ = 'ImageEditing'

        class AbcBase():
            def __init__(self, api_key: str = None, base_url: str = 'base_url'):
                self._client = 'abc(api_key=api_key, base_url=base_url'

        class AbcSTT(LazyLLMOnlineSTTModuleBase, AbcBase):
            def __init__(self, api_key=None, base_url='base_url'):
                super().__init__(api_key, base_url)
                AbcBase.__init__(self, api_key=api_key, base_url=base_url)

        class AbcTTS(LazyLLMOnlineTTSModuleBase, AbcBase):
            def __init__(self, api_key=None, base_url='base_url'):
                super().__init__(api_key, base_url)
                AbcBase.__init__(self, api_key=api_key, base_url=base_url)

        class AbcTextToImage(LazyLLMOnlineTextaoImageModuleBase, AbcBase):
            def __init__(self, api_key=None, base_url='base_url'):
                super().__init__(api_key, base_url)
                AbcBase.__init__(self, api_key=api_key, base_url=base_url)

        class AbcImageEditing(LazyLLMOnlineImageEditingBase, AbcBase):
            def __init__(self, api_key=None, base_url='base_url'):
                super().__init__(api_key, base_url)
                AbcBase.__init__(self, api_key=api_key, base_url=base_url)

        assert hasattr(lazyllm, 'online')
        assert hasattr(lazyllm.online, 'base')
        assert hasattr(lazyllm.online, 'stt')
        assert hasattr(lazyllm.online, 'tts')
        assert hasattr(lazyllm.online, 'TextToImage')
        assert hasattr(lazyllm.online, 'ImageEditing')
        assert len(lazyllm.online) == 4

        assert hasattr(lazyllm.online.stt, 'abc')
        assert hasattr(lazyllm.online.tts, 'abc')
        assert hasattr(lazyllm.online.TextToImage, 'abc')
        assert hasattr(lazyllm.online.ImageEditing, 'abc')
```