### PR TITLE
[Bugfix] Fix HybridStore search order error when using MapStore

### DIFF
--- a/lazyllm/tools/rag/store/hybrid/hybrid_store.py
+++ b/lazyllm/tools/rag/store/hybrid/hybrid_store.py
@@ -64,9 +64,12 @@ class HybridStore(LazyLLMStoreBase):
             uid2score = {item['uid']: item['score'] for item in res}
             uids = list(uid2score.keys())
             segments = self.segment_store.get(collection_name=collection_name, criteria={'uid': uids})
+            uid2segment = {}
             for segment in segments:
                 segment['score'] = uid2score.get(segment['uid'], 0)
-            return segments
+                uid2segment[segment.get('uid')] = segment
+            ordered = [uid2segment[uid] for uid in uids if uid in uid2segment]
+            return ordered
         else:
             res = self.segment_store.search(collection_name=collection_name, query=query,
                                             topk=topk, filters=filters, **kwargs)


### PR DESCRIPTION
## 📌 PR 内容 / PR Description
<!-- 简要描述本次 PR 的改动点 / Briefly describe the changes in this PR -->
- 修复ci中HybridStore search的bug（修改mapstore中build筛选条件逻辑造成的）


## ✅ 变更类型 / Type of Change
<!-- 勾选对应选项 / Check the relevant options -->
- [x] 修复 Bug / Bug fix (non-breaking change that fixes an issue)
- [ ] 新功能 / New feature (non-breaking change that adds functionality)
- [ ] 重构 / Refactor (no functionality change, code structure optimized)
- [ ] 重大变更 / Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 文档更新 / Documentation update (changes to docs only)
- [ ] 性能优化 / Performance optimization

## 🧪 如何测试 / How Has This Been Tested?
<!-- 描述测试步骤 / Describe the tests that you ran to verify your changes -->
1. `pytest tests/basic_tests/RAG/test_store.py::TestHybridStore::test_search`
