### PR TITLE
Feat: add BertDeploy and QueryEnhACProcessor with LLM/BERT boundary filter

### DIFF
--- a/docs/en/API Reference/components.md
+++ b/docs/en/API Reference/components.md
@@ -102,6 +102,11 @@
 ::: lazyllm.components.deploy.OCRDeploy
     options:
       heading_level: 3
+
+::: lazyllm.components.deploy.BertDeploy
+    options:
+      heading_level: 3
+
 ---
 
 ::: lazyllm.components.deploy.relay.base.RelayServer
@@ -109,15 +114,7 @@
       heading_level: 3
       members: [cmd, geturl]
 
-::: lazyllm.components.deploy.OCRDeploy
-    options:
-      heading_level: 3
-
 ::: lazyllm.components.deploy.text_to_speech.utils.TTSBase
-    options:
-      heading_level: 3
-
-::: lazyllm.components.deploy.BertDeploy
     options:
       heading_level: 3
 

--- a/docs/en/API Reference/components.md
+++ b/docs/en/API Reference/components.md
@@ -116,6 +116,11 @@
 ::: lazyllm.components.deploy.text_to_speech.utils.TTSBase
     options:
       heading_level: 3
+
+::: lazyllm.components.deploy.BertDeploy
+    options:
+      heading_level: 3
+
 ---
 
 ## Prompter

--- a/docs/en/API Reference/tools.md
+++ b/docs/en/API Reference/tools.md
@@ -545,3 +545,7 @@
 ::: lazyllm.tools.review.tools.chinese_corrector.ChineseCorrector
     members: correct, correct_batch
     exclude-members:
+
+::: lazyllm.tools.rag.QueryEnhACProcessor
+    members:
+    exclude-members:

--- a/docs/en/API Reference/tools.md
+++ b/docs/en/API Reference/tools.md
@@ -547,5 +547,5 @@
     exclude-members:
 
 ::: lazyllm.tools.rag.QueryEnhACProcessor
-    members:
+    members: __call__, get_matches, update_data_source, update_discriminator
     exclude-members:

--- a/docs/zh/API Reference/components.md
+++ b/docs/zh/API Reference/components.md
@@ -104,11 +104,11 @@
     options:
       heading_level: 3
 
-::: lazyllm.components.deploy.relay.base.RelayServer
+::: lazyllm.components.deploy.BertDeploy
     options:
       heading_level: 3
 
-::: lazyllm.components.deploy.OCRDeploy
+::: lazyllm.components.deploy.relay.base.RelayServer
     options:
       heading_level: 3
 
@@ -117,10 +117,6 @@
       heading_level: 3
       
 ::: lazyllm.components.deploy.relay.base.FastapiApp
-    options:
-      heading_level: 3
-
-::: lazyllm.components.deploy.BertDeploy
     options:
       heading_level: 3
 

--- a/docs/zh/API Reference/components.md
+++ b/docs/zh/API Reference/components.md
@@ -119,6 +119,11 @@
 ::: lazyllm.components.deploy.relay.base.FastapiApp
     options:
       heading_level: 3
+
+::: lazyllm.components.deploy.BertDeploy
+    options:
+      heading_level: 3
+
 ---
 
 ## Prompter

--- a/docs/zh/API Reference/tools.md
+++ b/docs/zh/API Reference/tools.md
@@ -535,5 +535,5 @@
     exclude-members:
 
 ::: lazyllm.tools.rag.QueryEnhACProcessor
-    members:
+    members: __call__, get_matches, update_data_source, update_discriminator
     exclude-members:

--- a/docs/zh/API Reference/tools.md
+++ b/docs/zh/API Reference/tools.md
@@ -533,3 +533,7 @@
 ::: lazyllm.tools.review.tools.chinese_corrector.ChineseCorrector
     members: correct, correct_batch
     exclude-members:
+
+::: lazyllm.tools.rag.QueryEnhACProcessor
+    members:
+    exclude-members:

--- a/lazyllm/components/deploy/__init__.py
+++ b/lazyllm/components/deploy/__init__.py
@@ -11,6 +11,7 @@ from .stable_diffusion import StableDiffusionDeploy
 from .text_to_speech import TTSDeploy, BarkDeploy, ChatTTSDeploy, MusicGenDeploy
 from .speech_to_text import SenseVoiceDeploy
 from .ocr import OCRDeploy
+from .bert import BertDeploy
 
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     'MusicGenDeploy',
     'SenseVoiceDeploy',
     'OCRDeploy',
+    'BertDeploy',
 ]

--- a/lazyllm/components/deploy/bert.py
+++ b/lazyllm/components/deploy/bert.py
@@ -6,6 +6,7 @@ from lazyllm import LOG, LazyLLMLaunchersBase
 from lazyllm.thirdparty import torch, transformers as tf
 
 from .base import LazyLLMDeployBase
+from .relay import RelayServer
 
 
 class _BertSequenceClassificationService:
@@ -47,9 +48,6 @@ class _BertSequenceClassificationService:
 
     def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
         lazyllm.call_once(self._init_flag, self._load_model)
-        # TrainableModule may assign the whole JSON body to ``text_a``; flatten once.
-        if isinstance(data.get('text_a'), dict):
-            data = {**data, **data['text_a']}
         ta, tb = data.get('text_a'), data.get('text_b')
         text_a = ta.strip() if isinstance(ta, str) else ''
         text_b = tb.strip() if isinstance(tb, str) else ''
@@ -147,8 +145,7 @@ class BertDeploy(LazyLLMDeployBase):
                 os.path.isdir(finetuned_model)
                 and any(
                     f.endswith(('.bin', '.safetensors', '.pt'))
-                    for _, _, filenames in os.walk(finetuned_model)
-                    for f in filenames
+                    for f in os.listdir(finetuned_model)
                 )
             )
             if valid_local:
@@ -160,6 +157,10 @@ class BertDeploy(LazyLLMDeployBase):
                 )
                 model_path = base_model
             else:
+                LOG.info(
+                    f'Bert deploy: finetuned_model({finetuned_model}) is not a valid local '
+                    f'checkpoint and no base_model provided; treating it as a remote model id.'
+                )
                 model_path = finetuned_model
 
         if not model_path:
@@ -171,7 +172,7 @@ class BertDeploy(LazyLLMDeployBase):
             max_length=self._max_length,
             device=self._device,
         )
-        return lazyllm.deploy.RelayServer(
+        return RelayServer(
             port=self._port,
             func=func,
             launcher=self._launcher,

--- a/lazyllm/components/deploy/bert.py
+++ b/lazyllm/components/deploy/bert.py
@@ -1,0 +1,185 @@
+import json
+import os
+from typing import Any, Dict, Optional
+
+import lazyllm
+from lazyllm import LOG, LazyLLMLaunchersBase
+from lazyllm.thirdparty import torch, transformers as tf
+
+from .base import LazyLLMDeployBase
+
+
+class _BertSequenceClassificationService:
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        trust_remote_code: bool = True,
+        max_length: int = 512,
+        device: Optional[str] = None,
+        init: bool = False,
+    ):
+        self._model_path = model_path
+        self._trust_remote_code = trust_remote_code
+        self._max_length = max_length
+        self._device_pref = device
+        self._tokenizer = None
+        self._model = None
+        self._device = None
+        self._init_flag = lazyllm.once_flag()
+        if init:
+            lazyllm.call_once(self._init_flag, self._load_model)
+
+    def _load_model(self) -> None:
+        self._tokenizer = tf.AutoTokenizer.from_pretrained(
+            self._model_path, trust_remote_code=self._trust_remote_code
+        )
+        self._model = tf.AutoModelForSequenceClassification.from_pretrained(
+            self._model_path, trust_remote_code=self._trust_remote_code
+        )
+        if self._device_pref:
+            self._device = torch.device(self._device_pref)
+        else:
+            self._device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self._model.to(self._device)
+        self._model.eval()
+        LOG.info(f'Bert deploy: loaded model from {self._model_path} on {self._device}')
+
+    def __call__(self, data: Dict[str, Any]) -> str:
+        lazyllm.call_once(self._init_flag, self._load_model)
+        # TrainableModule may assign the whole JSON body to ``text_a``; flatten once.
+        if isinstance(data.get('text_a'), dict):
+            data = {**data, **data['text_a']}
+        ta, tb = data.get('text_a'), data.get('text_b')
+        text_a = ta.strip() if isinstance(ta, str) else ''
+        text_b = tb.strip() if isinstance(tb, str) else ''
+        if not text_a and not text_b:
+            raise ValueError('At least one of text_a or text_b must be non-empty')
+
+        if not text_b:
+            enc = self._tokenizer(
+                text_a,
+                truncation=True,
+                padding=True,
+                max_length=self._max_length,
+                return_tensors='pt',
+            )
+        else:
+            enc = self._tokenizer(
+                text_a,
+                text_b,
+                truncation=True,
+                padding=True,
+                max_length=self._max_length,
+                return_tensors='pt',
+            )
+        enc = {k: v.to(self._device) for k, v in enc.items()}
+        with torch.no_grad():
+            logits = self._model(**enc).logits
+            probs = torch.softmax(logits.float(), dim=-1)
+
+        pred = int(torch.argmax(probs, dim=-1).item())
+        out = {
+            'logits': logits.cpu().tolist()[0],
+            'probs': probs.cpu().tolist()[0],
+            'predicted_label': pred,
+        }
+        return json.dumps(out)
+
+    @classmethod
+    def rebuild(cls, model_path, trust_remote_code, max_length, device, init):
+        return cls(
+            model_path,
+            trust_remote_code=trust_remote_code,
+            max_length=max_length,
+            device=device,
+            init=init,
+        )
+
+    def __reduce__(self):
+        init = bool(os.getenv('LAZYLLM_ON_CLOUDPICKLE', None) == 'ON' or self._init_flag)
+        return _BertSequenceClassificationService.rebuild, (
+            self._model_path,
+            self._trust_remote_code,
+            self._max_length,
+            self._device_pref,
+            init,
+        )
+
+
+class BertDeploy(LazyLLMDeployBase):
+
+    message_format = {
+        'text_a': '',
+        'text_b': '',
+    }
+    keys_name_handle = {'inputs': 'text_a'}
+    default_headers = {'Content-Type': 'application/json'}
+    stream_url_suffix = ''
+    stream_parse_parameters: dict = {}
+
+    def __init__(
+        self,
+        launcher: Optional[LazyLLMLaunchersBase] = None,
+        log_path: Optional[str] = None,
+        trust_remote_code: bool = True,
+        port: Optional[int] = None,
+        max_length: int = 512,
+        device: Optional[str] = None,
+        **kw,
+    ):
+        super().__init__(launcher=launcher)
+        self._log_path = log_path
+        self._trust_remote_code = trust_remote_code
+        self._port = port
+        self._max_length = max_length
+        self._device = device
+        if kw:
+            LOG.warning(f'Bert deploy: ignoring unknown kwargs: {sorted(kw.keys())}')
+
+    def __call__(self, finetuned_model=None, base_model=None):
+        finetuned_model = finetuned_model or ''
+        base_model = base_model or ''
+        if not finetuned_model:
+            model_path = base_model
+        else:
+            valid_local = (
+                os.path.isdir(finetuned_model)
+                and any(
+                    f.endswith(('.bin', '.safetensors', '.pt'))
+                    for _, _, filenames in os.walk(finetuned_model)
+                    for f in filenames
+                )
+            )
+            if valid_local:
+                model_path = finetuned_model
+            elif base_model:
+                LOG.warning(
+                    f'Note! finetuned_model({finetuned_model}) is not a local checkpoint with weights; '
+                    f'using base_model({base_model}).'
+                )
+                model_path = base_model
+            else:
+                model_path = finetuned_model
+
+        if not model_path:
+            raise ValueError('Bert deploy: finetuned_model and base_model are both empty or invalid.')
+
+        func = _BertSequenceClassificationService(
+            model_path,
+            trust_remote_code=self._trust_remote_code,
+            max_length=self._max_length,
+            device=self._device,
+        )
+        return lazyllm.deploy.RelayServer(
+            port=self._port,
+            func=func,
+            launcher=self._launcher,
+            log_path=self._log_path,
+            cls='bert',
+        )()
+
+    @staticmethod
+    def extract_result(output: str, inputs) -> str:
+        return output

--- a/lazyllm/components/deploy/bert.py
+++ b/lazyllm/components/deploy/bert.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import Any, Dict, Optional
 
@@ -46,7 +45,7 @@ class _BertSequenceClassificationService:
         self._model.eval()
         LOG.info(f'Bert deploy: loaded model from {self._model_path} on {self._device}')
 
-    def __call__(self, data: Dict[str, Any]) -> str:
+    def __call__(self, data: Dict[str, Any]) -> Dict[str, Any]:
         lazyllm.call_once(self._init_flag, self._load_model)
         # TrainableModule may assign the whole JSON body to ``text_a``; flatten once.
         if isinstance(data.get('text_a'), dict):
@@ -85,7 +84,7 @@ class _BertSequenceClassificationService:
             'probs': probs.cpu().tolist()[0],
             'predicted_label': pred,
         }
-        return json.dumps(out)
+        return out
 
     @classmethod
     def rebuild(cls, model_path, trust_remote_code, max_length, device, init):

--- a/lazyllm/docs/components.py
+++ b/lazyllm/docs/components.py
@@ -1795,12 +1795,12 @@ Args:
     **kw: 未识别的关键字参数将被记录警告并忽略。
 
 Message Format:
-    与 ``TrainableModule`` 联用时，首参映射为 ``text_a``，``text_b`` 通过关键字传入。请求体为 JSON：\\n
-    - text_a (str): 第一段文本（如候选词）\\n
-    - text_b (str): 第二段文本（如上下文片段）；可为空，此时按单序列编码\\n
+    与 ``TrainableModule`` 联用时，首参映射为 ``text_a``，``text_b`` 通过关键字传入。请求体为 JSON：
+    - text_a (str): 第一段文本（如候选词）
+    - text_b (str): 第二段文本（如上下文片段）；可为空，此时按单序列编码
 
-**Returns:**\\n
-- 服务进程返回的 JSON 字符串，含 ``logits``、``probs``、``predicted_label`` 等字段。\\n
+**Returns:**
+- 服务进程返回的 JSON 字符串，含 ``logits``、``probs``、``predicted_label`` 等字段。
 ''')
 
 add_english_doc('deploy.BertDeploy', '''\
@@ -1816,12 +1816,12 @@ Args:
     **kw: Unknown keyword arguments are logged as a warning and ignored.
 
 Message Format:
-    With ``TrainableModule``, the first positional argument maps to ``text_a`` and ``text_b`` is passed as a keyword. JSON body:\\n
-    - text_a (str): First segment (e.g. span text).\\n
-    - text_b (str): Second segment (e.g. context); may be empty for single-sequence encoding.\\n
+    With ``TrainableModule``, the first positional argument maps to ``text_a`` and ``text_b`` is passed as a keyword. JSON body:
+    - text_a (str): First segment (e.g. span text).
+    - text_b (str): Second segment (e.g. context); may be empty for single-sequence encoding.
 
-**Returns:**\\n
-- JSON string from the worker with fields such as ``logits``, ``probs``, and ``predicted_label``.\\n
+**Returns:**
+- JSON string from the worker with fields such as ``logits``, ``probs``, and ``predicted_label``.
 ''')
 
 add_example('deploy.BertDeploy', '''\

--- a/lazyllm/docs/components.py
+++ b/lazyllm/docs/components.py
@@ -1786,7 +1786,7 @@ add_chinese_doc('deploy.BertDeploy', '''\
 此类是 ``LazyLLMDeployBase`` 的子类，用于部署 HuggingFace 风格的**序列分类**（sequence classification）模型。服务通过 ``RelayServer`` 提供 HTTP ``/generate`` 接口，无独立 CLI；用法与 ``StableDiffusionDeploy`` 类似：对实例调用 ``__call__(finetuned_model, base_model)`` 得到可启动的 Relay 服务。
 
 Args:
-    launcher (Optional[lazyllm.launcher]): 启动器实例，默认为 ``None``。
+    launcher (Optional[LazyLLMLaunchersBase]): 启动器实例，默认为 ``None``。
     log_path (Optional[str]): 日志文件路径，默认为 ``None``。
     trust_remote_code (bool): 加载 tokenizer / 模型时是否 ``trust_remote_code``，默认为 ``True``。
     port (Optional[int]): 服务监听端口，默认为 ``None`` 时由框架分配。
@@ -1807,7 +1807,7 @@ add_english_doc('deploy.BertDeploy', '''\
 This class is a subclass of ``LazyLLMDeployBase``, used to deploy HuggingFace-style **sequence classification** models. The service exposes an HTTP ``/generate`` endpoint via ``RelayServer`` (no standalone CLI). Usage mirrors ``StableDiffusionDeploy``: calling the instance ``__call__(finetuned_model, base_model)`` returns a launchable Relay service.
 
 Args:
-    launcher (Optional[lazyllm.launcher]): Launcher instance, defaults to ``None``.
+    launcher (Optional[LazyLLMLaunchersBase]): Launcher instance, defaults to ``None``.
     log_path (Optional[str]): Log file path, defaults to ``None``.
     trust_remote_code (bool): Whether to pass ``trust_remote_code`` when loading tokenizer/model, defaults to ``True``.
     port (Optional[int]): Listen port; ``None`` lets the framework assign one.
@@ -1829,7 +1829,12 @@ add_example('deploy.BertDeploy', '''\
 >>> m = lazyllm.TrainableModule('xlm-roberta-base', use_model_map=False).deploy_method(
 ...     lazyllm.deploy.BertDeploy, port=36001, max_length=128,
 ... ).start()
->>> out = m('This is a test.', text_b='')
+>>> # Two-sequence input: candidate span + surrounding context.
+>>> pair_out = m('candidate_span', text_b='This is the surrounding context.')
+>>> print(pair_out)
+>>> # Single-sequence input: either omit ``text_b`` or pass an empty string.
+>>> single_out = m('This is a single sequence.')
+>>> print(single_out)
 ''')
 
 add_chinese_doc('deploy.relay.base.FastapiApp.get', """\

--- a/lazyllm/docs/components.py
+++ b/lazyllm/docs/components.py
@@ -1781,6 +1781,56 @@ Args:
     job (Optional[Any]): Job object, if None uses the current instance's job property.
 ''')
 
+# Deploy-BertDeploy
+add_chinese_doc('deploy.BertDeploy', '''\
+此类是 ``LazyLLMDeployBase`` 的子类，用于部署 HuggingFace 风格的**序列分类**（sequence classification）模型。服务通过 ``RelayServer`` 提供 HTTP ``/generate`` 接口，无独立 CLI；用法与 ``StableDiffusionDeploy`` 类似：对实例调用 ``__call__(finetuned_model, base_model)`` 得到可启动的 Relay 服务。
+
+Args:
+    launcher (Optional[lazyllm.launcher]): 启动器实例，默认为 ``None``。
+    log_path (Optional[str]): 日志文件路径，默认为 ``None``。
+    trust_remote_code (bool): 加载 tokenizer / 模型时是否 ``trust_remote_code``，默认为 ``True``。
+    port (Optional[int]): 服务监听端口，默认为 ``None`` 时由框架分配。
+    max_length (int): 编码时的最大序列长度，默认为 ``512``。
+    device (Optional[str]): 推理设备，例如 ``"cuda"``、``"cpu"``；默认为 ``None`` 时自动选择。
+    **kw: 未识别的关键字参数将被记录警告并忽略。
+
+Message Format:
+    与 ``TrainableModule`` 联用时，首参映射为 ``text_a``，``text_b`` 通过关键字传入。请求体为 JSON：\\n
+    - text_a (str): 第一段文本（如候选词）\\n
+    - text_b (str): 第二段文本（如上下文片段）；可为空，此时按单序列编码\\n
+
+**Returns:**\\n
+- 服务进程返回的 JSON 字符串，含 ``logits``、``probs``、``predicted_label`` 等字段。\\n
+''')
+
+add_english_doc('deploy.BertDeploy', '''\
+This class is a subclass of ``LazyLLMDeployBase``, used to deploy HuggingFace-style **sequence classification** models. The service exposes an HTTP ``/generate`` endpoint via ``RelayServer`` (no standalone CLI). Usage mirrors ``StableDiffusionDeploy``: calling the instance ``__call__(finetuned_model, base_model)`` returns a launchable Relay service.
+
+Args:
+    launcher (Optional[lazyllm.launcher]): Launcher instance, defaults to ``None``.
+    log_path (Optional[str]): Log file path, defaults to ``None``.
+    trust_remote_code (bool): Whether to pass ``trust_remote_code`` when loading tokenizer/model, defaults to ``True``.
+    port (Optional[int]): Listen port; ``None`` lets the framework assign one.
+    max_length (int): Maximum sequence length for tokenization, default ``512``.
+    device (Optional[str]): Device for inference, e.g. ``"cuda"`` or ``"cpu"``; ``None`` selects automatically.
+    **kw: Unknown keyword arguments are logged as a warning and ignored.
+
+Message Format:
+    With ``TrainableModule``, the first positional argument maps to ``text_a`` and ``text_b`` is passed as a keyword. JSON body:\\n
+    - text_a (str): First segment (e.g. span text).\\n
+    - text_b (str): Second segment (e.g. context); may be empty for single-sequence encoding.\\n
+
+**Returns:**\\n
+- JSON string from the worker with fields such as ``logits``, ``probs``, and ``predicted_label``.\\n
+''')
+
+add_example('deploy.BertDeploy', '''\
+>>> import lazyllm
+>>> m = lazyllm.TrainableModule('xlm-roberta-base', use_model_map=False).deploy_method(
+...     lazyllm.deploy.BertDeploy, port=36001, max_length=128,
+... ).start()
+>>> out = m('This is a test.', text_b='')
+''')
 
 add_chinese_doc('deploy.relay.base.FastapiApp.get', """\
 注册GET请求路由装饰器。

--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -9441,3 +9441,121 @@ add_example(
     >>> print(results)
     [{'source': '句子1', 'target': '修正后句子1', 'errors': [...]}, ...]
 """)
+
+# RAG-QueryEnhACProcessor
+add_chinese_doc('rag.QueryEnhACProcessor', '''\
+基于 Aho–Corasick（AC）自动机的查询同义词扩展处理器。
+
+在查询串上匹配词表中的词，将保留的命中词替换为「原词 + 同簇其它词形」的展示形式（首遇簇内词时展开，同句后续同簇命中仅保留原词）。匹配先做**最长无重叠**预选，再由判别器判断是否为独立词边界。若 ``discriminator`` 为 ``None`` 且 AC 仍有命中，会记录警告并不改写查询；判别器推理失败时过滤器返回空命中，同样保持原句。
+
+Args:
+    data_source: 词表数据源。可为无参可调用（每次调用返回 ``list[dict]``），或直接为字典列表。每条记录需包含 ``cluster_key``、``word_key`` 所指字段；缺字段项会被跳过。
+    discriminator: 词边界判别器。支持 ``OnlineChatModule``、用于 LLM 的 ``TrainableModule``（经 ``prompt``/``formatter`` 链），或已 ``deploy_method(lazyllm.deploy.BertDeploy)`` 且 ``start()`` 的 ``TrainableModule``（序列分类，与 ac-jieba 语义对齐）。``None`` 表示不增强。
+    cluster_key (str): 同义词簇 ID 字段名，默认 ``"cluster_id"``。
+    word_key (str): 词文字段名，默认 ``"word"``。
+    max_retries (int): LLM 整批调用或 BERT 逐条调用失败时的最大重试次数，默认 ``3``。
+    prompt_lang (Literal["zh", "en"]): 内置 LLM 提示语言；``discriminator`` 为 ``None`` 或 BERT 部署的 ``TrainableModule`` 时无效。
+
+Methods:
+    - ``__call__(queries)``: 对单条字符串或字符串列表做增强。\\n
+    - ``get_matches(query)``: 返回经 AC + 边界过滤后的匹配列表。\\n
+    - ``update_data_source`` / ``update_discriminator``: 热更新词表或判别器。\\n
+''')
+
+add_english_doc('rag.QueryEnhACProcessor', '''\
+Query synonym expansion using an Aho–Corasick (AC) automaton.
+
+Matches vocabulary words in the query string, then replaces kept hits with the original word plus other surface forms in the same cluster (first hit per cluster is expanded; later hits in the same cluster keep only the matched word). Candidates are pre-filtered to **longest non-overlapping** matches, then a discriminator decides true word boundaries. If ``discriminator`` is ``None`` but the automaton still matches, a warning is logged and the query is unchanged; if the discriminator fails after retries, enhancement is skipped and the original query is kept.
+
+Args:
+    data_source: Vocabulary source: a no-arg callable returning ``list[dict]``, or a list of dicts. Each record must contain the fields named by ``cluster_key`` and ``word_key``; incomplete rows are skipped.
+    discriminator: Boundary discriminator: ``OnlineChatModule``, ``TrainableModule`` for LLM (with prompt/formatter chain), or a started ``TrainableModule`` with ``deploy_method(lazyllm.deploy.BertDeploy)`` (sequence classification, same semantics as ac-jieba). ``None`` disables enhancement.
+    cluster_key (str): Field name for synonym cluster id, default ``"cluster_id"``.
+    word_key (str): Field name for surface word text, default ``"word"``.
+    max_retries (int): Max retries for batched LLM calls or per-match BERT calls, default ``3``.
+    prompt_lang (Literal["zh", "en"]): Language for built-in LLM prompts; ignored when ``discriminator`` is ``None`` or a BERT-deployed ``TrainableModule``.
+
+Methods:
+    - ``__call__(queries)``: Enhance a single string or a list of strings.\\n
+    - ``get_matches(query)``: Return matches after AC + boundary filtering.\\n
+    - ``update_data_source`` / ``update_discriminator``: Hot-swap vocabulary or discriminator.\\n
+''')
+
+add_chinese_doc('rag.QueryEnhACProcessor.update_data_source', '''\
+热更新词表数据源并重建 AC 自动机。
+
+Args:
+    data_source: 新的数据源，规则与构造参数 ``data_source`` 相同。
+''')
+
+add_english_doc('rag.QueryEnhACProcessor.update_data_source', '''\
+Replace the vocabulary source and rebuild the AC automaton.
+
+Args:
+    data_source: New source, same rules as the constructor ``data_source`` argument.
+''')
+
+add_chinese_doc('rag.QueryEnhACProcessor.update_discriminator', '''\
+热更新词边界判别器（按新实例类型重新构建内部 LLM / BERT 过滤器）。
+
+Args:
+    discriminator: 新的判别器；类型须与构造参数一致，可为 ``None``。
+''')
+
+add_english_doc('rag.QueryEnhACProcessor.update_discriminator', '''\
+Hot-swap the boundary discriminator (rebuilds the internal LLM / BERT filter from the new instance).
+
+Args:
+    discriminator: New discriminator; same supported types as the constructor, or ``None``.
+''')
+
+add_chinese_doc('rag.QueryEnhACProcessor.get_matches', '''\
+返回经 AC 匹配与边界过滤后的命中列表（与 ac-jieba ``return_matches_only`` 形态对齐）。
+
+**Returns:**\\n
+- ``List[dict]``: 每项含当前 ``word_key``、``cluster_key`` 字段，以及 ``cluster_words``（该簇全部词形列表）。\\n
+''')
+
+add_english_doc('rag.QueryEnhACProcessor.get_matches', '''\
+Return matches after AC matching and boundary filtering (shape aligned with ac-jieba ``return_matches_only``).
+
+**Returns:**\\n
+- ``List[dict]``: Each item contains the configured ``word_key`` and ``cluster_key`` fields, plus ``cluster_words`` (all words in that cluster).\\n
+''')
+
+add_chinese_doc('rag.QueryEnhACProcessor.__call__', '''\
+对查询执行同义词扩展增强。
+
+Args:
+    queries (Union[str, List[str]]): 单条查询字符串，或查询字符串列表。
+
+**Returns:**\\n
+- ``Union[str, List[str]]``: 与输入同结构——单条入参返回字符串，列表入参返回增强后的字符串列表。\\n
+''')
+
+add_english_doc('rag.QueryEnhACProcessor.__call__', '''\
+Run synonym expansion on one or more queries.
+
+Args:
+    queries (Union[str, List[str]]): A single query string or a list of query strings.
+
+**Returns:**\\n
+- ``Union[str, List[str]]``: Same structure as input—a string for a single query, or a list of enhanced strings.\\n
+''')
+
+add_example('rag.QueryEnhACProcessor', '''\
+>>> import lazyllm
+>>> from lazyllm.tools.rag import QueryEnhACProcessor
+>>> def vocab():
+...     return [
+...         {"cluster_id": "C1", "word": "民法"},
+...         {"cluster_id": "C1", "word": "civil law"},
+...     ]
+>>> model = lazyllm.OnlineChatModule()
+>>> proc = QueryEnhACProcessor(data_source=vocab, discriminator=model)
+>>> out = proc("什么是民法？")
+>>> proc.update_data_source(vocab)
+>>> proc.update_discriminator(model)
+''')
+
+

--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -9457,9 +9457,9 @@ Args:
     prompt_lang (Literal["zh", "en"]): 内置 LLM 提示语言；``discriminator`` 为 ``None`` 或 BERT 部署的 ``TrainableModule`` 时无效。
 
 Methods:
-    - ``__call__(queries)``: 对单条字符串或字符串列表做增强。\\n
-    - ``get_matches(query)``: 返回经 AC + 边界过滤后的匹配列表。\\n
-    - ``update_data_source`` / ``update_discriminator``: 热更新词表或判别器。\\n
+    - ``__call__(queries)``: 对单条字符串或字符串列表做增强。
+    - ``get_matches(query)``: 返回经 AC + 边界过滤后的匹配列表。
+    - ``update_data_source`` / ``update_discriminator``: 热更新词表或判别器。
 ''')
 
 add_english_doc('rag.QueryEnhACProcessor', '''\
@@ -9476,9 +9476,9 @@ Args:
     prompt_lang (Literal["zh", "en"]): Language for built-in LLM prompts; ignored when ``discriminator`` is ``None`` or a BERT-deployed ``TrainableModule``.
 
 Methods:
-    - ``__call__(queries)``: Enhance a single string or a list of strings.\\n
-    - ``get_matches(query)``: Return matches after AC + boundary filtering.\\n
-    - ``update_data_source`` / ``update_discriminator``: Hot-swap vocabulary or discriminator.\\n
+    - ``__call__(queries)``: Enhance a single string or a list of strings.
+    - ``get_matches(query)``: Return matches after AC + boundary filtering.
+    - ``update_data_source`` / ``update_discriminator``: Hot-swap vocabulary or discriminator.
 ''')
 
 add_chinese_doc('rag.QueryEnhACProcessor.update_data_source', '''\
@@ -9512,15 +9512,21 @@ Args:
 add_chinese_doc('rag.QueryEnhACProcessor.get_matches', '''\
 返回经 AC 匹配与边界过滤后的命中列表（与 ac-jieba ``return_matches_only`` 形态对齐）。
 
-**Returns:**\\n
-- ``List[dict]``: 每项含当前 ``word_key``、``cluster_key`` 字段，以及 ``cluster_words``（该簇全部词形列表）。\\n
+Args:
+    query (str): 待匹配的查询字符串。
+
+**Returns:**
+- ``List[dict]``: 每项含当前 ``word_key``、``cluster_key`` 字段，以及 ``cluster_words``（该簇全部词形列表）。
 ''')
 
 add_english_doc('rag.QueryEnhACProcessor.get_matches', '''\
 Return matches after AC matching and boundary filtering (shape aligned with ac-jieba ``return_matches_only``).
 
-**Returns:**\\n
-- ``List[dict]``: Each item contains the configured ``word_key`` and ``cluster_key`` fields, plus ``cluster_words`` (all words in that cluster).\\n
+Args:
+    query (str): The query string to match against the AC automaton.
+
+**Returns:**
+- ``List[dict]``: Each item contains the configured ``word_key`` and ``cluster_key`` fields, plus ``cluster_words`` (all words in that cluster).
 ''')
 
 add_chinese_doc('rag.QueryEnhACProcessor.__call__', '''\
@@ -9529,8 +9535,8 @@ add_chinese_doc('rag.QueryEnhACProcessor.__call__', '''\
 Args:
     queries (Union[str, List[str]]): 单条查询字符串，或查询字符串列表。
 
-**Returns:**\\n
-- ``Union[str, List[str]]``: 与输入同结构——单条入参返回字符串，列表入参返回增强后的字符串列表。\\n
+**Returns:**
+- ``Union[str, List[str]]``: 与输入同结构——单条入参返回字符串，列表入参返回增强后的字符串列表。
 ''')
 
 add_english_doc('rag.QueryEnhACProcessor.__call__', '''\
@@ -9539,8 +9545,8 @@ Run synonym expansion on one or more queries.
 Args:
     queries (Union[str, List[str]]): A single query string or a list of query strings.
 
-**Returns:**\\n
-- ``Union[str, List[str]]``: Same structure as input—a string for a single query, or a list of enhanced strings.\\n
+**Returns:**
+- ``Union[str, List[str]]``: Same structure as input—a string for a single query, or a list of enhanced strings.
 ''')
 
 add_example('rag.QueryEnhACProcessor', '''\
@@ -9551,9 +9557,18 @@ add_example('rag.QueryEnhACProcessor', '''\
 ...         {"cluster_id": "C1", "word": "民法"},
 ...         {"cluster_id": "C1", "word": "civil law"},
 ...     ]
+>>> # LLM discriminator
 >>> model = lazyllm.OnlineChatModule()
 >>> proc = QueryEnhACProcessor(data_source=vocab, discriminator=model)
 >>> out = proc("什么是民法？")
+>>> print(out)
+>>> # BERT discriminator
+>>> bert_m = lazyllm.TrainableModule('your-seq-cls-model', use_model_map=False).deploy_method(
+...     lazyllm.deploy.BertDeploy, max_length=128,
+... ).start()
+>>> proc2 = QueryEnhACProcessor(data_source=vocab, discriminator=bert_m)
+>>> out2 = proc2("什么是民法？")
+>>> print(out2)
 >>> proc.update_data_source(vocab)
 >>> proc.update_discriminator(model)
 ''')

--- a/lazyllm/tools/rag/__init__.py
+++ b/lazyllm/tools/rag/__init__.py
@@ -22,6 +22,7 @@ from .data_type import DataType
 from .index_base import IndexBase
 from .store import LazyLLMStoreBase
 from .doc_to_db import SchemaExtractor
+from .query_enh_ac import QueryEnhACProcessor
 
 
 add_post_action_for_default_reader = SimpleDirectoryReader.add_post_action_for_default_reader
@@ -77,5 +78,6 @@ __all__ = [
     'XMLSplitter',
     'GeneralCodeSplitter',
     'JSONLSplitter',
-    'SchemaExtractor'
+    'SchemaExtractor',
+    'QueryEnhACProcessor',
 ]

--- a/lazyllm/tools/rag/query_enh_ac.py
+++ b/lazyllm/tools/rag/query_enh_ac.py
@@ -4,14 +4,12 @@ from typing import List, Literal, Optional, Union
 import lazyllm
 from lazyllm.thirdparty import ahocorasick
 from lazyllm import LOG, JsonFormatter, ChatPrompter
-from lazyllm.components import EmptyFormatter
-from lazyllm.components.prompter import EmptyPrompter
 from lazyllm.module import LLMBase, TrainableModule
 
 PromptLang = Literal['zh', 'en']
 
 # ── LLM prompts (Chinese default, English optional) ───────────────────────────
-_LLM_SYSTEM_ZH = """你是一个自然语言处理专家，擅长判断词语边界与语义完整性。
+_LLM_SYSTEM_ZH = '''你是一个自然语言处理专家，擅长判断词语边界与语义完整性。
 
 ## 任务
 给定一段查询文本和若干候选匹配词，判断每个候选词在文本中是否以**完整、独立的词语**形式出现。
@@ -30,13 +28,15 @@ _LLM_SYSTEM_ZH = """你是一个自然语言处理专家，擅长判断词语边
 严格返回JSON数组，元素个数与候选词数量一致，每个元素为 true 或 false。
 不要输出任何其他内容。
 示例：[true, false, true]
-"""
-_LLM_USER_ZH = """查询文本："{query}"\n\n候选匹配：\n{candidates_text}"""
+'''
 
-_LLM_SYSTEM_EN = """You are an NLP expert skilled at judging word boundaries and semantic completeness.
+_LLM_USER_ZH = '查询文本："{query}"\n\n候选匹配：\n{candidates_text}'
+
+_LLM_SYSTEM_EN = '''You are an NLP expert skilled at judging word boundaries and semantic completeness.
 
 ## Task
-Given a query string and several candidate substring matches, decide whether each candidate appears as a **complete, standalone word** in the text.
+Given a query string and several candidate substring matches,
+decide whether each candidate appears as a **complete, standalone word** in the text.
 
 ## Rules
 1. If the candidate is a semantically complete word on its own (not part of a longer word), return true.
@@ -51,8 +51,9 @@ Given a query string and several candidate substring matches, decide whether eac
 ## Output
 Return **only** a JSON array with one boolean per candidate, same order as listed.
 Example: [true, false, true]
-"""
-_LLM_USER_EN = """Query text: "{query}"\n\nCandidates:\n{candidates_text}"""
+'''
+
+_LLM_USER_EN = 'Query text: "{query}"\n\nCandidates:\n{candidates_text}'
 
 
 def _default_llm_prompt(lang: PromptLang) -> ChatPrompter:
@@ -188,8 +189,8 @@ class QueryEnhACProcessor:
         self,
         data_source=None,
         discriminator=None,
-        cluster_key: str = "cluster_id",
-        word_key: str = "word",
+        cluster_key: str = 'cluster_id',
+        word_key: str = 'word',
         max_retries: int = 3,
         prompt_lang: PromptLang = 'zh',
     ):
@@ -203,15 +204,13 @@ class QueryEnhACProcessor:
         self._boundary_filter: Optional[Union[_LLMFilter, _BERTFilter]] = None
         self._build_filter(discriminator)
 
-        self.vocab_data: list = []
-        self.word_to_cluster: dict = {}
-        self.cluster_to_words: dict = {}
-        self.automaton: Optional[ahocorasick.Automaton] = None
+        self.vocab_data = []
+        self.word_to_cluster = {}
+        self.cluster_to_words = {}
+        self.automaton = None
 
         self._data_source = data_source if data_source is not None else []
         self._rebuild_automaton()
-
-    # ── 内部构建方法 ────────────────────────────────────────────────────────────
 
     def _build_filter(self, discriminator):
         if discriminator is None:
@@ -266,7 +265,6 @@ class QueryEnhACProcessor:
 
         LOG.info(f'AC automaton built, vocabulary size: {len(self.word_to_cluster)}')
 
-
     def update_data_source(self, data_source):
         self._data_source = data_source
         self._rebuild_automaton()
@@ -282,10 +280,10 @@ class QueryEnhACProcessor:
         for end_idx, (cluster_id, matched_word) in self.automaton.iter(str(query)):
             start_idx = end_idx - len(matched_word) + 1
             raw_matches.append({
-                "word": matched_word,
-                "cluster_id": cluster_id,
-                "start": start_idx,
-                "end": end_idx,
+                'word': matched_word,
+                'cluster_id': cluster_id,
+                'start': start_idx,
+                'end': end_idx,
             })
 
         if not raw_matches:
@@ -298,13 +296,13 @@ class QueryEnhACProcessor:
             )
             return []
 
-        raw_matches.sort(key=lambda x: (x["start"], -len(x["word"])))
+        raw_matches.sort(key=lambda x: (x['start'], -len(x['word'])))
         result, last_end = [], -1
         for m in raw_matches:
-            if m["start"] <= last_end:
+            if m['start'] <= last_end:
                 continue
             result.append(m)
-            last_end = m["end"]
+            last_end = m['end']
         return self._boundary_filter(query, result)
 
     def _enhance_single(self, query: str) -> str:
@@ -317,22 +315,22 @@ class QueryEnhACProcessor:
         seen_clusters: set = set()
 
         for match in matches:
-            start_idx = match["start"]
-            end_idx = match["end"]
+            start_idx = match['start']
+            end_idx = match['end']
 
             if start_idx > last_pos:
                 enhanced_parts.append(query[last_pos:start_idx])
 
-            cluster_id = match["cluster_id"]
+            cluster_id = match['cluster_id']
             if cluster_id in seen_clusters:
-                replacement = match["word"]
+                replacement = match['word']
             else:
                 seen_clusters.add(cluster_id)
                 cluster_words = self.cluster_to_words.get(cluster_id, [])
-                other_words = [w for w in cluster_words if w != match["word"]]
+                other_words = [w for w in cluster_words if w != match['word']]
                 replacement = (
-                    f"{match['word']}（{', '.join(other_words)}）"
-                    if other_words else match["word"]
+                    f'{match["word"]}（{", ".join(other_words)}）'
+                    if other_words else match['word']
                 )
 
             enhanced_parts.append(replacement)
@@ -341,7 +339,7 @@ class QueryEnhACProcessor:
         if last_pos < len(query):
             enhanced_parts.append(query[last_pos:])
 
-        return "".join(enhanced_parts)
+        return ''.join(enhanced_parts)
 
     def get_matches(self, query: str) -> List[dict]:
         out: List[dict] = []
@@ -358,16 +356,3 @@ class QueryEnhACProcessor:
         if isinstance(queries, str):
             return self._enhance_single(queries)
         return [self._enhance_single(q) for q in queries]
-
-
-# ── 默认数据源（测试用）────────────────────────────────────────────────────────
-def _default_data_source():
-    """提供默认的模拟词表数据供测试"""
-    return [
-        {"cluster_id": "C001", "word": "民法"},
-        {"cluster_id": "C001", "word": "minfa"},
-        {"cluster_id": "C002", "word": "丙醇"},
-        {"cluster_id": "C002", "word": "bingchun"},
-        {"cluster_id": "C003", "word": "染色体"},
-        {"cluster_id": "C003", "word": "ranseti"},
-    ]

--- a/lazyllm/tools/rag/query_enh_ac.py
+++ b/lazyllm/tools/rag/query_enh_ac.py
@@ -1,0 +1,373 @@
+import json
+from typing import List, Literal, Optional, Union
+
+import lazyllm
+from lazyllm.thirdparty import ahocorasick
+from lazyllm import LOG, JsonFormatter, ChatPrompter
+from lazyllm.components import EmptyFormatter
+from lazyllm.components.prompter import EmptyPrompter
+from lazyllm.module import LLMBase, TrainableModule
+
+PromptLang = Literal['zh', 'en']
+
+# ── LLM prompts (Chinese default, English optional) ───────────────────────────
+_LLM_SYSTEM_ZH = """你是一个自然语言处理专家，擅长判断词语边界与语义完整性。
+
+## 任务
+给定一段查询文本和若干候选匹配词，判断每个候选词在文本中是否以**完整、独立的词语**形式出现。
+
+## 判断规则
+1. 若候选词在文本中是一个语义完整的独立词语（不依附于更长的词），返回 true
+2. 若候选词仅是文本中某个更长词语的组成部分（子串），返回 false
+
+## 示例
+- 文本"民法典"中的"民法" → false（"民法"是"民法典"的一部分）
+- 文本"什么是民法？"中的"民法" → true（"民法"是完整独立的词语）
+- 文本"加入丙醇酸"中的"丙醇" → false（"丙醇"是"丙醇酸"的一部分）
+- 文本"加入丙醇和水"中的"丙醇" → true（"丙醇"是完整独立的词语）
+
+## 输出格式
+严格返回JSON数组，元素个数与候选词数量一致，每个元素为 true 或 false。
+不要输出任何其他内容。
+示例：[true, false, true]
+"""
+_LLM_USER_ZH = """查询文本："{query}"\n\n候选匹配：\n{candidates_text}"""
+
+_LLM_SYSTEM_EN = """You are an NLP expert skilled at judging word boundaries and semantic completeness.
+
+## Task
+Given a query string and several candidate substring matches, decide whether each candidate appears as a **complete, standalone word** in the text.
+
+## Rules
+1. If the candidate is a semantically complete word on its own (not part of a longer word), return true.
+2. If the candidate is only a substring inside a longer word, return false.
+
+## Examples
+- In "民法典", candidate "民法" → false ("民法" is part of "民法典").
+- In "什么是民法？", candidate "民法" → true ("民法" is a standalone word).
+- In "加入丙醇酸", candidate "丙醇" → false ("丙醇" is part of "丙醇酸").
+- In "加入丙醇和水", candidate "丙醇" → true ("丙醇" is a standalone word).
+
+## Output
+Return **only** a JSON array with one boolean per candidate, same order as listed.
+Example: [true, false, true]
+"""
+_LLM_USER_EN = """Query text: "{query}"\n\nCandidates:\n{candidates_text}"""
+
+
+def _default_llm_prompt(lang: PromptLang) -> ChatPrompter:
+    if lang == 'en':
+        return ChatPrompter({'system': _LLM_SYSTEM_EN, 'user': _LLM_USER_EN})
+    return ChatPrompter({'system': _LLM_SYSTEM_ZH, 'user': _LLM_USER_ZH})
+
+
+class _LLMFilter:
+
+    _default_inference_kwargs: dict = {}
+
+    def __init__(
+        self,
+        model: LLMBase,
+        prompt=None,
+        max_retries: int = 3,
+        prompt_lang: PromptLang = 'zh',
+    ):
+        lang: PromptLang = prompt_lang if prompt_lang in ('zh', 'en') else 'zh'
+        self._prompt_lang = lang
+        prompt = prompt if prompt is not None else _default_llm_prompt(lang)
+        self.model = model.share().prompt(prompt).formatter(JsonFormatter())
+        self._max_retries = max_retries
+
+    def _preprocess(self, query: str, matches: list) -> dict:
+        if self._prompt_lang == 'en':
+            lines = [
+                f'{i}. matched_word="{m["word"]}", '
+                f'context="...{query[max(0, m["start"] - 5):m["end"] + 6]}..."'
+                for i, m in enumerate(matches)
+            ]
+        else:
+            lines = [
+                f'{i}. 匹配词="{m["word"]}", '
+                f'上下文="...{query[max(0, m["start"] - 5):m["end"] + 6]}..."'
+                for i, m in enumerate(matches)
+            ]
+        candidates_text = '\n'.join(lines)
+        return {'query': query, 'candidates_text': candidates_text}
+
+    def __call__(self, query: str, matches: list) -> list:
+        if not matches:
+            return []
+        prepared = self._preprocess(query, matches)
+        for attempt in range(self._max_retries):
+            try:
+                res = self.model(prepared, **self._default_inference_kwargs)
+                if isinstance(res, list) and len(res) == len(matches):
+                    return [m for m, keep in zip(matches, res) if keep]
+                LOG.warning(
+                    f'_LLMFilter invalid output, attempt {attempt + 1}/{self._max_retries}: {res}'
+                )
+            except Exception as e:
+                LOG.warning(
+                    f'_LLMFilter inference failed, attempt {attempt + 1}/{self._max_retries}: {e}'
+                )
+        LOG.warning(
+            '_LLMFilter gave up after retries; skipping enhancement (original query unchanged).'
+        )
+        return []
+
+
+def _is_bert_deploy(module: TrainableModule) -> bool:
+    return module._deploy_type is lazyllm.deploy.BertDeploy
+
+
+class _BERTFilter:
+
+    def __init__(
+        self,
+        model: TrainableModule,
+        threshold: float = 0.5,
+        max_retries: int = 3,
+    ):
+        self.model = model.share()
+        self.threshold = float(threshold)
+        self._max_retries = max_retries
+
+    @staticmethod
+    def _context(query: str, match: dict) -> str:
+        s, e = match['start'], match['end']
+        return f'...{query[max(0, s - 5):e + 6]}...'
+
+    @staticmethod
+    def _prob_label1(obj: dict) -> float:
+        probs = obj.get('probs') or []
+        if len(probs) >= 2:
+            return float(probs[1])
+        if len(probs) == 1:
+            return float(probs[0])
+        raise ValueError(f'BERT response missing probs: {obj!r}')
+
+    @classmethod
+    def _parse_output(cls, raw: Union[str, dict]) -> dict:
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            return json.loads(raw)
+        raise TypeError(f'Unexpected BERT output type: {type(raw)}')
+
+    def __call__(self, query: str, matches: list) -> list:
+        if not matches:
+            return matches
+
+        kept: list = []
+        for m in matches:
+            word, ctx = m['word'], self._context(query, m)
+            placed = False
+            for attempt in range(self._max_retries):
+                try:
+                    raw = self.model(word, text_b=ctx)
+                    obj = self._parse_output(raw)
+                    if self._prob_label1(obj) >= self.threshold:
+                        kept.append(m)
+                    placed = True
+                    break
+                except Exception as e:
+                    LOG.warning(
+                        f'_BERTFilter inference failed, attempt {attempt + 1}/{self._max_retries}: {e}'
+                    )
+            if not placed:
+                LOG.warning(
+                    f'_BERTFilter gave up on match after retries: {m.get("word")!r}; dropping that match only.'
+                )
+
+        return kept
+
+
+class QueryEnhACProcessor:
+
+    def __init__(
+        self,
+        data_source=None,
+        discriminator=None,
+        cluster_key: str = "cluster_id",
+        word_key: str = "word",
+        max_retries: int = 3,
+        prompt_lang: PromptLang = 'zh',
+    ):
+        if prompt_lang not in ('zh', 'en'):
+            raise ValueError(f'prompt_lang must be "zh" or "en", got {prompt_lang!r}')
+        self.cluster_key = cluster_key
+        self.word_key = word_key
+        self._max_retries = max_retries
+        self._prompt_lang: PromptLang = prompt_lang
+
+        self._boundary_filter: Optional[Union[_LLMFilter, _BERTFilter]] = None
+        self._build_filter(discriminator)
+
+        self.vocab_data: list = []
+        self.word_to_cluster: dict = {}
+        self.cluster_to_words: dict = {}
+        self.automaton: Optional[ahocorasick.Automaton] = None
+
+        self._data_source = data_source if data_source is not None else []
+        self._rebuild_automaton()
+
+    # ── 内部构建方法 ────────────────────────────────────────────────────────────
+
+    def _build_filter(self, discriminator):
+        if discriminator is None:
+            self._boundary_filter = None
+            return
+        if isinstance(discriminator, TrainableModule) and _is_bert_deploy(discriminator):
+            self._boundary_filter = _BERTFilter(
+                model=discriminator,
+                max_retries=self._max_retries,
+            )
+            return
+        if isinstance(discriminator, LLMBase):
+            self._boundary_filter = _LLMFilter(
+                model=discriminator,
+                max_retries=self._max_retries,
+                prompt_lang=self._prompt_lang,
+            )
+            return
+        raise TypeError(
+            f'Unsupported discriminator type {type(discriminator)}. '
+            'Use OnlineChatModule, TrainableModule (LLM or lazyllm.deploy.BertDeploy), or None.'
+        )
+
+    def _rebuild_automaton(self):
+        if callable(self._data_source):
+            self.vocab_data = self._data_source()
+        else:
+            self.vocab_data = list(self._data_source)
+
+        self.word_to_cluster = {}
+        self.cluster_to_words = {}
+
+        for item in self.vocab_data:
+            cluster_id = item.get(self.cluster_key)
+            word = item.get(self.word_key)
+            if cluster_id is None or word is None:
+                continue
+            self.word_to_cluster[word] = cluster_id
+            if cluster_id not in self.cluster_to_words:
+                self.cluster_to_words[cluster_id] = []
+            if word not in self.cluster_to_words[cluster_id]:
+                self.cluster_to_words[cluster_id].append(word)
+
+        if self.word_to_cluster:
+            automaton = ahocorasick.Automaton()
+            for word, cluster_id in self.word_to_cluster.items():
+                automaton.add_word(str(word), (cluster_id, str(word)))
+            automaton.make_automaton()
+            self.automaton = automaton
+        else:
+            self.automaton = None
+
+        LOG.info(f'AC automaton built, vocabulary size: {len(self.word_to_cluster)}')
+
+
+    def update_data_source(self, data_source):
+        self._data_source = data_source
+        self._rebuild_automaton()
+
+    def update_discriminator(self, discriminator):
+        self._build_filter(discriminator)
+
+    def _get_matches(self, query: str) -> list:
+        if not self.automaton or not query:
+            return []
+
+        raw_matches = []
+        for end_idx, (cluster_id, matched_word) in self.automaton.iter(str(query)):
+            start_idx = end_idx - len(matched_word) + 1
+            raw_matches.append({
+                "word": matched_word,
+                "cluster_id": cluster_id,
+                "start": start_idx,
+                "end": end_idx,
+            })
+
+        if not raw_matches:
+            return []
+
+        if self._boundary_filter is None:
+            LOG.warning(
+                'QueryEnhACProcessor: discriminator is None but AC automaton had matches; '
+                'skipping enhancement (original query unchanged).'
+            )
+            return []
+
+        raw_matches.sort(key=lambda x: (x["start"], -len(x["word"])))
+        result, last_end = [], -1
+        for m in raw_matches:
+            if m["start"] <= last_end:
+                continue
+            result.append(m)
+            last_end = m["end"]
+        return self._boundary_filter(query, result)
+
+    def _enhance_single(self, query: str) -> str:
+        matches = self._get_matches(query)
+        if not matches:
+            return query
+
+        enhanced_parts = []
+        last_pos = 0
+        seen_clusters: set = set()
+
+        for match in matches:
+            start_idx = match["start"]
+            end_idx = match["end"]
+
+            if start_idx > last_pos:
+                enhanced_parts.append(query[last_pos:start_idx])
+
+            cluster_id = match["cluster_id"]
+            if cluster_id in seen_clusters:
+                replacement = match["word"]
+            else:
+                seen_clusters.add(cluster_id)
+                cluster_words = self.cluster_to_words.get(cluster_id, [])
+                other_words = [w for w in cluster_words if w != match["word"]]
+                replacement = (
+                    f"{match['word']}（{', '.join(other_words)}）"
+                    if other_words else match["word"]
+                )
+
+            enhanced_parts.append(replacement)
+            last_pos = end_idx + 1
+
+        if last_pos < len(query):
+            enhanced_parts.append(query[last_pos:])
+
+        return "".join(enhanced_parts)
+
+    def get_matches(self, query: str) -> List[dict]:
+        out: List[dict] = []
+        for m in self._get_matches(query):
+            cid = m['cluster_id']
+            out.append({
+                self.word_key: m['word'],
+                self.cluster_key: cid,
+                'cluster_words': self.cluster_to_words.get(cid, []),
+            })
+        return out
+
+    def __call__(self, queries: Union[str, List[str]]) -> Union[str, List[str]]:
+        if isinstance(queries, str):
+            return self._enhance_single(queries)
+        return [self._enhance_single(q) for q in queries]
+
+
+# ── 默认数据源（测试用）────────────────────────────────────────────────────────
+def _default_data_source():
+    """提供默认的模拟词表数据供测试"""
+    return [
+        {"cluster_id": "C001", "word": "民法"},
+        {"cluster_id": "C001", "word": "minfa"},
+        {"cluster_id": "C002", "word": "丙醇"},
+        {"cluster_id": "C002", "word": "bingchun"},
+        {"cluster_id": "C003", "word": "染色体"},
+        {"cluster_id": "C003", "word": "ranseti"},
+    ]

--- a/lazyllm/tools/rag/query_enh_ac.py
+++ b/lazyllm/tools/rag/query_enh_ac.py
@@ -193,6 +193,7 @@ class QueryEnhACProcessor:
         word_key: str = 'word',
         max_retries: int = 3,
         prompt_lang: PromptLang = 'zh',
+        threshold: float = 0.5,
     ):
         if prompt_lang not in ('zh', 'en'):
             raise ValueError(f'prompt_lang must be "zh" or "en", got {prompt_lang!r}')
@@ -200,6 +201,7 @@ class QueryEnhACProcessor:
         self.word_key = word_key
         self._max_retries = max_retries
         self._prompt_lang: PromptLang = prompt_lang
+        self._threshold = float(threshold)
 
         self._boundary_filter: Optional[Union[_LLMFilter, _BERTFilter]] = None
         self._build_filter(discriminator)
@@ -219,6 +221,7 @@ class QueryEnhACProcessor:
         if isinstance(discriminator, TrainableModule) and _is_bert_deploy(discriminator):
             self._boundary_filter = _BERTFilter(
                 model=discriminator,
+                threshold=self._threshold,
                 max_retries=self._max_retries,
             )
             return

--- a/lazyllm/tools/rag/query_enh_ac.py
+++ b/lazyllm/tools/rag/query_enh_ac.py
@@ -118,7 +118,8 @@ class _LLMFilter:
 
 
 def _is_bert_deploy(module: TrainableModule) -> bool:
-    return module._deploy_type is lazyllm.deploy.BertDeploy
+    deploy_type = getattr(module, '_deploy_type', None)
+    return deploy_type is not None and deploy_type is lazyllm.deploy.BertDeploy
 
 
 class _BERTFilter:
@@ -269,10 +270,10 @@ class QueryEnhACProcessor:
                 automaton.add_word(str(word), (cluster_id, str(word)))
             automaton.make_automaton()
             self.automaton = automaton
+            LOG.info(f'AC automaton built, vocabulary size: {len(self.word_to_cluster)}')
         else:
             self.automaton = None
-
-        LOG.info(f'AC automaton built, vocabulary size: {len(self.word_to_cluster)}')
+            LOG.debug('AC automaton: vocabulary is empty, automaton not built')
 
     def update_data_source(self, data_source):
         self._data_source = data_source
@@ -366,4 +367,13 @@ class QueryEnhACProcessor:
     def __call__(self, queries: Union[str, List[str]]) -> Union[str, List[str]]:
         if isinstance(queries, str):
             return self._enhance_single(queries)
-        return [self._enhance_single(q) for q in queries]
+        if isinstance(queries, list):
+            for i, q in enumerate(queries):
+                if not isinstance(q, str):
+                    raise TypeError(
+                        f'QueryEnhACProcessor: queries[{i}] must be str, got {type(q).__name__}'
+                    )
+            return [self._enhance_single(q) for q in queries]
+        raise TypeError(
+            f'QueryEnhACProcessor: queries must be str or List[str], got {type(queries).__name__}'
+        )

--- a/lazyllm/tools/rag/query_enh_ac.py
+++ b/lazyllm/tools/rag/query_enh_ac.py
@@ -144,6 +144,10 @@ class _BERTFilter:
         if len(probs) >= 2:
             return float(probs[1])
         if len(probs) == 1:
+            LOG.warning(
+                f'_BERTFilter: BERT response has only 1 probability value; '
+                f'assuming it represents label-1 probability. obj={obj!r}'
+            )
             return float(probs[0])
         raise ValueError(f'BERT response missing probs: {obj!r}')
 
@@ -165,6 +169,7 @@ class _BERTFilter:
             placed = False
             for attempt in range(self._max_retries):
                 try:
+                    # TrainableModule merges kwargs into BertDeploy.message_format fields
                     raw = self.model(word, text_b=ctx)
                     obj = self._parse_output(raw)
                     if self._prob_label1(obj) >= self.threshold:
@@ -244,7 +249,7 @@ class QueryEnhACProcessor:
             self.vocab_data = list(self._data_source)
 
         self.word_to_cluster = {}
-        self.cluster_to_words = {}
+        cluster_word_sets: dict = {}
 
         for item in self.vocab_data:
             cluster_id = item.get(self.cluster_key)
@@ -252,10 +257,11 @@ class QueryEnhACProcessor:
             if cluster_id is None or word is None:
                 continue
             self.word_to_cluster[word] = cluster_id
-            if cluster_id not in self.cluster_to_words:
-                self.cluster_to_words[cluster_id] = []
-            if word not in self.cluster_to_words[cluster_id]:
-                self.cluster_to_words[cluster_id].append(word)
+            if cluster_id not in cluster_word_sets:
+                cluster_word_sets[cluster_id] = set()
+            cluster_word_sets[cluster_id].add(word)
+
+        self.cluster_to_words = {k: list(v) for k, v in cluster_word_sets.items()}
 
         if self.word_to_cluster:
             automaton = ahocorasick.Automaton()
@@ -279,6 +285,8 @@ class QueryEnhACProcessor:
         if not self.automaton or not query:
             return []
 
+        # Internal match dict schema (fixed keys, independent of user-facing word_key/cluster_key):
+        # {'word': str, 'cluster_id': str, 'start': int, 'end': int}
         raw_matches = []
         for end_idx, (cluster_id, matched_word) in self.automaton.iter(str(query)):
             start_idx = end_idx - len(matched_word) + 1

--- a/tests/advanced_tests/Tools/test_vocab.py
+++ b/tests/advanced_tests/Tools/test_vocab.py
@@ -11,13 +11,6 @@ from lazyllm.tools.rag.query_enh_ac import (
 
 
 def _mock_llm_discriminator(*call_returns):
-    """Build a MagicMock LLMBase chain for the terminal module __call__.
-
-    - One arg that is a list of only bools: use as fixed JSON list response every call (e.g. ``[True]``).
-    - One arg that is any other list: ``side_effect`` sequence (one value per call).
-    - One non-list arg: ``return_value`` for every call.
-    - Multiple args: ``side_effect`` in order.
-    """
     model = MagicMock(spec=LLMBase)
     terminal = MagicMock()
     if len(call_returns) == 1:
@@ -39,7 +32,7 @@ class TestQueryEnhACProcessor(object):
     @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
     def test_invalid_prompt_lang_raises(self):
         with pytest.raises(ValueError, match='prompt_lang'):
-            QueryEnhACProcessor(data_source=[], discriminator=None, prompt_lang='fr')  # type: ignore[arg-type]
+            QueryEnhACProcessor(data_source=[], discriminator=None, prompt_lang='fr')
 
     @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
     def test_invalid_discriminator_type_raises(self):
@@ -219,7 +212,6 @@ class TestLLMFilter(object):
 
 
 def _mock_bert_module_chain(*call_returns):
-    """Terminal is what ``model.share()`` returns; :class:`_BERTFilter` calls it as ``terminal(word, text_b=...)``."""
     terminal = MagicMock()
     if len(call_returns) == 1:
         only = call_returns[0]
@@ -267,5 +259,3 @@ class TestBERTFilter(object):
             out = f('qq', matches)
         assert out == []
         assert terminal.call_count == 2
-
-

--- a/tests/advanced_tests/Tools/test_vocab.py
+++ b/tests/advanced_tests/Tools/test_vocab.py
@@ -1,0 +1,271 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from lazyllm.module import LLMBase
+from lazyllm.tools.rag.query_enh_ac import (
+    QueryEnhACProcessor,
+    _LLMFilter,
+    _BERTFilter,
+    _default_llm_prompt,
+)
+
+
+def _mock_llm_discriminator(*call_returns):
+    """Build a MagicMock LLMBase chain for the terminal module __call__.
+
+    - One arg that is a list of only bools: use as fixed JSON list response every call (e.g. ``[True]``).
+    - One arg that is any other list: ``side_effect`` sequence (one value per call).
+    - One non-list arg: ``return_value`` for every call.
+    - Multiple args: ``side_effect`` in order.
+    """
+    model = MagicMock(spec=LLMBase)
+    terminal = MagicMock()
+    if len(call_returns) == 1:
+        only = call_returns[0]
+        if isinstance(only, list) and only and all(isinstance(x, bool) for x in only):
+            terminal.return_value = only
+        elif isinstance(only, list):
+            terminal.side_effect = only
+        else:
+            terminal.return_value = only
+    else:
+        terminal.side_effect = list(call_returns)
+    model.share.return_value.prompt.return_value.formatter.return_value = terminal
+    return model, terminal
+
+
+class TestQueryEnhACProcessor(object):
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_invalid_prompt_lang_raises(self):
+        with pytest.raises(ValueError, match='prompt_lang'):
+            QueryEnhACProcessor(data_source=[], discriminator=None, prompt_lang='fr')  # type: ignore[arg-type]
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_invalid_discriminator_type_raises(self):
+        with pytest.raises(TypeError, match='Unsupported discriminator'):
+            QueryEnhACProcessor(data_source=[], discriminator=object())
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_empty_vocab_returns_query_unchanged(self):
+        proc = QueryEnhACProcessor(data_source=[], discriminator=None)
+        assert proc('任意查询文本') == '任意查询文本'
+        assert proc(['a', 'b']) == ['a', 'b']
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_discriminator_none_logs_and_returns_original_when_ac_matches(self):
+        vocab = [
+            {'cluster_id': 'cx', 'word': 'lazyllmacpodvocabtoken'},
+            {'cluster_id': 'cx', 'word': 'alias_ac'},
+        ]
+        proc = QueryEnhACProcessor(data_source=vocab, discriminator=None)
+        q = '请用lazyllmacpodvocabtoken完成检索'
+        with patch('lazyllm.tools.rag.query_enh_ac.LOG') as mock_log:
+            out = proc(q)
+        assert out == q
+        mock_log.warning.assert_called()
+        wargs = mock_log.warning.call_args[0]
+        assert wargs and 'discriminator is None' in str(wargs[0])
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_llm_synonym_enhancement(self):
+        vocab = [
+            {'cluster_id': 'cx', 'word': 'fooword'},
+            {'cluster_id': 'cx', 'word': 'alias_ac'},
+        ]
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(data_source=vocab, discriminator=model)
+        out = proc('fooword')
+        assert 'fooword' in out
+        assert 'alias_ac' in out
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_get_matches_aligned_with_ac_jieba_shape(self):
+        vocab = [
+            {'cluster_id': 'cx', 'word': 'fooword'},
+            {'cluster_id': 'cx', 'word': 'alias_ac'},
+        ]
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(data_source=vocab, discriminator=model)
+        ms = proc.get_matches('fooword')
+        assert len(ms) == 1
+        assert ms[0]['word'] == 'fooword'
+        assert ms[0]['cluster_id'] == 'cx'
+        assert set(ms[0]['cluster_words']) == {'fooword', 'alias_ac'}
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_update_data_source_rebuilds_automaton(self):
+        token = 'updqwxyztoken'
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(data_source=[], discriminator=model)
+        assert proc(f'前缀{token}后缀') == f'前缀{token}后缀'
+        proc.update_data_source([
+            {'cluster_id': 'u', 'word': token},
+            {'cluster_id': 'u', 'word': 'syn_u'},
+        ])
+        out = proc(f'前缀{token}后缀')
+        assert token in out
+        assert 'syn_u' in out
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_callable_data_source(self):
+        rows = [{'cluster_id': 'k', 'word': 'callabletok'}]
+
+        def ds():
+            return list(rows)
+
+        token = 'callabletok'
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(data_source=ds, discriminator=model)
+        out = proc(f'使用{token}测试')
+        assert token in out
+        rows.append({'cluster_id': 'k', 'word': 'callable_alias'})
+        proc.update_data_source(ds)
+        out2 = proc(f'使用{token}测试')
+        assert 'callable_alias' in out2
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_custom_cluster_and_word_keys(self):
+        token = 'keytokabc'
+        vocab = [{'cid': 1, 'w': token}, {'cid': 1, 'w': 'alt_w'}]
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(
+            data_source=vocab,
+            discriminator=model,
+            cluster_key='cid',
+            word_key='w',
+        )
+        out = proc(f'X{token}Y')
+        assert token in out and 'alt_w' in out
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_prompt_lang_en_init_with_llm(self):
+        model, _ = _mock_llm_discriminator([True])
+        proc = QueryEnhACProcessor(
+            data_source=[],
+            discriminator=model,
+            prompt_lang='en',
+        )
+        assert proc('q') == 'q'
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_llm_invalid_output_returns_original_query(self):
+        vocab = [
+            {'cluster_id': 'c', 'word': 'hi'},
+            {'cluster_id': 'c', 'word': 'hello'},
+        ]
+        model, terminal = _mock_llm_discriminator('not-a-list')
+        proc = QueryEnhACProcessor(data_source=vocab, discriminator=model, max_retries=2)
+        with patch('lazyllm.tools.rag.query_enh_ac.LOG') as mock_log:
+            out = proc('hi')
+        assert out == 'hi'
+        assert terminal.call_count == 2
+        warn_blob = ' '.join(
+            str(a) for call in mock_log.warning.call_args_list for a in call.args
+        )
+        assert '_LLMFilter' in warn_blob
+
+
+class TestQueryEnhACPrompts(object):
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_default_llm_prompt_zh_and_en_differ(self):
+        p_zh = _default_llm_prompt('zh')
+        p_en = _default_llm_prompt('en')
+        assert p_zh is not None and p_en is not None
+        assert p_zh != p_en
+
+
+class TestLLMFilter(object):
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_preprocess_candidate_labels_zh_vs_en(self):
+        def make_filter(lang):
+            model = MagicMock(spec=LLMBase)
+            model.share.return_value.prompt.return_value.formatter.return_value = MagicMock()
+            return _LLMFilter(model=model, prompt_lang=lang)
+
+        f_zh = make_filter('zh')
+        d_zh = f_zh._preprocess('什么是民法？', [
+            {'word': '民法', 'start': 3, 'end': 4},
+        ])
+        assert '匹配词="' in d_zh['candidates_text']
+        assert '上下文="' in d_zh['candidates_text']
+
+        f_en = make_filter('en')
+        d_en = f_en._preprocess('什么是民法？', [
+            {'word': '民法', 'start': 3, 'end': 4},
+        ])
+        assert 'matched_word="' in d_en['candidates_text']
+        assert 'context="' in d_en['candidates_text']
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_call_empty_matches_short_circuit(self):
+        model = MagicMock(spec=LLMBase)
+        model.share.return_value.prompt.return_value.formatter.return_value = MagicMock()
+        f = _LLMFilter(model=model)
+        assert f('q', []) == []
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_call_failure_returns_empty_list(self):
+        model = MagicMock(spec=LLMBase)
+        terminal = MagicMock(return_value=None)
+        model.share.return_value.prompt.return_value.formatter.return_value = terminal
+        f = _LLMFilter(model=model, max_retries=2)
+        matches = [{'word': 'a', 'start': 0, 'end': 0}]
+        out = f('query', matches)
+        assert out == []
+        assert terminal.call_count == 2
+
+
+def _mock_bert_module_chain(*call_returns):
+    """Terminal is what ``model.share()`` returns; :class:`_BERTFilter` calls it as ``terminal(word, text_b=...)``."""
+    terminal = MagicMock()
+    if len(call_returns) == 1:
+        only = call_returns[0]
+        if isinstance(only, list):
+            terminal.side_effect = only
+        elif isinstance(only, BaseException):
+            terminal.side_effect = only
+        else:
+            terminal.return_value = only
+    else:
+        terminal.side_effect = list(call_returns)
+    model = MagicMock()
+    model.share.return_value = terminal
+    return model, terminal
+
+
+class TestBERTFilter(object):
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_call_empty_matches(self):
+        model, _ = _mock_bert_module_chain('{}')
+        f = _BERTFilter(model=model)
+        assert f('q', []) == []
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_threshold_keeps_or_drops(self):
+        hi = '{"probs": [0.2, 0.8], "predicted_label": 1}'
+        lo = '{"probs": [0.8, 0.2], "predicted_label": 0}'
+        model, terminal = _mock_bert_module_chain(hi, lo)
+        f = _BERTFilter(model=model, threshold=0.5)
+        matches = [
+            {'word': 'a', 'start': 0, 'end': 0},
+            {'word': 'b', 'start': 1, 'end': 1},
+        ]
+        out = f('querytext', matches)
+        assert len(out) == 1 and out[0]['word'] == 'a'
+        assert terminal.call_count == 2
+
+    @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
+    def test_inference_failure_drops_match_after_retries(self):
+        model, terminal = _mock_bert_module_chain(ValueError('bad'), ValueError('bad'))
+        f = _BERTFilter(model=model, max_retries=2)
+        matches = [{'word': 'x', 'start': 0, 'end': 0}]
+        with patch('lazyllm.tools.rag.query_enh_ac.LOG'):
+            out = f('qq', matches)
+        assert out == []
+        assert terminal.call_count == 2
+
+

--- a/tests/advanced_tests/Tools/test_vocab.py
+++ b/tests/advanced_tests/Tools/test_vocab.py
@@ -111,7 +111,8 @@ class TestQueryEnhACProcessor(object):
         model, _ = _mock_llm_discriminator([True])
         proc = QueryEnhACProcessor(data_source=ds, discriminator=model)
         out = proc(f'使用{token}测试')
-        assert token in out
+        # Only one word in the cluster (no synonyms yet) → original query unchanged.
+        assert out == f'使用{token}测试'
         rows.append({'cluster_id': 'k', 'word': 'callable_alias'})
         proc.update_data_source(ds)
         out2 = proc(f'使用{token}测试')
@@ -217,7 +218,9 @@ def _mock_bert_module_chain(*call_returns):
         only = call_returns[0]
         if isinstance(only, list):
             terminal.side_effect = only
-        elif isinstance(only, BaseException):
+        elif isinstance(only, BaseException) or (
+            isinstance(only, type) and issubclass(only, BaseException)
+        ):
             terminal.side_effect = only
         else:
             terminal.return_value = only
@@ -249,6 +252,9 @@ class TestBERTFilter(object):
         out = f('querytext', matches)
         assert len(out) == 1 and out[0]['word'] == 'a'
         assert terminal.call_count == 2
+        # Verify ``text_b`` keyword argument is forwarded to the underlying module.
+        for call in terminal.call_args_list:
+            assert 'text_b' in call.kwargs, f'text_b missing from BERT call kwargs: {call}'
 
     @pytest.mark.run_on_change('lazyllm/tools/rag/query_enh_ac.py')
     def test_inference_failure_drops_match_after_retries(self):


### PR DESCRIPTION
## PR 内容 / PR Description

### 问题背景 / Problem Context

在 RAG 或检索场景下，需要基于词表对查询做**同义词/多词形扩展**，同时避免 AC 命中落在**更长词内部**的子串（边界误判）。此前缺少与 LazyLLM 部署体系一致的 **BERT 序列分类**判别路径；本 PR 提供 **`BertDeploy`**（RelayServer 上的序列分类服务）与 **`QueryEnhACProcessor`**（AC 自动机 + LLM 或 BERT 边界过滤），并与现有 `TrainableModule` / `OnlineChatModule` 用法对齐。

### 变更类型 / Type of Change

- [ ] Bug fix  
- [x] New feature  
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation  
- [ ] Performance optimization  

### 如何测试 / How Has This Been Tested?

- 单元 / 高级测试（按你本地环境调整路径）：
  - `pytest LazyLLM/tests/advanced_tests/Tools/test_vocab.py -v`

### Demo (Optional)
<img width="566" height="241" alt="企业微信截图_17756321732191" src="https://github.com/user-attachments/assets/81d6c3ae-8c35-468d-bdb6-56e655e371fc" />

<img width="573" height="225" alt="企业微信截图_17756324771877" src="https://github.com/user-attachments/assets/6660cdbd-7839-413c-9980-31fb162fedcc" />


### 更新后的用法示例 / Usage After Update

**1. BERT 序列分类部署（`BertDeploy`）**

```python
import lazyllm

m = lazyllm.TrainableModule('your-seq-cls-model', use_model_map=False).deploy_method(
    lazyllm.deploy.BertDeploy, port=36001, max_length=128,
).start()
# 推理：首参 -> text_a，上下文用 text_b=
out = m('候选词', text_b='...上下文片段...')
```

**2. AC 查询增强（`QueryEnhACProcessor`）**

```python
from lazyllm.tools.rag import QueryEnhACProcessor

# data_source: 可调用返回 list[dict] 或列表；需含 cluster_id / word（字段名可配）
# discriminator: OnlineChatModule / LLM 用 TrainableModule，或已 BertDeploy 的 TrainableModule
proc = QueryEnhACProcessor(data_source=my_vocab, discriminator=model)
enhanced = proc("用户查询")           # str 或 List[str]
matches = proc.get_matches("查询")    # 边界过滤后的匹配信息

proc.update_data_source(new_vocab)
proc.update_discriminator(new_model)
```

### AI 参与情况 / AI Involvement

- [ ] 未使用 AI  
- [ ] 使用 AI 辅助（局部代码）  
- [x] 使用 AI 主导（大部分代码）  

**使用工具 / Tools Used：** Cursor（及其他请自填）

### AI 生成过程 / AI Generation Process

**初始 Prompt：** （可简述：BERT 部署 + AC 查询增强 + 与 ac-jieba 语义对齐等）

**AI 初始输出质量：** 部分正确

**问题点：** 例如 mock 链、`share()` 返回值、文档键名与 `lazyllm.tools.rag` 路径等需人工核对。

**人工干预：** 逻辑与边界行为、测试与 lint、PR 描述与命名统一。

**最终策略：** 以 `RelayServer` 部署 BERT；`QueryEnhACProcessor` 内按判别器类型分支 LLM / BERT；对外暴露 `get_matches` 与文档注册键 `rag.QueryEnhACProcessor`。

### AI vs 人工贡献占比（自填）

- AI 生成代码占比：`95%`  
- 人工修改占比：`5%`  

**主要人工修改点：** 逻辑与边界、测试、代码风格与 review 反馈。

### AI 问题记录 / AI Failure Cases

（可选：记录易错点，如过滤器 mock、文档 `add_doc` 路径等）

### 可复用经验 / Reusable Patterns

- Deploy 类文档集中在 `docs/components.py`；RAG 工具在 `docs/tools/tool_rag.py`，`module=lazyllm.tools` 时键为 `rag.*`。  
- BERT 与 `TrainableModule` 传参需注意 **`text_a` / `text_b`** 的映射方式，避免整包 JSON 被误赋到 `text_a`。
