### PR TITLE
ci venv setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - cyb/ci-fix
     tags:
       - "v*.*.*a*"
       - "v*.*.*b*"
@@ -24,7 +25,6 @@ env:
   CI_PATH: '/home/mnt/platform_ci/GitHub/${{ github.repository }}/${{ github.run_number }}'
   PYTHON_VERSION: "3.10.9"
   LAZYLLM_DEFAULT_RECENT_K: 20
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{
     github.event_name == 'pull_request_target' && github.event.pull_request.title || github.ref }}
@@ -92,7 +92,7 @@ jobs:
     if: github.ref_type != 'tag'
     needs: [lint, doc_check]
     runs-on: tps_sco_nv
-    environment: protected
+    # environment: protected
     steps:
       - run: echo "run on branch"
 
@@ -137,6 +137,18 @@ jobs:
         run: |
           git fetch origin ${{ github.event.pull_request.base.ref }} --depth=1
 
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
+
       - name: Build doc
         run: |
           set -e
@@ -152,6 +164,7 @@ jobs:
           rm -rf ${{ env.CI_PATH }}/* ${{ env.CI_PATH }}/.[!.]*
           mv $GITHUB_WORKSPACE/* $GITHUB_WORKSPACE/.[!.]* ${{ env.CI_PATH }}/
           cd ${{ env.CI_PATH }}
+          
           pip install -r tests/requirements.txt
           pip install -r tests/requirements_linux.txt
 
@@ -165,8 +178,22 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
+
       - name: Install package in editable mode
-        run: pip install -e .
+        run: |
+          set -e
+          pip install -e .
 
       - name: RunTests
         uses: ./.github/actions/run_tests
@@ -204,6 +231,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
 
       - name: RunTests
         uses: ./.github/actions/run_tests
@@ -243,6 +282,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
+
       - name: RunTests
         uses: ./.github/actions/run_tests
         with:
@@ -277,6 +328,18 @@ jobs:
         uses: actions/checkout@v4 # For run_tests afterwards.
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
 
       - name: Load cache
         uses: ./.github/actions/load_cache
@@ -344,6 +407,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Python venv
+        run: |
+          VENV_DIR="/home/mnt/platform_ci/GitHub/.venv/${{ runner.name }}"
+          if [ ! -f "$VENV_DIR/bin/python" ]; then
+            mkdir -p "$VENV_DIR"
+            python -m venv --system-site-packages "$VENV_DIR"
+          fi
+          source "$VENV_DIR/bin/activate"
+          echo "$VENV_DIR/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VENV_DIR" >> $GITHUB_ENV
+          echo "VENV_DIR=$VENV_DIR" >> $GITHUB_ENV
 
       - name: Install data tests dependencies
         run: |
@@ -439,6 +514,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -e
+
           pip install -r requirements.txt
           pip install -r docs/requirements.txt
           cp -r docs/assets docs/zh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - cyb/ci-fix
     tags:
       - "v*.*.*a*"
       - "v*.*.*b*"
@@ -92,7 +91,7 @@ jobs:
     if: github.ref_type != 'tag'
     needs: [lint, doc_check]
     runs-on: tps_sco_nv
-    # environment: protected
+    environment: protected
     steps:
       - run: echo "run on branch"
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description
- 为所有 `tps_sco_nv` runner 上的 CI 任务添加独立的 Python venv，实现 pip 包的跨 CI 运行缓存，避免多 runner 间的环境污染。
---
# 🎯 问题背景 / Problem Context
- 自托管 runner (`tps_sco_nv`) 有多个实例（如 `actions-runner-3`、`actions-runner-4`）共享文件系统。之前在一个 runner 上执行 `pip install -e .` 的 editable 安装路径会被其他 runner 读到，导致模块加载时 `FileNotFoundError`（例如 runner-3 运行脚本却从 runner-4 的工作区路径加载 `lazyllm/__init__.py`）。
- 同时 pip 安装到全局用户目录（`~/.local/`），没有隔离，不同 CI 运行之间的依赖可能相互冲突。
# 🔍 相关 Issue / Related Issue
* 无
---
# ✅ 变更类型 / Type of Change
* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization
---
# 🧪 如何测试 / How Has This Been Tested?
1. 在 `cyb/ci-fix` 分支上经过多轮 CI 验证
2. 确认 venv 创建、激活、pip 安装均在 venv 内部执行
3. 确认各 runner 的 venv 路径独立（通过 `${{ runner.name }}` 隔离）
---
# ⚠️ 注意事项 / Additional Notes
* venv 路径为 `/home/mnt/platform_ci/GitHub/.venv/<runner_name>`，持久化在磁盘上跨 CI 运行复用
* 使用 `--system-site-packages` 继承 runner 上已有的 conda 基础环境，避免重复安装大量依赖
* 仅影响 `tps_sco_nv` 上的 6 个任务（clone、basic_tests、advanced_tests、engine_tests、charge_tests、data_op_ppl_tests），不影响 ubuntu-latest / macos-latest / windows-latest 任务
* `wait_approve` 和 `skip_approve` 只执行 echo，无需 venv
