### PR TITLE
add fs for skills

### DIFF
--- a/lazyllm/__init__.py
+++ b/lazyllm/__init__.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
                         LLMParser)
 from .patch import patch_os_env
 from .docs import add_doc
+from .tools.fs.client import FS, dynamic_fs_config  # noqa F401
 config.done()
 
 patch_os_env(lambda key, value: refresh_config(key), refresh_config)

--- a/lazyllm/__init__.py
+++ b/lazyllm/__init__.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
                         LLMParser)
 from .patch import patch_os_env
 from .docs import add_doc
-from .tools.fs.client import FS, dynamic_fs_config  # noqa F401
 config.done()
 
 patch_os_env(lambda key, value: refresh_config(key), refresh_config)
@@ -100,6 +99,8 @@ __all__ = [
     'set_trace_context',
 
     # tools
+    'FS',
+    'dynamic_fs_config',
     'Document',
     'Retriever',
     'Reranker',

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -1,6 +1,5 @@
 from importlib import import_module
 from typing import TYPE_CHECKING
-from .fs.client import FS, dynamic_fs_config
 if TYPE_CHECKING:
     # flake8: noqa: E401
     from .rag import (Document, GraphDocument, UrlGraphDocument, Reranker, Retriever, TempDocRetriever,

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
         ReWOOAgent,
         ModuleTool,
         SkillManager,
+        install_skill,
     )
     from .sandbox import LazyLLMSandboxBase, DummySandbox, SandboxFusion
     from .classifier import IntentClassifier
@@ -78,6 +79,7 @@ _SUBMOD_MAP = {
         'PlanAndSolveAgent',
         'ReWOOAgent',
         'SkillManager',
+        'install_skill',
     ],
     'sandbox': [
         'LazyLLMSandboxBase',

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -1,11 +1,12 @@
 from importlib import import_module
 from typing import TYPE_CHECKING
+from .fs.client import FS, dynamic_fs_config
 if TYPE_CHECKING:
     # flake8: noqa: E401
     from .rag import (Document, GraphDocument, UrlGraphDocument, Reranker, Retriever, TempDocRetriever,
                     GraphRetriever, SentenceSplitter, LLMParser, DocServer)
     from .webpages import WebModule
-    from .fs import (LazyLLMFSBase, CloudFSBufferedFile, CloudFS, CloudFsWatchdog,
+    from .fs import (LazyLLMFSBase, CloudFSBufferedFile, CloudFsWatchdog, FS, dynamic_fs_config,
                      FeishuFS, ConfluenceFS, NotionFS, GoogleDriveFS, OneDriveFS, YuqueFS, OnesFS, S3FS,
                      ObsidianFS)
     from .agent import (
@@ -136,8 +137,9 @@ _SUBMOD_MAP = {
     'fs': [
         'LazyLLMFSBase',
         'CloudFSBufferedFile',
-        'CloudFS',
         'CloudFsWatchdog',
+        'FS',
+        'dynamic_fs_config',
         'FeishuFS',
         'ConfluenceFS',
         'NotionFS',

--- a/lazyllm/tools/agent/__init__.py
+++ b/lazyllm/tools/agent/__init__.py
@@ -7,6 +7,7 @@ from .rewooAgent import ReWOOAgent
 from .toolsManager import ModuleTool
 from .code_interpreter import code_interpreter
 from .skill_manager import SkillManager
+from .skill_hub import install_skill
 
 __all__ = [
     'ToolManager',
@@ -20,4 +21,5 @@ __all__ = [
     'ModuleTool',
     'code_interpreter',
     'SkillManager',
+    'install_skill',
 ]

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -1,5 +1,5 @@
 import os
-from typing import Iterable, Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 import lazyllm
 from lazyllm.module import ModuleBase
@@ -25,9 +25,16 @@ class LazyLLMAgentBase(ModuleBase):
                  stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Optional[Union[bool, str, Iterable[str]]] = None, memory=None,
                  desc: str = '', workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None, skills_dir: Optional[str] = None):
+                 fs: Optional[Any] = None, skills_dir: Optional[str] = None):
         super().__init__(return_trace=return_trace)
         use_skills, skills = self._normalize_skills_config(skills)
+        if not use_skills and (fs is not None or skills_dir is not None):
+            import warnings
+            warnings.warn(
+                'fs and skills_dir are ignored because skills is not enabled. '
+                'Pass skills=True (or a list of skill names) to enable skill loading.',
+                UserWarning, stacklevel=2,
+            )
         self._llm = llm
         self._tools = list(tools) if tools else []
         self._memory = memory

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -24,7 +24,8 @@ class LazyLLMAgentBase(ModuleBase):
     def __init__(self, llm=None, tools=None, max_retries: int = 5, return_trace: bool = False,
                  stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Optional[Union[bool, str, Iterable[str]]] = None, memory=None,
-                 desc: str = '', workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None):
+                 desc: str = '', workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
+                 fs=None):
         super().__init__(return_trace=return_trace)
         use_skills, skills = self._normalize_skills_config(skills)
         self._llm = llm
@@ -39,9 +40,10 @@ class LazyLLMAgentBase(ModuleBase):
         self._agent = None
         self._skill_manager = None
         self._sandbox = sandbox or create_sandbox()
+        self._fs = fs
 
         if use_skills:
-            self._skill_manager = SkillManager(skills=self._skills)
+            self._skill_manager = SkillManager(skills=self._skills, fs=fs)
             self._ensure_default_skill_tools()
         self._tools_manager = ToolManager(self._tools, return_trace=return_trace, sandbox=self._sandbox)
 

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -40,7 +40,6 @@ class LazyLLMAgentBase(ModuleBase):
         self._agent = None
         self._skill_manager = None
         self._sandbox = sandbox or create_sandbox()
-        self._fs = fs
 
         if use_skills:
             self._skill_manager = SkillManager(skills=self._skills, fs=fs)

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -25,7 +25,7 @@ class LazyLLMAgentBase(ModuleBase):
                  stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Optional[Union[bool, str, Iterable[str]]] = None, memory=None,
                  desc: str = '', workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None):
+                 fs=None, skills_dir: Optional[str] = None):
         super().__init__(return_trace=return_trace)
         use_skills, skills = self._normalize_skills_config(skills)
         self._llm = llm
@@ -42,7 +42,7 @@ class LazyLLMAgentBase(ModuleBase):
         self._sandbox = sandbox or create_sandbox()
 
         if use_skills:
-            self._skill_manager = SkillManager(skills=self._skills, fs=fs)
+            self._skill_manager = SkillManager(dir=skills_dir, skills=self._skills, fs=fs)
             self._ensure_default_skill_tools()
         self._tools_manager = ToolManager(self._tools, return_trace=return_trace, sandbox=self._sandbox)
 

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -196,11 +196,11 @@ class FunctionCallAgent(LazyLLMAgentBase):
     def __init__(self, llm, tools: List[str], max_retries: int = 5, return_trace: bool = False, stream: bool = False,
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
-                 workspace: Optional[str] = None, fs=None):
+                 workspace: Optional[str] = None, fs=None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,
-                         skills=skills, desc=desc, workspace=workspace, fs=fs)
+                         skills=skills, desc=desc, workspace=workspace, fs=fs, skills_dir=skills_dir)
         assert self._llm is not None, 'llm cannot be empty.'
         self._assert_tools()
         prompt = FC_PROMPT

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -196,7 +196,8 @@ class FunctionCallAgent(LazyLLMAgentBase):
     def __init__(self, llm, tools: List[str], max_retries: int = 5, return_trace: bool = False, stream: bool = False,
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
-                 workspace: Optional[str] = None, fs=None, skills_dir: Optional[str] = None):
+                 workspace: Optional[str] = None, fs: Optional[Any] = None,
+                 skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -196,11 +196,11 @@ class FunctionCallAgent(LazyLLMAgentBase):
     def __init__(self, llm, tools: List[str], max_retries: int = 5, return_trace: bool = False, stream: bool = False,
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
-                 workspace: Optional[str] = None):
+                 workspace: Optional[str] = None, fs=None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,
-                         skills=skills, desc=desc, workspace=workspace)
+                         skills=skills, desc=desc, workspace=workspace, fs=fs)
         assert self._llm is not None, 'llm cannot be empty.'
         self._assert_tools()
         prompt = FC_PROMPT

--- a/lazyllm/tools/agent/planAndSolveAgent.py
+++ b/lazyllm/tools/agent/planAndSolveAgent.py
@@ -42,12 +42,13 @@ class PlanAndSolveAgent(LazyLLMAgentBase):
                  max_retries: int = 5, return_trace: bool = False, stream: bool = False,
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
-                 workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None):
+                 workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
+                 fs=None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,
                          skills=skills, desc=desc, workspace=workspace,
-                         sandbox=sandbox)
+                         sandbox=sandbox, fs=fs)
         self._assert_tools()
         plan_llm, solve_llm = self._normalize_llms(llm, plan_llm, solve_llm)
         self._init_planner_prompter()

--- a/lazyllm/tools/agent/planAndSolveAgent.py
+++ b/lazyllm/tools/agent/planAndSolveAgent.py
@@ -4,7 +4,7 @@ from .base import LazyLLMAgentBase
 from lazyllm.components import ChatPrompter
 from lazyllm import loop, pipeline, _0, package, bind, LOG, Color, once_wrapper
 from .functionCall import FunctionCall, FC_PROMPT
-from typing import List, Optional, Union
+from typing import List, Any, Optional, Union
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase
 
 PLANNER_PROMPT = (
@@ -43,7 +43,7 @@ class PlanAndSolveAgent(LazyLLMAgentBase):
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None, skills_dir: Optional[str] = None):
+                 fs: Optional[Any] = None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,

--- a/lazyllm/tools/agent/planAndSolveAgent.py
+++ b/lazyllm/tools/agent/planAndSolveAgent.py
@@ -43,12 +43,12 @@ class PlanAndSolveAgent(LazyLLMAgentBase):
                  return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None):
+                 fs=None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries,
                          return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls,
                          skills=skills, desc=desc, workspace=workspace,
-                         sandbox=sandbox, fs=fs)
+                         sandbox=sandbox, fs=fs, skills_dir=skills_dir)
         self._assert_tools()
         plan_llm, solve_llm = self._normalize_llms(llm, plan_llm, solve_llm)
         self._init_planner_prompter()

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -75,10 +75,10 @@ class ReactAgent(LazyLLMAgentBase):
                  skills: Optional[Union[bool, str, List[str]]] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  force_summarize: bool = False, force_summarize_context: str = '',
-                 keep_full_turns: int = 0):
+                 keep_full_turns: int = 0, fs=None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries, return_trace=return_trace,
                          stream=stream, return_last_tool_calls=return_last_tool_calls, skills=skills,
-                         desc=desc, workspace=workspace, sandbox=sandbox)
+                         desc=desc, workspace=workspace, sandbox=sandbox, fs=fs)
         prompt = prompt or INSTRUCTION
         if self._return_last_tool_calls:
             prompt += '\nIf no more tool calls are needed, reply with ok and skip any summary.'

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -75,7 +75,7 @@ class ReactAgent(LazyLLMAgentBase):
                  skills: Optional[Union[bool, str, List[str]]] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  force_summarize: bool = False, force_summarize_context: str = '',
-                 keep_full_turns: int = 0, fs=None, skills_dir: Optional[str] = None):
+                 keep_full_turns: int = 0, fs: Optional[Any] = None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries, return_trace=return_trace,
                          stream=stream, return_last_tool_calls=return_last_tool_calls, skills=skills,
                          desc=desc, workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir)

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -75,10 +75,10 @@ class ReactAgent(LazyLLMAgentBase):
                  skills: Optional[Union[bool, str, List[str]]] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  force_summarize: bool = False, force_summarize_context: str = '',
-                 keep_full_turns: int = 0, fs=None):
+                 keep_full_turns: int = 0, fs=None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries, return_trace=return_trace,
                          stream=stream, return_last_tool_calls=return_last_tool_calls, skills=skills,
-                         desc=desc, workspace=workspace, sandbox=sandbox, fs=fs)
+                         desc=desc, workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir)
         prompt = prompt or INSTRUCTION
         if self._return_last_tool_calls:
             prompt += '\nIf no more tool calls are needed, reply with ok and skip any summary.'

--- a/lazyllm/tools/agent/rewooAgent.py
+++ b/lazyllm/tools/agent/rewooAgent.py
@@ -41,10 +41,10 @@ class ReWOOAgent(LazyLLMAgentBase):
                  return_trace: bool = False, stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None):
+                 fs=None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls, skills=skills, desc=desc,
-                         workspace=workspace, sandbox=sandbox, fs=fs)
+                         workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir)
         if llm is None and plan_llm is None and solve_llm is None:
             raise ValueError('Either specify llm, or provide plan_llm/solve_llm.')
         if llm is None:

--- a/lazyllm/tools/agent/rewooAgent.py
+++ b/lazyllm/tools/agent/rewooAgent.py
@@ -40,10 +40,11 @@ class ReWOOAgent(LazyLLMAgentBase):
                  plan_llm: Union[ModuleBase, None] = None, solve_llm: Union[ModuleBase, None] = None,
                  return_trace: bool = False, stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
-                 workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None):
+                 workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
+                 fs=None):
         super().__init__(llm=llm, tools=tools, return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls, skills=skills, desc=desc,
-                         workspace=workspace, sandbox=sandbox)
+                         workspace=workspace, sandbox=sandbox, fs=fs)
         if llm is None and plan_llm is None and solve_llm is None:
             raise ValueError('Either specify llm, or provide plan_llm/solve_llm.')
         if llm is None:

--- a/lazyllm/tools/agent/rewooAgent.py
+++ b/lazyllm/tools/agent/rewooAgent.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Any, Optional, Union
 import re
 import json
 
@@ -41,7 +41,7 @@ class ReWOOAgent(LazyLLMAgentBase):
                  return_trace: bool = False, stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Union[bool, str, List[str], None] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,
-                 fs=None, skills_dir: Optional[str] = None):
+                 fs: Optional[Any] = None, skills_dir: Optional[str] = None):
         super().__init__(llm=llm, tools=tools, return_trace=return_trace, stream=stream,
                          return_last_tool_calls=return_last_tool_calls, skills=skills, desc=desc,
                          workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir)

--- a/lazyllm/tools/agent/skill_hub.py
+++ b/lazyllm/tools/agent/skill_hub.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import os
+import re
+from typing import Optional
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
+import json
+
+from lazyllm import config, LOG
+
+_AGENTSKILLHUB_API = 'https://agentskillhub.dev/api/v1'
+_GITHUB_RAW = 'https://raw.githubusercontent.com'
+_GITHUB_API = 'https://api.github.com'
+
+# source format examples:
+#   agentskillhub:username/skill-slug
+#   github:owner/repo/path/to/skill          (SKILL.md lives at path/to/skill/SKILL.md)
+#   github:owner/repo                         (SKILL.md lives at repo root)
+#   https://...                               (direct URL to SKILL.md or a zip)
+_SOURCE_RE = re.compile(
+    r'^(?P<scheme>[a-zA-Z][a-zA-Z0-9+\-.]*):'
+    r'(?P<rest>.+)$'
+)
+
+
+def _http_get(url: str, token: Optional[str] = None) -> bytes:
+    headers = {'User-Agent': 'lazyllm-skill-installer/1.0'}
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+    req = Request(url, headers=headers)
+    try:
+        with urlopen(req, timeout=30) as resp:
+            return resp.read()
+    except HTTPError as e:
+        raise RuntimeError(f'HTTP {e.code} fetching {url}: {e.reason}') from e
+    except URLError as e:
+        raise RuntimeError(f'Network error fetching {url}: {e.reason}') from e
+
+
+def _write_file(dest_dir: str, rel_path: str, content: bytes) -> None:
+    full = os.path.join(dest_dir, rel_path)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, 'wb') as f:
+        f.write(content)
+
+
+# --- agentskillhub.dev ---
+
+def _install_from_agentskillhub(slug: str, dest_dir: str, token: Optional[str] = None) -> str:
+    parts = slug.strip('/').split('/', 1)
+    if len(parts) != 2:
+        raise ValueError(f'agentskillhub source must be "username/skill-slug", got: {slug!r}')
+    username, skill_slug = parts
+    url = f'{_AGENTSKILLHUB_API}/u/{username}/skills/{skill_slug}'
+    LOG.info(f'Fetching skill metadata from {url}')
+    data = json.loads(_http_get(url, token=token))
+
+    skill_name = data['skill'].get('slug', skill_slug)
+    skill_dir = os.path.join(dest_dir, skill_name)
+    os.makedirs(skill_dir, exist_ok=True)
+
+    latest = data.get('latestVersion', {})
+    skill_md_raw = latest.get('skillMdRaw')
+    file_manifest = latest.get('fileManifest', [])
+
+    # Write SKILL.md from inline content (saves one request)
+    if skill_md_raw:
+        _write_file(skill_dir, 'SKILL.md', skill_md_raw.encode('utf-8'))
+
+    # Fetch remaining files via GitHub blob API using gitBlobSha
+    source_identifier = data['skill'].get('sourceIdentifier', '')  # e.g. "owner/repo"
+    skill_path = data['skill'].get('skillPath', '')                 # e.g. "skills/webapp-testing"
+    default_branch = data['skill'].get('defaultBranch', 'main')
+
+    for entry in file_manifest:
+        rel = entry['path']
+        if rel == 'SKILL.md' and skill_md_raw:
+            continue  # already written
+        blob_sha = entry.get('gitBlobSha')
+        if blob_sha and source_identifier:
+            owner_repo = source_identifier
+            blob_url = f'{_GITHUB_API}/repos/{owner_repo}/git/blobs/{blob_sha}'
+            LOG.info(f'Fetching {rel} via blob {blob_sha[:8]}')
+            blob_data = json.loads(_http_get(blob_url, token=token))
+            import base64
+            content = base64.b64decode(blob_data['content'])
+        else:
+            # Fallback: raw URL from GitHub
+            if not source_identifier:
+                LOG.warning(f'Cannot fetch {rel}: no sourceIdentifier in skill metadata')
+                continue
+            raw_url = f'{_GITHUB_RAW}/{source_identifier}/{default_branch}/{skill_path}/{rel}'
+            LOG.info(f'Fetching {rel} from {raw_url}')
+            content = _http_get(raw_url, token=token)
+        _write_file(skill_dir, rel, content)
+
+    LOG.info(f'Skill {skill_name!r} installed to {skill_dir}')
+    return skill_dir
+
+
+# --- GitHub ---
+
+def _install_from_github(spec: str, dest_dir: str, token: Optional[str] = None,
+                          branch: Optional[str] = None) -> str:
+    # spec: owner/repo  or  owner/repo/path/to/skill
+    parts = spec.strip('/').split('/', 2)
+    if len(parts) < 2:
+        raise ValueError(f'github source must be "owner/repo[/path]", got: {spec!r}')
+    owner, repo = parts[0], parts[1]
+    skill_path = parts[2].strip('/') if len(parts) == 3 else ''
+
+    # Resolve default branch if not given
+    if not branch:
+        repo_url = f'{_GITHUB_API}/repos/{owner}/{repo}'
+        repo_info = json.loads(_http_get(repo_url, token=token))
+        branch = repo_info.get('default_branch', 'main')
+
+    # Use GitHub Trees API to list all files under skill_path
+    tree_url = f'{_GITHUB_API}/repos/{owner}/{repo}/git/trees/{branch}?recursive=1'
+    LOG.info(f'Fetching file tree from {tree_url}')
+    tree_data = json.loads(_http_get(tree_url, token=token))
+
+    prefix = skill_path + '/' if skill_path else ''
+    blobs = [
+        item for item in tree_data.get('tree', [])
+        if item['type'] == 'blob' and item['path'].startswith(prefix)
+    ]
+
+    if not blobs:
+        raise RuntimeError(
+            f'No files found under {spec!r} (branch={branch}). '
+            f'Check that the path contains a SKILL.md.'
+        )
+
+    # Derive skill name from the last component of skill_path, or repo name
+    skill_name = skill_path.rsplit('/', 1)[-1] if skill_path else repo
+    skill_dir = os.path.join(dest_dir, skill_name)
+    os.makedirs(skill_dir, exist_ok=True)
+
+    import base64
+    for item in blobs:
+        rel = item['path'][len(prefix):]  # strip the skill_path prefix
+        blob_url = f'{_GITHUB_API}/repos/{owner}/{repo}/git/blobs/{item["sha"]}'
+        LOG.info(f'Fetching {rel}')
+        blob_data = json.loads(_http_get(blob_url, token=token))
+        content = base64.b64decode(blob_data['content'])
+        _write_file(skill_dir, rel, content)
+
+    if not os.path.exists(os.path.join(skill_dir, 'SKILL.md')):
+        raise RuntimeError(
+            f'Installed files from {spec!r} but no SKILL.md found. '
+            f'Make sure the path points to a skill directory.'
+        )
+
+    LOG.info(f'Skill {skill_name!r} installed to {skill_dir}')
+    return skill_dir
+
+
+# --- public API ---
+
+def install_skill(source: str, dest_dir: Optional[str] = None,
+                  token: Optional[str] = None, branch: Optional[str] = None) -> str:
+    dest_dir = dest_dir or config['skills_dir'].split(',')[0].strip()
+    os.makedirs(dest_dir, exist_ok=True)
+
+    m = _SOURCE_RE.match(source)
+    if not m:
+        raise ValueError(
+            f'Cannot parse skill source: {source!r}. '
+            f'Expected formats: "agentskillhub:user/slug", "github:owner/repo[/path]", '
+            f'or a full URL.'
+        )
+    scheme = m.group('scheme').lower()
+    rest = m.group('rest')
+
+    if scheme == 'agentskillhub':
+        return _install_from_agentskillhub(rest, dest_dir, token=token)
+    elif scheme == 'github':
+        return _install_from_github(rest, dest_dir, token=token, branch=branch)
+    elif scheme in ('http', 'https'):
+        # Direct URL: treat as raw SKILL.md or a zip (zip not yet supported)
+        raise NotImplementedError(
+            'Direct URL install is not yet supported. '
+            'Use "github:owner/repo/path" or "agentskillhub:user/slug" instead.'
+        )
+    else:
+        raise ValueError(
+            f'Unknown skill source scheme: {scheme!r}. '
+            f'Supported: agentskillhub, github.'
+        )

--- a/lazyllm/tools/agent/skill_hub.py
+++ b/lazyllm/tools/agent/skill_hub.py
@@ -101,7 +101,7 @@ def _install_from_agentskillhub(slug: str, dest_dir: str, token: Optional[str] =
 # --- GitHub ---
 
 def _install_from_github(spec: str, dest_dir: str, token: Optional[str] = None,
-                          branch: Optional[str] = None) -> str:
+                         branch: Optional[str] = None) -> str:
     # spec: owner/repo  or  owner/repo/path/to/skill
     parts = spec.strip('/').split('/', 2)
     if len(parts) < 2:

--- a/lazyllm/tools/agent/skill_hub.py
+++ b/lazyllm/tools/agent/skill_hub.py
@@ -38,7 +38,11 @@ def _http_get(url: str, token: Optional[str] = None) -> bytes:
 
 
 def _write_file(dest_dir: str, rel_path: str, content: bytes) -> None:
-    full = os.path.join(dest_dir, rel_path)
+    # Guard against path traversal (e.g. rel_path = "../../evil")
+    dest_dir = os.path.realpath(dest_dir)
+    full = os.path.realpath(os.path.join(dest_dir, rel_path))
+    if not full.startswith(dest_dir + os.sep) and full != dest_dir:
+        raise ValueError(f'Path traversal detected: {rel_path!r} escapes dest_dir {dest_dir!r}')
     os.makedirs(os.path.dirname(full), exist_ok=True)
     with open(full, 'wb') as f:
         f.write(content)

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -181,14 +181,15 @@ class SkillManager(ModuleBase):
                 for entry in entries:
                     name = entry.get('name', '')
                     basename = name.rsplit('/', 1)[-1]
+                    full_path = name if '/' in name else self._fs_join(cur, basename)
                     etype = entry.get('type', 'file')
                     if etype not in ('directory', 'dir'):
                         # Local: match 'SKILL.md'; cloud: match any name starting with CLOUD_SKILL_PREFIX
                         if (self._is_local and basename == 'SKILL.md') or \
                                 (not self._is_local and basename.startswith(CLOUD_SKILL_PREFIX)):
-                            skill_node = name
+                            skill_node = full_path
                     elif etype in ('directory', 'dir'):
-                        subdirs.append(name)
+                        subdirs.append(full_path)
                 if skill_node:
                     yield cur, skill_node
                 else:

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -1,10 +1,11 @@
 import os
+import re
 import shlex
 from typing import Dict, Iterable, List, Optional, Tuple
 
 import yaml
 
-from lazyllm import config, ModuleBase
+from lazyllm import config, ModuleBase, thirdparty
 from .file_tool import read_file as _read_file
 from .shell_tool import shell_tool as _shell_tool
 
@@ -18,15 +19,19 @@ config.add(
     description='The maximum size of SKILL.md that can be loaded by default'
 )
 
+# Filename convention for cloud FS skills (no extension).
+# A node/file whose name starts with this prefix is treated as a skill definition.
+CLOUD_SKILL_PREFIX = 'SKILL'
+
 SKILLS_PROMPT = '''
 ## Skills Guide
 You have access to a skills library that encodes specialized workflows and domain knowledge.
 
 ### How to Use Skills (Progressive Disclosure)
-You can see the name/description above, but only fetch a skill’s full instructions when it’s relevant.
+You can see the name/description above, but only fetch a skill's full instructions when it's relevant.
 
-1) **Identify relevance**: If a skill’s description matches the task, consider using it.
-2) **Get the skill’s full usage**: Call `get_skill` to retrieve the complete workflow.
+1) **Identify relevance**: If a skill's description matches the task, consider using it.
+2) **Get the skill's full usage**: Call `get_skill` to retrieve the complete workflow.
 3) **Follow the workflow strictly**: After you obtain the full usage,
 execute the workflow steps, constraints, and examples in order.
 4) **Adapt workflow to the current task**: Before execution, map the workflow
@@ -54,9 +59,9 @@ Skills may include Python or shell scripts. Prefer `run_script` for scripts prov
 Use `shell_tool` only when needed, and always use absolute paths.
 
 ### Example
-User: “Research the latest developments in quantum computing.”
+User: "Research the latest developments in quantum computing."
 
-1) See a “web‑research” skill in the list
+1) See a "web‑research" skill in the list
 2) Call `get_skill` to fetch its full usage
 3) Follow the research workflow (search → organize → synthesize)
 4) Use `read_reference` and `run_script` if the workflow calls for them
@@ -71,30 +76,69 @@ _META_REQUIRED_FIELDS = {
 }
 
 
+def _local_fs():
+    return thirdparty.fsspec.implementations.local.LocalFileSystem()
+
+
 class SkillManager(ModuleBase):
     def __init__(self, dir: Optional[str] = None, skills: Optional[Iterable[str]] = None,
-                 max_skill_md_bytes: Optional[int] = None):
+                 max_skill_md_bytes: Optional[int] = None, fs=None):
         super().__init__(return_trace=False)
-        self._skills_dir = self._parse_dirs(dir) if dir else self._parse_dirs(config['skills_dir'])
+        self._fs = fs or _local_fs()
+        self._is_local = fs is None
+        self._skills_dir = self._parse_dirs(dir) if dir else (
+            self._parse_dirs(config['skills_dir']) if self._is_local else []
+        )
+        self._validate_fs_dir_consistency(fs, self._skills_dir)
         self._skills_expected = self._parse_skills(skills)
         self._max_skill_md_bytes = max_skill_md_bytes or config['max_skill_md_bytes']
         self._skills_index: Dict[str, Dict] = {}
         self._skills_selected: List[str] = []
 
     @staticmethod
+    def _extract_protocol(path: str) -> Optional[str]:
+        m = re.match(r'^([a-zA-Z][a-zA-Z0-9+\-.]*)(@[^:/]+)?:/', path)
+        return m.group(1).lower() if m else None
+
+    @staticmethod
+    def _validate_fs_dir_consistency(fs, dirs: List[str]) -> None:
+        from lazyllm.tools.fs.client import _FSRouter
+        if fs is None or isinstance(fs, _FSRouter):
+            return
+        fs_protocol = getattr(fs, '_fs_protocol_key', None)
+        for path in dirs:
+            path_protocol = SkillManager._extract_protocol(path)
+            if fs_protocol:
+                # Known FS: path without protocol is fine (treated as this FS's protocol);
+                # path with a different protocol is an error.
+                if path_protocol is not None and path_protocol != fs_protocol:
+                    raise ValueError(
+                        f'dir protocol {path_protocol!r} does not match fs protocol {fs_protocol!r}. '
+                        f'Use \'{fs_protocol}:/your/path\' or a bare path, or pass the matching FS instance.'
+                    )
+            else:
+                # Unknown third-party FS: cannot validate a protocol prefix, so reject it.
+                if path_protocol is not None:
+                    raise ValueError(
+                        f'dir {path!r} has a protocol prefix {path_protocol!r}, but the provided fs '
+                        f'{type(fs).__name__!r} has no _fs_protocol_key. '
+                        f'Use a bare path (without protocol prefix) for this FS.'
+                    )
+
+    @staticmethod
     def _parse_dirs(dir_value: Optional[str]) -> List[str]:
         if not dir_value:
             return []
-        if isinstance(dir_value, str):
-            dirs = [d.strip() for d in dir_value.split(',') if d.strip()]
-        else:
-            dirs = list(dir_value)
+        dirs = [d.strip() for d in dir_value.split(',') if d.strip()] if isinstance(dir_value, str) else list(dir_value)
+        seen = set()
         result = []
         for d in dirs:
             if not d:
                 continue
-            path = os.path.abspath(os.path.expanduser(d))
-            if path not in result:
+            # Keep cloud paths (protocol:/ prefix) as-is; expand local paths
+            path = d if re.match(r'^[a-zA-Z][a-zA-Z0-9+\-.]*:/', d) else os.path.abspath(os.path.expanduser(d))
+            if path not in seen:
+                seen.add(path)
                 result.append(path)
         return result
 
@@ -102,42 +146,62 @@ class SkillManager(ModuleBase):
     def _parse_skills(skills: Optional[Iterable[str]]) -> List[str]:
         if skills is None:
             return []
-        if isinstance(skills, str):
-            items = [s.strip() for s in skills.split(',') if s.strip()]
-        else:
-            items = [s for s in skills if s]
-        seen = set()
+        items = [s.strip() for s in skills.split(',') if s.strip()] if isinstance(skills, str) else list(skills)
+        seen: set = set()
         result = []
         for item in items:
-            if item not in seen:
+            if item and item not in seen:
                 seen.add(item)
                 result.append(item)
         return result
 
+    def _fs_read(self, path: str) -> str:
+        with self._fs.open(path, 'r', encoding='utf-8', errors='replace') as f:
+            return f.read()
+
+    def _fs_getsize(self, path: str) -> int:
+        return self._fs.info(path).get('size', 0)
+
+    def _fs_listdir(self, path: str) -> List[Dict]:
+        try:
+            return self._fs.ls(path, detail=True)
+        except Exception:
+            return []
+
+    def _fs_join(self, base: str, name: str) -> str:
+        if self._is_local:
+            return os.path.join(base, name)
+        return base.rstrip('/') + '/' + name
+
     def _iter_skill_files(self) -> Iterable[Tuple[str, str]]:
         for base_dir in self._skills_dir:
-            if not os.path.isdir(base_dir):
-                continue
             stack = [base_dir]
             while stack:
                 cur = stack.pop()
-                try:
-                    entries = sorted(os.listdir(cur))
-                except OSError:
-                    continue
-                skill_md = os.path.join(cur, 'SKILL.md')
-                if 'SKILL.md' in entries and os.path.isfile(skill_md):
-                    yield cur, skill_md
+                entries = self._fs_listdir(cur)
+                skill_node = None
+                subdirs = []
+                for entry in entries:
+                    name = entry.get('name', '')
+                    basename = name.rsplit('/', 1)[-1]
+                    etype = entry.get('type', 'file')
+                    if etype not in ('directory', 'dir'):
+                        # Local: match 'SKILL.md'; cloud: match any name starting with CLOUD_SKILL_PREFIX
+                        if (self._is_local and basename == 'SKILL.md') or \
+                                (not self._is_local and basename.startswith(CLOUD_SKILL_PREFIX)):
+                            skill_node = name
+                    elif etype in ('directory', 'dir'):
+                        subdirs.append(name)
+                if skill_node:
+                    yield cur, skill_node
                 else:
-                    subdirs = [os.path.join(cur, e) for e in entries if os.path.isdir(os.path.join(cur, e))]
                     for subdir in reversed(subdirs):
                         stack.append(subdir)
 
     @staticmethod
     def _extract_yaml_meta(text: str) -> Optional[dict]:
         lines = text.splitlines()
-        start_idx = None
-        end_idx = None
+        start_idx = end_idx = None
         for idx, line in enumerate(lines):
             if line.strip() == '---':
                 if start_idx is None:
@@ -147,9 +211,8 @@ class SkillManager(ModuleBase):
                 break
         if start_idx is None or end_idx is None or end_idx <= start_idx:
             return None
-        yaml_text = '\n'.join(lines[start_idx + 1:end_idx])
         try:
-            meta = yaml.safe_load(yaml_text) or {}
+            meta = yaml.safe_load('\n'.join(lines[start_idx + 1:end_idx])) or {}
         except yaml.YAMLError:
             return None
         return meta if isinstance(meta, dict) else None
@@ -161,18 +224,13 @@ class SkillManager(ModuleBase):
     def _load_skills_index(self) -> None:
         if self._skills_index:
             return
-        seen = set()
+        seen: set = set()
         for skill_dir, skill_md in self._iter_skill_files():
-            try:
-                size = os.path.getsize(skill_md)
-            except OSError:
-                continue
-            if size > self._max_skill_md_bytes:
+            if self._fs_getsize(skill_md) > self._max_skill_md_bytes:
                 continue
             try:
-                with open(skill_md, 'r', encoding='utf-8', errors='replace') as f:
-                    content = f.read()
-            except OSError:
+                content = self._fs_read(skill_md)
+            except Exception:
                 continue
             meta = self._extract_yaml_meta(content)
             if not self._is_meta_valid(meta):
@@ -193,57 +251,33 @@ class SkillManager(ModuleBase):
                 'raw_meta': meta,
             }
         if self._skills_expected:
-            self._skills_selected = [name for name in self._skills_expected if name in self._skills_index]
+            self._skills_selected = [n for n in self._skills_expected if n in self._skills_index]
         else:
             self._skills_selected = [
-                name for name, info in self._skills_index.items()
-                if not info.get('disable-model-invocation')
+                n for n, info in self._skills_index.items() if not info.get('disable-model-invocation')
             ]
 
     def list_skill(self) -> str:
         self._load_skills_index()
-        lines = ['# Skills']
-        if self._skills_dir:
-            lines.append('')
-            lines.append('## Skill Locations')
-            lines.extend([f'- {path}' for path in self._skills_dir])
-        else:
-            lines.append('')
-            lines.append('## Skill Locations')
-            lines.append('- (none)')
-
+        lines = ['# Skills', '', '## Skill Locations']
+        lines.extend([f'- {path}' for path in self._skills_dir] or ['- (none)'])
+        lines += ['', '## Available Skills']
         if not self._skills_index:
-            lines.append('')
-            lines.append('## Available Skills')
             lines.append('- (none)')
             return '\n'.join(lines)
-
-        lines.append('')
-        lines.append('## Available Skills')
         for name, info in self._skills_index.items():
-            desc = info.get('description', '') or ''
-            if len(desc) > 1024:
-                desc = desc[:1024] + '...'
-            path = info.get('path') or ''
-            lines.append(f'- **{name}**')
-            if desc:
-                lines.append(f'  - {desc}')
-            lines.append(f'  - Path: {path}')
+            desc = (info.get('description', '') or '')[:1024]
+            lines += [f'- **{name}**', f'  - {desc}', f'  - Path: {info.get("path")}']
         return '\n'.join(lines)
 
     def build_prompt(self, task: str) -> str:
         self._load_skills_index()
-        selected = self._selector(task)
-        if not selected:
-            selected = list(self._skills_index.keys())
+        selected = self._selector(task) or list(self._skills_index.keys())
         skills_list = self._format_skills_list(selected)
-        skills_locations = self._format_skills_locations()
-        lines = []
-        lines.append('**Skills Directory**')
-        if skills_locations:
-            lines.append(skills_locations)
-        lines.append('**Available Skills**')
-        lines.append(skills_list if skills_list else '- (none)')
+        lines = ['**Skills Directory**']
+        if self._skills_dir:
+            lines.append(self._format_skills_locations())
+        lines += ['**Available Skills**', skills_list or '- (none)']
         return '\n'.join(lines)
 
     def _available_skills_text(self, task: str) -> str:
@@ -274,100 +308,69 @@ class SkillManager(ModuleBase):
             return value
         if isinstance(value, str):
             return value.strip().lower() in ('true', '1', 'yes', 'y', 'on')
-        if value is None:
-            return False
-        return bool(value)
+        return bool(value) if value is not None else False
 
     def _selector(self, task: str) -> List[str]:
         self._load_skills_index()
         if self._skills_expected:
             return list(self._skills_selected)
         candidates = self._skills_selected
-        if not task or not candidates:
-            return candidates
         # TODO: Use BM25-based ranking when rag dependencies are available.
-        return list(candidates)
+        return list(candidates) if task and candidates else list(candidates)
 
     def get_skill(self, name: str, allow_large: bool = False) -> Dict[str, str]:
-        '''Get full skill usage from SKILL.md.
-
-        Args:
-            name (str): Skill name.
-            allow_large (bool, optional): Allow loading large SKILL.md. Defaults to False.
-        '''
         self._load_skills_index()
         info = self._skills_index.get(name)
         if not info:
             return {'status': 'missing', 'name': name}
         skill_md = info['skill_md']
-        size = os.path.getsize(skill_md)
+        size = self._fs_getsize(skill_md)
         if size > self._max_skill_md_bytes and not allow_large:
-            return {
-                'status': 'too_large',
-                'name': name,
-                'path': skill_md,
-                'size': size,
-                'limit': self._max_skill_md_bytes,
-            }
-        with open(skill_md, 'r', encoding='utf-8', errors='replace') as f:
-            return {'status': 'ok', 'name': name, 'path': skill_md, 'content': f.read()}
+            return {'status': 'too_large', 'name': name, 'path': skill_md,
+                    'size': size, 'limit': self._max_skill_md_bytes}
+        try:
+            content = self._fs_read(skill_md)
+        except Exception as e:
+            return {'status': 'error', 'name': name, 'error': str(e)}
+        return {'status': 'ok', 'name': name, 'path': skill_md, 'content': content}
 
     def read_file(self, name: str, rel_path: str, **kwargs) -> Dict[str, str]:
-        '''Read a file inside a skill directory.
-
-        Args:
-            name (str): Skill name.
-            rel_path (str): Relative file path inside the skill directory.
-        '''
         self._load_skills_index()
         info = self._skills_index.get(name)
         if not info:
             return {'status': 'missing', 'name': name}
         base = info['path']
-        path = os.path.join(base, rel_path)
+        path = self._fs_join(base, rel_path)
+        if not self._is_local:
+            try:
+                return {'status': 'ok', 'path': path, 'content': self._fs_read(path)}
+            except Exception as e:
+                return {'status': 'error', 'path': path, 'error': str(e)}
         return _read_file(path, root=base, **kwargs)
 
     def run_script(self, name: str, rel_path: str, args: Optional[List[str]] = None,
                    allow_unsafe: bool = False, cwd: Optional[str] = None) -> Dict[str, str]:
-        '''Run a script inside a skill directory.
-
-        Args:
-            name (str): Skill name.
-            rel_path (str): Relative script path inside the skill directory.
-            args (list[str], optional): Script arguments.
-            allow_unsafe (bool, optional): Allow execution. Defaults to False.
-            cwd (str, optional): Working directory.
-        '''
         self._load_skills_index()
         info = self._skills_index.get(name)
         if not info:
             return {'status': 'missing', 'name': name}
+        if not self._is_local:
+            return {'status': 'error', 'error': 'run_script is not supported for cloud FS skills'}
         base = info['path']
         script_path = os.path.join(base, rel_path)
         if not os.path.exists(script_path):
             return {'status': 'missing', 'path': script_path}
         ext = os.path.splitext(script_path)[1].lower()
-        if ext == '.py':
-            cmd = ['python', script_path]
-        elif ext in ('.sh', '.bash'):
-            cmd = ['bash', script_path]
-        else:
-            cmd = ['sh', script_path]
+        cmd = ['python' if ext == '.py' else 'bash' if ext in ('.sh', '.bash') else 'sh', script_path]
         if args:
             cmd.extend(args)
-        cmd_str = ' '.join(shlex.quote(part) for part in cmd)
-        return _shell_tool(cmd_str, cwd=cwd or base, allow_unsafe=allow_unsafe)
+        return _shell_tool(' '.join(shlex.quote(p) for p in cmd), cwd=cwd or base, allow_unsafe=allow_unsafe)
 
     def read_reference(self, name: str, rel_path: str, **kwargs) -> Dict[str, str]:
-        '''Read a reference file within a skill directory.'''
         return self.read_file(name=name, rel_path=rel_path, **kwargs)
 
     def get_skill_tools(self) -> List:
-        return [
-            self._build_get_skill_tool(),
-            self._build_read_reference_tool(),
-            self._build_run_script_tool(),
-        ]
+        return [self._build_get_skill_tool(), self._build_read_reference_tool(), self._build_run_script_tool()]
 
     def _build_get_skill_tool(self):
         def get_skill(name: str, allow_large: bool = False) -> dict:
@@ -411,15 +414,10 @@ class SkillManager(ModuleBase):
         lines = []
         for name in names:
             info = self._skills_index.get(name)
-            if not info:
-                continue
-            desc = info.get('description', '') or ''
-            if len(desc) > 1024:
-                desc = desc[:1024] + '...'
-            lines.append(f'- {name}: {desc} (path: {info.get("path")})')
+            if info:
+                desc = (info.get('description', '') or '')[:1024]
+                lines.append(f'- {name}: {desc} (path: {info.get("path")})')
         return '\n'.join(lines)
 
     def _format_skills_locations(self) -> str:
-        if not self._skills_dir:
-            return ''
-        return '\n'.join([f'- {path}' for path in self._skills_dir])
+        return '\n'.join(f'- {path}' for path in self._skills_dir)

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -5,7 +5,8 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import yaml
 
-from lazyllm import config, ModuleBase, thirdparty
+from lazyllm import config, ModuleBase
+from lazyllm.thirdparty import fsspec
 from .file_tool import read_file as _read_file
 from .shell_tool import shell_tool as _shell_tool
 
@@ -76,15 +77,11 @@ _META_REQUIRED_FIELDS = {
 }
 
 
-def _local_fs():
-    return thirdparty.fsspec.implementations.local.LocalFileSystem()
-
-
 class SkillManager(ModuleBase):
     def __init__(self, dir: Optional[str] = None, skills: Optional[Iterable[str]] = None,
                  max_skill_md_bytes: Optional[int] = None, fs=None):
         super().__init__(return_trace=False)
-        self._fs = fs or _local_fs()
+        self._fs = fs or fsspec.implementations.local.LocalFileSystem()
         self._is_local = fs is None
         self._skills_dir = self._parse_dirs(dir) if dir else (
             self._parse_dirs(config['skills_dir']) if self._is_local else []

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -132,8 +132,9 @@ class SkillManager(ModuleBase):
         for d in dirs:
             if not d:
                 continue
-            # Keep cloud paths (protocol:/ prefix) as-is; expand local paths
-            path = d if re.match(r'^[a-zA-Z][a-zA-Z0-9+\-.]*:/', d) else os.path.abspath(os.path.expanduser(d))
+            # Keep cloud paths (protocol:/ prefix) as-is; expand local paths.
+            # Use the same regex as _extract_protocol for consistency.
+            path = d if re.match(r'^[a-zA-Z][a-zA-Z0-9+\-.]*(@[^:/]+)?:/', d) else os.path.abspath(os.path.expanduser(d))
             if path not in seen:
                 seen.add(path)
                 result.append(path)

--- a/lazyllm/tools/fs/__init__.py
+++ b/lazyllm/tools/fs/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
 from .base import LazyLLMFSBase, CloudFSBufferedFile
 from .watchdog import CloudFsWatchdog
+from .client import FS, dynamic_fs_config
 from .supplier.feishu import FeishuFS, FeishuWikiFS
 from .supplier.confluence import ConfluenceFS
 from .supplier.notion import NotionFS
@@ -15,8 +16,9 @@ from .supplier.obsidian import ObsidianFS
 __all__ = [
     'LazyLLMFSBase',
     'CloudFSBufferedFile',
-    'CloudFS',
     'CloudFsWatchdog',
+    'FS',
+    'dynamic_fs_config',
     'FeishuFS',
     'FeishuWikiFS',
     'ConfluenceFS',

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -180,7 +180,8 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     @property
     def _dynamic_token(self) -> str:
-        return globals.config['dynamic_fs_auth'].get(self._fs_protocol_key, '')
+        mapping = globals.config['dynamic_fs_auth'] or {}
+        return mapping.get(self._fs_protocol_key, '')
 
     def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
         return '', None
@@ -200,7 +201,8 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         auth_header = self._get_auth_header()
         if auth_header:
             existing = kwargs.get('headers') or {}
-            kwargs = {**kwargs, 'headers': {**auth_header, **existing}}
+            # auth_header takes highest priority — caller-supplied headers cannot override credentials
+            kwargs = {**kwargs, 'headers': {**existing, **auth_header}}
         resp = self._session.request(method, url, **kwargs)
         if not resp.ok:
             try:

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -64,7 +64,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         if isleaf:
             if not name.lower().endswith('fs'):
                 raise ValueError(f'Class name {name} must follow the schema of <SupplierType>FS, like <GoogleDriveFS>')
-            cls.protocol = name[:-3].lower()
+            cls.protocol = cls._fs_protocol_key = name[:-2].lower()
 
     def close(self) -> None:
         self._session.close()
@@ -182,7 +182,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
     def _dynamic_token(self) -> str:
         from lazyllm.common import globals as _globals
         cfg = _globals['config'].get('dynamic_fs_auth') or {}
-        # prefer _fs_protocol_key (human-readable path prefix) over self.protocol (registry-derived)
+        # _fs_protocol_key is set by __lazyllm_after_registry_hook__ and equals self.protocol
         key = getattr(self, '_fs_protocol_key', None) or self.protocol
         return cfg.get(key, '')
 

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -44,12 +44,14 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     def __init__(self, token: Any, base_url: Optional[str] = None, asynchronous: bool = False,
                  use_listings_cache: bool = False, skip_instance_cache: bool = False, loop: Optional[Any] = None,
-                 auth: str = 'static'):
+                 dynamic_auth: bool = False):
         super().__init__(asynchronous=asynchronous, use_listings_cache=use_listings_cache,
                          skip_instance_cache=skip_instance_cache, loop=loop)
-        self._dynamic_auth: bool = (auth == 'dynamic')
+        self._dynamic_auth: bool = dynamic_auth
         # Long-lived credential (string or dict), semantics decided by subclasses.
         self._secret_key: Any = token
+        # Cached short-lived access token (static auth only); not used for dynamic auth.
+        self._access_token: str = ''
         # Expiration timestamp for short-lived access token; None means non-expiring.
         self._token_expire_at: Optional[float] = None
         self._base_url = (base_url or '').rstrip('/')
@@ -61,7 +63,6 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     @staticmethod
     def __lazyllm_after_registry_hook__(cls, group_name: str, name: str, isleaf: bool):
-        print(cls, group_name, name, isleaf)
         if isleaf:
             if not name.lower().endswith('fs'):
                 raise ValueError(f'Class name {name} must follow the schema of <SupplierType>FS, like <GoogleDriveFS>')
@@ -166,13 +167,11 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     def _ensure_token(self) -> None:
         if self._dynamic_auth:
-            token = self._dynamic_token
-            if not token:
+            if not self._dynamic_token:
                 raise ValueError(
                     f'dynamic_fs_auth["{self.protocol}"] is not set in globals.config; '
                     f'use dynamic_fs_config() or set globals.config["dynamic_fs_auth"] before calling FS methods'
                 )
-            self._apply_access_token(token)
             return
         if not self._token_expire_at or time.time() < self._token_expire_at: return
         with self._lock:
@@ -181,16 +180,27 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     @property
     def _dynamic_token(self) -> str:
-        return  globals.config['dynamic_fs_auth'].get(self._fs_protocol_key, '')
+        return globals.config['dynamic_fs_auth'].get(self._fs_protocol_key, '')
 
     def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
         return '', None
 
     def _apply_access_token(self, token: str) -> None:
-        self._session.headers.update({'Authorization': f'Bearer {token}'})
+        self._access_token = token
+
+    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+        if self._dynamic_auth:
+            return {'Authorization': f'Bearer {self._dynamic_token}'}
+        if self._access_token:
+            return {'Authorization': f'Bearer {self._access_token}'}
+        return None
 
     def _request(self, method: str, url: str, **kwargs) -> requests.Response:
         self._ensure_token()
+        auth_header = self._get_auth_header()
+        if auth_header:
+            existing = kwargs.get('headers') or {}
+            kwargs = {**kwargs, 'headers': {**auth_header, **existing}}
         resp = self._session.request(method, url, **kwargs)
         if not resp.ok:
             try:

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -43,9 +43,11 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
     protocol: str = 'cloudfs'
 
     def __init__(self, token: Any, base_url: Optional[str] = None, asynchronous: bool = False,
-                 use_listings_cache: bool = False, skip_instance_cache: bool = False, loop: Optional[Any] = None):
+                 use_listings_cache: bool = False, skip_instance_cache: bool = False, loop: Optional[Any] = None,
+                 auth: str = 'static'):
         super().__init__(asynchronous=asynchronous, use_listings_cache=use_listings_cache,
                          skip_instance_cache=skip_instance_cache, loop=loop)
+        self._dynamic_auth: bool = (auth == 'dynamic')
         # Long-lived credential (string or dict), semantics decided by subclasses.
         self._secret_key: Any = token
         # Expiration timestamp for short-lived access token; None means non-expiring.
@@ -54,7 +56,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         self._session = requests.Session()
         self._setup_auth()
         self._lock = threading.Lock()
-        if self.__class__._acquire_access_token is not __class__._acquire_access_token:
+        if not self._dynamic_auth and self.__class__._acquire_access_token is not __class__._acquire_access_token:
             self._ensure_token_initialized()
 
     @staticmethod
@@ -162,10 +164,27 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         self._token_expire_at = expires_at
 
     def _ensure_token(self) -> None:
+        if self._dynamic_auth:
+            token = self._dynamic_token
+            if not token:
+                raise ValueError(
+                    f'dynamic_fs_auth["{self.protocol}"] is not set in globals.config; '
+                    f'use dynamic_fs_config() or set globals.config["dynamic_fs_auth"] before calling FS methods'
+                )
+            self._apply_access_token(token)
+            return
         if not self._token_expire_at or time.time() < self._token_expire_at: return
         with self._lock:
             if time.time() < self._token_expire_at: return
             self._ensure_token_initialized()
+
+    @property
+    def _dynamic_token(self) -> str:
+        from lazyllm.common import globals as _globals
+        cfg = _globals['config'].get('dynamic_fs_auth') or {}
+        # prefer _fs_protocol_key (human-readable path prefix) over self.protocol (registry-derived)
+        key = getattr(self, '_fs_protocol_key', None) or self.protocol
+        return cfg.get(key, '')
 
     def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
         return '', None

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -7,7 +7,7 @@ import time
 import threading
 import io
 
-from lazyllm import thirdparty
+from lazyllm import thirdparty, globals
 from lazyllm.common.registry import LazyLLMRegisterMetaABCClass
 
 AbstractFileSystem = thirdparty.fsspec.spec.AbstractFileSystem
@@ -61,6 +61,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     @staticmethod
     def __lazyllm_after_registry_hook__(cls, group_name: str, name: str, isleaf: bool):
+        print(cls, group_name, name, isleaf)
         if isleaf:
             if not name.lower().endswith('fs'):
                 raise ValueError(f'Class name {name} must follow the schema of <SupplierType>FS, like <GoogleDriveFS>')
@@ -180,11 +181,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     @property
     def _dynamic_token(self) -> str:
-        from lazyllm.common import globals as _globals
-        cfg = _globals['config'].get('dynamic_fs_auth') or {}
-        # _fs_protocol_key is set by __lazyllm_after_registry_hook__ and equals self.protocol
-        key = getattr(self, '_fs_protocol_key', None) or self.protocol
-        return cfg.get(key, '')
+        return  globals.config['dynamic_fs_auth'].get(self._fs_protocol_key, '')
 
     def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
         return '', None
@@ -239,3 +236,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         stripped = self._strip_protocol(path)
         parts = [p for p in stripped.split('/') if p]
         return tuple(parts)
+
+
+globals.config.add('dynamic_fs_auth', dict, None, 'DYNAMIC_FS_AUTH',
+                   description='Per-source dynamic FS auth: {source: token}.')

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
 import re
+import threading
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 from lazyllm import globals
@@ -24,6 +25,7 @@ class _FSRouter:
 
     def __init__(self) -> None:
         self._instances: Dict[tuple, Any] = {}
+        self._lock = threading.Lock()
 
     def _parse(self, path: str):
         m = _PROTOCOL_RE.match(path)
@@ -37,17 +39,23 @@ class _FSRouter:
     def _get_or_create_fs(self, protocol: str, space_id: Optional[str]) -> Any:
         key = (protocol, space_id)
         if key not in self._instances:
-            cls = _lookup_fs_cls(protocol)
-            self._instances[key] = cls(space_id=space_id, dynamic_auth=True) if space_id else cls(dynamic_auth=True)
+            with self._lock:
+                if key not in self._instances:
+                    cls = _lookup_fs_cls(protocol)
+                    import inspect
+                    init_params = inspect.signature(cls.__init__).parameters
+                    kwargs: Dict[str, Any] = {'dynamic_auth': True}
+                    if space_id and 'space_id' in init_params:
+                        kwargs['space_id'] = space_id
+                    self._instances[key] = cls(**kwargs)
         return self._instances[key]
 
     def _dispatch(self, method: str, path: str, *args, **kwargs) -> Any:
         protocol, space_id, real_path = self._parse(path)
         if protocol == 'file':
-            if method == 'open':
-                mode = args[0] if args else kwargs.pop('mode', 'rb')
-                return open(real_path, mode)
-            raise ValueError(f'Local file system does not support {method!r} via FS router; use open() directly.')
+            import fsspec.implementations.local as _local_fs
+            fs = _local_fs.LocalFileSystem()
+            return getattr(fs, method)(real_path, *args, **kwargs)
         fs = self._get_or_create_fs(protocol, space_id)
         return getattr(fs, method)(real_path, *args, **kwargs)
 

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import re
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, Optional
+
+_PROTOCOL_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+\-.]*)(@[^:/]+)?:/(.*)$')
+
+
+def _lookup_fs_cls(protocol: str):
+    from lazyllm.common import LazyLLMRegisterMetaClass
+    registry = LazyLLMRegisterMetaClass.all_clses.get('fs', {})
+    cls = registry.get(protocol + 'fs')
+    if cls is None:
+        available = sorted(k[:-2] for k in registry if k.endswith('fs'))
+        raise ValueError(
+            f'Unknown FS protocol: {protocol!r}. '
+            f'Supported protocols: {", ".join(available)}.'
+        )
+    return cls
+
+
+class _FSRouter:
+
+    def __init__(self) -> None:
+        self._instances: Dict[tuple, Any] = {}
+
+    def _parse(self, path: str):
+        m = _PROTOCOL_RE.match(path)
+        if not m:
+            return 'file', None, path
+        protocol = m.group(1).lower()
+        at_id = m.group(2)
+        rest = '/' + m.group(3)
+        return protocol, (at_id[1:] if at_id else None), rest
+
+    def _get_or_create_fs(self, protocol: str, space_id: Optional[str], **kwargs) -> Any:
+        key = (protocol, space_id)
+        if key not in self._instances:
+            cls = _lookup_fs_cls(protocol)
+            self._instances[key] = cls(space_id=space_id, **kwargs) if space_id else cls(**kwargs)
+        return self._instances[key]
+
+    def _dispatch(self, method: str, path: str, *args, **kwargs) -> Any:
+        protocol, space_id, real_path = self._parse(path)
+        if protocol == 'file':
+            if method == 'open':
+                mode = args[0] if args else kwargs.pop('mode', 'rb')
+                return open(real_path, mode)
+            raise ValueError(f'Local file system does not support {method!r} via FS router; use open() directly.')
+        fs = self._get_or_create_fs(protocol, space_id)
+        return getattr(fs, method)(real_path, *args, **kwargs)
+
+    def open(self, path: str, mode: str = 'rb', **kwargs) -> Any:
+        return self._dispatch('open', path, mode, **kwargs)
+
+    def ls(self, path: str, detail: bool = True, **kwargs) -> Any:
+        return self._dispatch('ls', path, detail=detail, **kwargs)
+
+    def info(self, path: str, **kwargs) -> Any:
+        return self._dispatch('info', path, **kwargs)
+
+    def mkdir(self, path: str, create_parents: bool = True, **kwargs) -> None:
+        self._dispatch('mkdir', path, create_parents=create_parents, **kwargs)
+
+    def rm(self, path: str, recursive: bool = False) -> None:
+        self._dispatch('rm', path, recursive=recursive)
+
+    def exists(self, path: str, **kwargs) -> bool:
+        return self._dispatch('exists', path, **kwargs)
+
+    def read_bytes(self, path: str) -> bytes:
+        return self._dispatch('read_bytes', path)
+
+    def read_file(self, path: str) -> str:
+        return self._dispatch('read_file', path)
+
+    def write_file(self, path: str, data: bytes) -> None:
+        self._dispatch('write_file', path, data)
+
+    def copy(self, path1: str, path2: str, recursive: bool = False, **kwargs) -> None:
+        self._dispatch('copy', path1, path2, recursive=recursive, **kwargs)
+
+    def move(self, path1: str, path2: str, recursive: bool = False, **kwargs) -> None:
+        self._dispatch('move', path1, path2, recursive=recursive, **kwargs)
+
+
+FS = _FSRouter()
+
+
+@contextmanager
+def dynamic_fs_config(source_token_map: Dict[str, str]) -> Iterator[None]:
+    from lazyllm.common import globals as _globals
+    old = _globals['config'].get('dynamic_fs_auth')
+    _globals['config']['dynamic_fs_auth'] = source_token_map
+    try:
+        yield
+    finally:
+        _globals['config']['dynamic_fs_auth'] = old

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -2,6 +2,7 @@
 import re
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
+from lazyllm import globals
 
 _PROTOCOL_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+\-.]*)(@[^:/]+)?:/(.*)$')
 
@@ -89,10 +90,9 @@ FS = _FSRouter()
 
 @contextmanager
 def dynamic_fs_config(source_token_map: Dict[str, str]) -> Iterator[None]:
-    from lazyllm.common import globals as _globals
-    old = _globals['config'].get('dynamic_fs_auth')
-    _globals['config']['dynamic_fs_auth'] = source_token_map
+    old = globals.config['dynamic_fs_auth']
+    globals.config['dynamic_fs_auth'] = {**(old or {}), **source_token_map}
     try:
         yield
     finally:
-        _globals['config']['dynamic_fs_auth'] = old
+        globals.config['dynamic_fs_auth'] = old

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -34,11 +34,11 @@ class _FSRouter:
         rest = '/' + m.group(3)
         return protocol, (at_id[1:] if at_id else None), rest
 
-    def _get_or_create_fs(self, protocol: str, space_id: Optional[str], **kwargs) -> Any:
+    def _get_or_create_fs(self, protocol: str, space_id: Optional[str]) -> Any:
         key = (protocol, space_id)
         if key not in self._instances:
             cls = _lookup_fs_cls(protocol)
-            self._instances[key] = cls(space_id=space_id, **kwargs) if space_id else cls(**kwargs)
+            self._instances[key] = cls(space_id=space_id, dynamic_auth=True) if space_id else cls(dynamic_auth=True)
         return self._instances[key]
 
     def _dispatch(self, method: str, path: str, *args, **kwargs) -> Any:

--- a/lazyllm/tools/fs/supplier/confluence.py
+++ b/lazyllm/tools/fs/supplier/confluence.py
@@ -20,8 +20,8 @@ class ConfluenceFS(LazyLLMFSBase):
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  email: Optional[str] = None, cloud: bool = True,
-                 cloud_id: Optional[str] = None, auth: str = 'static', **storage_options):
-        if auth == 'dynamic':
+                 cloud_id: Optional[str] = None, dynamic_auth: bool = False, **storage_options):
+        if dynamic_auth:
             token = ''
             email = None
         else:
@@ -39,24 +39,22 @@ class ConfluenceFS(LazyLLMFSBase):
             resolved_base = ''
         else:
             resolved_base = _CLOUD_BASE
-        super().__init__(token=token, base_url=resolved_base, auth=auth, **storage_options)
+        super().__init__(token=token, base_url=resolved_base, dynamic_auth=dynamic_auth, **storage_options)
 
     def _setup_auth(self) -> None:
+        self._session.headers.update({
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+        })
+
+    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+        if self._dynamic_auth:
+            token = self._dynamic_token
+            return {'Authorization': f'Bearer {token}'} if token else None
         if self._cloud and self._email:
-            cred = base64.b64encode(
-                f'{self._email}:{self._secret_key}'.encode()
-            ).decode()
-            self._session.headers.update({
-                'Authorization': f'Basic {cred}',
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-            })
-        else:
-            self._session.headers.update({
-                'Authorization': f'Bearer {self._secret_key}',
-                'Content-Type': 'application/json',
-                'Accept': 'application/json',
-            })
+            cred = base64.b64encode(f'{self._email}:{self._secret_key}'.encode()).decode()
+            return {'Authorization': f'Basic {cred}'}
+        return {'Authorization': f'Bearer {self._secret_key}'} if self._secret_key else None
 
     @property
     def _rest(self) -> str:

--- a/lazyllm/tools/fs/supplier/confluence.py
+++ b/lazyllm/tools/fs/supplier/confluence.py
@@ -17,7 +17,6 @@ _CLOUD_BASE = 'https://api.atlassian.com/ex/confluence'
 
 
 class ConfluenceFS(LazyLLMFSBase):
-    _fs_protocol_key = 'confluence'
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  email: Optional[str] = None, cloud: bool = True,

--- a/lazyllm/tools/fs/supplier/confluence.py
+++ b/lazyllm/tools/fs/supplier/confluence.py
@@ -17,11 +17,17 @@ _CLOUD_BASE = 'https://api.atlassian.com/ex/confluence'
 
 
 class ConfluenceFS(LazyLLMFSBase):
+    _fs_protocol_key = 'confluence'
+
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  email: Optional[str] = None, cloud: bool = True,
-                 cloud_id: Optional[str] = None, **storage_options):
-        token = token or config['confluence_token'] or ''
-        email = email or config['confluence_email']
+                 cloud_id: Optional[str] = None, auth: str = 'static', **storage_options):
+        if auth == 'dynamic':
+            token = ''
+            email = None
+        else:
+            token = token or config['confluence_token'] or ''
+            email = email or config['confluence_email']
         cloud_id = cloud_id or config['confluence_cloud_id']
         self._email = email
         self._cloud = cloud
@@ -34,7 +40,7 @@ class ConfluenceFS(LazyLLMFSBase):
             resolved_base = ''
         else:
             resolved_base = _CLOUD_BASE
-        super().__init__(token=token, base_url=resolved_base, **storage_options)
+        super().__init__(token=token, base_url=resolved_base, auth=auth, **storage_options)
 
     def _setup_auth(self) -> None:
         if self._cloud and self._email:

--- a/lazyllm/tools/fs/supplier/confluence.py
+++ b/lazyllm/tools/fs/supplier/confluence.py
@@ -22,6 +22,10 @@ class ConfluenceFS(LazyLLMFSBase):
                  email: Optional[str] = None, cloud: bool = True,
                  cloud_id: Optional[str] = None, dynamic_auth: bool = False, **storage_options):
         if dynamic_auth:
+            if token:
+                raise ValueError('token must be None when dynamic_auth=True')
+            if email:
+                raise ValueError('email must be None when dynamic_auth=True')
             token = ''
             email = None
         else:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -834,6 +834,8 @@ class FeishuWikiFile(CloudFSBufferedFile):
 
 class FeishuWikiFS(FeishuFSBase):
     __lazyllm_registry_disable__ = True
+    protocol = 'feishu'
+    _fs_protocol_key = 'feishu'
 
     def _create_docx_node(self, title: str, parent_token: str = '') -> str:
         url = f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes'

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -218,14 +218,14 @@ class FeishuFSBase(LazyLLMFSBase):
                  space_id: Optional[str] = None, user_refresh_token: Optional[str] = None,
                  oauth_port: int = 9981, oauth_scope: str = _DEFAULT_OAUTH_SCOPE,
                  asynchronous: bool = False, use_listings_cache: bool = False,
-                 skip_instance_cache: bool = False, loop: Optional[Any] = None, auth: str = 'static'):
-        if auth == 'dynamic':
+                 skip_instance_cache: bool = False, loop: Optional[Any] = None, dynamic_auth: bool = False):
+        if dynamic_auth:
             if app_id:
-                raise ValueError('app_id must be None when auth="dynamic"')
+                raise ValueError('app_id must be None when dynamic_auth=True')
             if app_secret:
-                raise ValueError('app_secret must be None when auth="dynamic"')
+                raise ValueError('app_secret must be None when dynamic_auth=True')
             if user_refresh_token:
-                raise ValueError('user_refresh_token must be None when auth="dynamic"')
+                raise ValueError('user_refresh_token must be None when dynamic_auth=True')
             self._oauth_auto = False
             self._user_refresh_token = ''
             self._oauth_port = oauth_port
@@ -237,7 +237,7 @@ class FeishuFSBase(LazyLLMFSBase):
                 use_listings_cache=use_listings_cache,
                 skip_instance_cache=skip_instance_cache,
                 loop=loop,
-                auth='dynamic',
+                dynamic_auth=True,
             )
             self._space_id = (space_id or '').strip() if space_id is not None else ''
             return
@@ -301,7 +301,7 @@ class FeishuFSBase(LazyLLMFSBase):
         return _feishu_acquire_access_token(self._session, self._app_id, self._app_secret)
 
     def _apply_access_token(self, token: str) -> None:
-        self._session.headers.update({'Authorization': f'Bearer {token}'})
+        self._access_token = token
 
     def get_user_refresh_token(self) -> str:
         return self._user_refresh_token
@@ -641,13 +641,13 @@ class FeishuFS(FeishuFSBase):
                 oauth_port: int = 9981, oauth_scope: str = _DEFAULT_OAUTH_SCOPE,
                 asynchronous: bool = False, use_listings_cache: bool = False,
                 skip_instance_cache: bool = False, loop: Optional[Any] = None,
-                auth: str = 'static') -> LazyLLMFSBase:
+                dynamic_auth: bool = False) -> LazyLLMFSBase:
         if space_id is not None and str(space_id).strip():
             return FeishuWikiFS(base_url=base_url, app_id=app_id, app_secret=app_secret, space_id=space_id,
                                 user_refresh_token=user_refresh_token, oauth_port=oauth_port,
                                 oauth_scope=oauth_scope, asynchronous=asynchronous,
                                 use_listings_cache=use_listings_cache,
-                                skip_instance_cache=skip_instance_cache, loop=loop, auth=auth)
+                                skip_instance_cache=skip_instance_cache, loop=loop, dynamic_auth=dynamic_auth)
         return super().__new__(cls)
 
     def _list_files_raw(self, folder_token: str = '') -> List[Dict[str, Any]]:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -213,12 +213,35 @@ def _feishu_refresh_user_token(
 
 class FeishuFSBase(LazyLLMFSBase):
     __lazyllm_registry_disable__ = True
+    _fs_protocol_key = 'feishu'
 
     def __init__(self, base_url: Optional[str] = None, app_id: Optional[str] = None, app_secret: Optional[str] = None,
                  space_id: Optional[str] = None, user_refresh_token: Optional[str] = None,
                  oauth_port: int = 9981, oauth_scope: str = _DEFAULT_OAUTH_SCOPE,
                  asynchronous: bool = False, use_listings_cache: bool = False,
-                 skip_instance_cache: bool = False, loop: Optional[Any] = None):
+                 skip_instance_cache: bool = False, loop: Optional[Any] = None, auth: str = 'static'):
+        if auth == 'dynamic':
+            if app_id:
+                raise ValueError('app_id must be None when auth="dynamic"')
+            if app_secret:
+                raise ValueError('app_secret must be None when auth="dynamic"')
+            if user_refresh_token:
+                raise ValueError('user_refresh_token must be None when auth="dynamic"')
+            self._oauth_auto = False
+            self._user_refresh_token = ''
+            self._oauth_port = oauth_port
+            self._oauth_scope = oauth_scope
+            super().__init__(
+                token={},
+                base_url=base_url or _API_BASE,
+                asynchronous=asynchronous,
+                use_listings_cache=use_listings_cache,
+                skip_instance_cache=skip_instance_cache,
+                loop=loop,
+                auth='dynamic',
+            )
+            self._space_id = (space_id or '').strip() if space_id is not None else ''
+            return
         if not app_id or not app_secret:
             app_id, app_secret = config['feishu_app_id'] or app_id, config['feishu_app_secret']
         assert app_id and app_secret, 'feishu_app_id and feishu_app_secret are required'
@@ -618,13 +641,14 @@ class FeishuFS(FeishuFSBase):
                 space_id: Optional[str] = None, user_refresh_token: Optional[str] = None,
                 oauth_port: int = 9981, oauth_scope: str = _DEFAULT_OAUTH_SCOPE,
                 asynchronous: bool = False, use_listings_cache: bool = False,
-                skip_instance_cache: bool = False, loop: Optional[Any] = None) -> LazyLLMFSBase:
+                skip_instance_cache: bool = False, loop: Optional[Any] = None,
+                auth: str = 'static') -> LazyLLMFSBase:
         if space_id is not None and str(space_id).strip():
             return FeishuWikiFS(base_url=base_url, app_id=app_id, app_secret=app_secret, space_id=space_id,
                                 user_refresh_token=user_refresh_token, oauth_port=oauth_port,
                                 oauth_scope=oauth_scope, asynchronous=asynchronous,
                                 use_listings_cache=use_listings_cache,
-                                skip_instance_cache=skip_instance_cache, loop=loop)
+                                skip_instance_cache=skip_instance_cache, loop=loop, auth=auth)
         return super().__new__(cls)
 
     def _list_files_raw(self, folder_token: str = '') -> List[Dict[str, Any]]:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -213,7 +213,6 @@ def _feishu_refresh_user_token(
 
 class FeishuFSBase(LazyLLMFSBase):
     __lazyllm_registry_disable__ = True
-    _fs_protocol_key = 'feishu'
 
     def __init__(self, base_url: Optional[str] = None, app_id: Optional[str] = None, app_secret: Optional[str] = None,
                  space_id: Optional[str] = None, user_refresh_token: Optional[str] = None,

--- a/lazyllm/tools/fs/supplier/googledrive.py
+++ b/lazyllm/tools/fs/supplier/googledrive.py
@@ -20,6 +20,7 @@ _SA_TOKEN_BUFFER = 300  # refresh 5 min before expiry
 
 
 class GoogleDriveFS(LazyLLMFSBase):
+    _fs_protocol_key = 'googledrive'
 
     def __init__(
         self,
@@ -29,7 +30,19 @@ class GoogleDriveFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
+        auth: str = 'static',
     ):
+        if auth == 'dynamic':
+            super().__init__(
+                token={},
+                base_url=base_url or _API_BASE,
+                asynchronous=asynchronous,
+                use_listings_cache=use_listings_cache,
+                skip_instance_cache=skip_instance_cache,
+                loop=loop,
+                auth='dynamic',
+            )
+            return
         credentials = (credentials or config['googledrive_credentials']
                        or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'))
         secret_payload: Optional[Dict] = None

--- a/lazyllm/tools/fs/supplier/googledrive.py
+++ b/lazyllm/tools/fs/supplier/googledrive.py
@@ -29,9 +29,9 @@ class GoogleDriveFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
-        auth: str = 'static',
+        dynamic_auth: bool = False,
     ):
-        if auth == 'dynamic':
+        if dynamic_auth:
             super().__init__(
                 token={},
                 base_url=base_url or _API_BASE,
@@ -39,7 +39,7 @@ class GoogleDriveFS(LazyLLMFSBase):
                 use_listings_cache=use_listings_cache,
                 skip_instance_cache=skip_instance_cache,
                 loop=loop,
-                auth='dynamic',
+                dynamic_auth=True,
             )
             return
         credentials = (credentials or config['googledrive_credentials']

--- a/lazyllm/tools/fs/supplier/googledrive.py
+++ b/lazyllm/tools/fs/supplier/googledrive.py
@@ -20,7 +20,6 @@ _SA_TOKEN_BUFFER = 300  # refresh 5 min before expiry
 
 
 class GoogleDriveFS(LazyLLMFSBase):
-    _fs_protocol_key = 'googledrive'
 
     def __init__(
         self,

--- a/lazyllm/tools/fs/supplier/notion.py
+++ b/lazyllm/tools/fs/supplier/notion.py
@@ -15,11 +15,16 @@ _NOTION_VERSION = '2022-06-28'
 
 
 class NotionFS(LazyLLMFSBase):
+    _fs_protocol_key = 'notion'
 
-    def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None, **storage_options):
-        token = (token or config['notion_token'] or os.environ.get('NOTION_TOKEN')
-                 or os.environ.get('NOTION_API_KEY') or '')
-        super().__init__(token=token, base_url=base_url or _API_BASE, **storage_options)
+    def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
+                 auth: str = 'static', **storage_options):
+        if auth == 'dynamic':
+            token = ''
+        else:
+            token = (token or config['notion_token'] or os.environ.get('NOTION_TOKEN')
+                     or os.environ.get('NOTION_API_KEY') or '')
+        super().__init__(token=token, base_url=base_url or _API_BASE, auth=auth, **storage_options)
 
     def _setup_auth(self) -> None:
         self._session.headers.update({

--- a/lazyllm/tools/fs/supplier/notion.py
+++ b/lazyllm/tools/fs/supplier/notion.py
@@ -17,20 +17,20 @@ _NOTION_VERSION = '2022-06-28'
 class NotionFS(LazyLLMFSBase):
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
-                 auth: str = 'static', **storage_options):
-        if auth == 'dynamic':
+                 dynamic_auth: bool = False, **storage_options):
+        if dynamic_auth:
             token = ''
         else:
             token = (token or config['notion_token'] or os.environ.get('NOTION_TOKEN')
                      or os.environ.get('NOTION_API_KEY') or '')
-        super().__init__(token=token, base_url=base_url or _API_BASE, auth=auth, **storage_options)
+        super().__init__(token=token, base_url=base_url or _API_BASE, dynamic_auth=dynamic_auth, **storage_options)
 
     def _setup_auth(self) -> None:
         self._session.headers.update({
-            'Authorization': f'Bearer {self._secret_key}',
             'Notion-Version': _NOTION_VERSION,
             'Content-Type': 'application/json',
         })
+        self._access_token = self._secret_key
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/notion.py
+++ b/lazyllm/tools/fs/supplier/notion.py
@@ -19,6 +19,8 @@ class NotionFS(LazyLLMFSBase):
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  dynamic_auth: bool = False, **storage_options):
         if dynamic_auth:
+            if token:
+                raise ValueError('token must be None when dynamic_auth=True')
             token = ''
         else:
             token = (token or config['notion_token'] or os.environ.get('NOTION_TOKEN')
@@ -30,7 +32,8 @@ class NotionFS(LazyLLMFSBase):
             'Notion-Version': _NOTION_VERSION,
             'Content-Type': 'application/json',
         })
-        self._access_token = self._secret_key
+        if not self._dynamic_auth:
+            self._apply_access_token(self._secret_key)
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/notion.py
+++ b/lazyllm/tools/fs/supplier/notion.py
@@ -15,7 +15,6 @@ _NOTION_VERSION = '2022-06-28'
 
 
 class NotionFS(LazyLLMFSBase):
-    _fs_protocol_key = 'notion'
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  auth: str = 'static', **storage_options):

--- a/lazyllm/tools/fs/supplier/obsidian.py
+++ b/lazyllm/tools/fs/supplier/obsidian.py
@@ -21,7 +21,7 @@ class ObsidianFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
-        auth: str = 'static',
+        dynamic_auth: bool = False,
     ):
         token = token or config['obsidian_vault_path'] or ''
         vault = (token or '').strip() or '.'
@@ -33,7 +33,7 @@ class ObsidianFS(LazyLLMFSBase):
             use_listings_cache=use_listings_cache,
             skip_instance_cache=skip_instance_cache,
             loop=loop,
-            auth=auth,
+            dynamic_auth=dynamic_auth,
         )
 
     def _setup_auth(self) -> None:

--- a/lazyllm/tools/fs/supplier/obsidian.py
+++ b/lazyllm/tools/fs/supplier/obsidian.py
@@ -12,7 +12,6 @@ config.add('obsidian_vault_path', str, None, 'OBSIDIAN_VAULT_PATH', description=
 
 
 class ObsidianFS(LazyLLMFSBase):
-    _fs_protocol_key = 'obsidian'
 
     def __init__(
         self,

--- a/lazyllm/tools/fs/supplier/obsidian.py
+++ b/lazyllm/tools/fs/supplier/obsidian.py
@@ -12,6 +12,7 @@ config.add('obsidian_vault_path', str, None, 'OBSIDIAN_VAULT_PATH', description=
 
 
 class ObsidianFS(LazyLLMFSBase):
+    _fs_protocol_key = 'obsidian'
 
     def __init__(
         self,
@@ -21,6 +22,7 @@ class ObsidianFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
+        auth: str = 'static',
     ):
         token = token or config['obsidian_vault_path'] or ''
         vault = (token or '').strip() or '.'
@@ -32,6 +34,7 @@ class ObsidianFS(LazyLLMFSBase):
             use_listings_cache=use_listings_cache,
             skip_instance_cache=skip_instance_cache,
             loop=loop,
+            auth=auth,
         )
 
     def _setup_auth(self) -> None:

--- a/lazyllm/tools/fs/supplier/onedrive.py
+++ b/lazyllm/tools/fs/supplier/onedrive.py
@@ -20,6 +20,7 @@ _TOKEN_REFRESH_BUFFER = 300  # refresh 5 min before expiry
 
 
 class OneDriveFS(LazyLLMFSBase):
+    _fs_protocol_key = 'onedrive'
 
     def __init__(
         self,
@@ -31,7 +32,22 @@ class OneDriveFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
+        auth: str = 'static',
     ):
+        if auth == 'dynamic':
+            self._client_id = ''
+            self._client_secret = ''
+            self._tenant_id = tenant_id or 'common'
+            super().__init__(
+                token={},
+                base_url=base_url or _GRAPH_BASE,
+                asynchronous=asynchronous,
+                use_listings_cache=use_listings_cache,
+                skip_instance_cache=skip_instance_cache,
+                loop=loop,
+                auth='dynamic',
+            )
+            return
         client_id = client_id or config['onedrive_client_id'] or os.environ.get('AZURE_CLIENT_ID')
         client_secret = client_secret or config['onedrive_client_secret'] or os.environ.get('AZURE_CLIENT_SECRET')
         tenant_id = tenant_id or config['onedrive_tenant_id'] or os.environ.get('AZURE_TENANT_ID') or 'common'

--- a/lazyllm/tools/fs/supplier/onedrive.py
+++ b/lazyllm/tools/fs/supplier/onedrive.py
@@ -31,9 +31,9 @@ class OneDriveFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
-        auth: str = 'static',
+        dynamic_auth: bool = False,
     ):
-        if auth == 'dynamic':
+        if dynamic_auth:
             self._client_id = ''
             self._client_secret = ''
             self._tenant_id = tenant_id or 'common'
@@ -44,7 +44,7 @@ class OneDriveFS(LazyLLMFSBase):
                 use_listings_cache=use_listings_cache,
                 skip_instance_cache=skip_instance_cache,
                 loop=loop,
-                auth='dynamic',
+                dynamic_auth=True,
             )
             return
         client_id = client_id or config['onedrive_client_id'] or os.environ.get('AZURE_CLIENT_ID')
@@ -81,7 +81,7 @@ class OneDriveFS(LazyLLMFSBase):
         return token, expires_at
 
     def _apply_access_token(self, token: str) -> None:
-        self._session.headers.update({'Authorization': f'Bearer {token}'})
+        self._access_token = token
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         url = self._make_children_url(path)

--- a/lazyllm/tools/fs/supplier/onedrive.py
+++ b/lazyllm/tools/fs/supplier/onedrive.py
@@ -34,11 +34,15 @@ class OneDriveFS(LazyLLMFSBase):
         dynamic_auth: bool = False,
     ):
         if dynamic_auth:
+            if client_id:
+                raise ValueError('client_id must be None when dynamic_auth=True')
+            if client_secret:
+                raise ValueError('client_secret must be None when dynamic_auth=True')
             self._client_id = ''
             self._client_secret = ''
             self._tenant_id = tenant_id or 'common'
             super().__init__(
-                token={},
+                token='',
                 base_url=base_url or _GRAPH_BASE,
                 asynchronous=asynchronous,
                 use_listings_cache=use_listings_cache,

--- a/lazyllm/tools/fs/supplier/onedrive.py
+++ b/lazyllm/tools/fs/supplier/onedrive.py
@@ -20,7 +20,6 @@ _TOKEN_REFRESH_BUFFER = 300  # refresh 5 min before expiry
 
 
 class OneDriveFS(LazyLLMFSBase):
-    _fs_protocol_key = 'onedrive'
 
     def __init__(
         self,

--- a/lazyllm/tools/fs/supplier/ones.py
+++ b/lazyllm/tools/fs/supplier/ones.py
@@ -21,9 +21,9 @@ class OnesFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
-        auth: str = 'static',
+        dynamic_auth: bool = False,
     ):
-        if auth == 'dynamic':
+        if dynamic_auth:
             self._user_id = user_id or ''
             super().__init__(
                 token='',
@@ -32,7 +32,7 @@ class OnesFS(LazyLLMFSBase):
                 use_listings_cache=use_listings_cache,
                 skip_instance_cache=skip_instance_cache,
                 loop=loop,
-                auth='dynamic',
+                dynamic_auth=True,
             )
             return
         token = token or config['ones_token'] or ''
@@ -52,13 +52,25 @@ class OnesFS(LazyLLMFSBase):
         )
 
     def _setup_auth(self) -> None:
-        headers: Dict[str, str] = {
-            'Ones-Auth-Token': self._secret_key,
-            'Content-Type': 'application/json',
-        }
+        self._session.headers.update({'Content-Type': 'application/json'})
+
+    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+        if self._dynamic_auth:
+            raw = self._dynamic_token
+            if not raw:
+                return None
+            if ':' in raw:
+                uid, tok = raw.split(':', 1)
+            else:
+                uid, tok = self._user_id, raw
+            h = {'Ones-Auth-Token': tok}
+            if uid:
+                h['Ones-User-Id'] = uid
+            return h
+        h = {'Ones-Auth-Token': self._secret_key}
         if self._user_id:
-            headers['Ones-User-Id'] = self._user_id
-        self._session.headers.update(headers)
+            h['Ones-User-Id'] = self._user_id
+        return h if self._secret_key else None
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/ones.py
+++ b/lazyllm/tools/fs/supplier/ones.py
@@ -11,7 +11,6 @@ _CLOUD_BASE = 'https://ones.ai/project/api/project'
 
 
 class OnesFS(LazyLLMFSBase):
-    _fs_protocol_key = 'ones'
 
     def __init__(
         self,

--- a/lazyllm/tools/fs/supplier/ones.py
+++ b/lazyllm/tools/fs/supplier/ones.py
@@ -11,6 +11,7 @@ _CLOUD_BASE = 'https://ones.ai/project/api/project'
 
 
 class OnesFS(LazyLLMFSBase):
+    _fs_protocol_key = 'ones'
 
     def __init__(
         self,
@@ -21,7 +22,20 @@ class OnesFS(LazyLLMFSBase):
         use_listings_cache: bool = False,
         skip_instance_cache: bool = False,
         loop: Optional[Any] = None,
+        auth: str = 'static',
     ):
+        if auth == 'dynamic':
+            self._user_id = user_id or ''
+            super().__init__(
+                token='',
+                base_url=base_url or _CLOUD_BASE,
+                asynchronous=asynchronous,
+                use_listings_cache=use_listings_cache,
+                skip_instance_cache=skip_instance_cache,
+                loop=loop,
+                auth='dynamic',
+            )
+            return
         token = token or config['ones_token'] or ''
         if ':' in token and not user_id:
             uid, tok = token.split(':', 1)

--- a/lazyllm/tools/fs/supplier/ones.py
+++ b/lazyllm/tools/fs/supplier/ones.py
@@ -24,6 +24,8 @@ class OnesFS(LazyLLMFSBase):
         dynamic_auth: bool = False,
     ):
         if dynamic_auth:
+            if token:
+                raise ValueError('token must be None when dynamic_auth=True')
             self._user_id = user_id or ''
             super().__init__(
                 token='',

--- a/lazyllm/tools/fs/supplier/s3.py
+++ b/lazyllm/tools/fs/supplier/s3.py
@@ -18,13 +18,23 @@ except ImportError:
 
 
 class S3FS(LazyLLMFSBase):
+    _fs_protocol_key = 's3'
 
     def __init__(self, token: str = '', base_url: Optional[str] = None,
                  access_key: Optional[str] = None,
                  secret_key: Optional[str] = None,
                  endpoint_url: Optional[str] = None,
                  region_name: Optional[str] = None,
+                 auth: str = 'static',
                  **storage_options):
+        if auth == 'dynamic':
+            self._access_key = ''
+            self._secret_key = ''
+            self._endpoint_url = endpoint_url or None
+            self._region_name = region_name or None
+            self._s3_client = None
+            super().__init__(token='', base_url=base_url, auth='dynamic', **storage_options)
+            return
         _ak = config['s3_access_key'] or os.environ.get('AWS_ACCESS_KEY_ID')
         access_key = access_key or token or _ak or ''
         secret_key = secret_key or config['s3_secret_key'] or os.environ.get('AWS_SECRET_ACCESS_KEY') or ''

--- a/lazyllm/tools/fs/supplier/s3.py
+++ b/lazyllm/tools/fs/supplier/s3.py
@@ -24,15 +24,15 @@ class S3FS(LazyLLMFSBase):
                  secret_key: Optional[str] = None,
                  endpoint_url: Optional[str] = None,
                  region_name: Optional[str] = None,
-                 auth: str = 'static',
+                 dynamic_auth: bool = False,
                  **storage_options):
-        if auth == 'dynamic':
+        if dynamic_auth:
             self._access_key = ''
             self._secret_key = ''
             self._endpoint_url = endpoint_url or None
             self._region_name = region_name or None
             self._s3_client = None
-            super().__init__(token='', base_url=base_url, auth='dynamic', **storage_options)
+            super().__init__(token='', base_url=base_url, dynamic_auth=True, **storage_options)
             return
         _ak = config['s3_access_key'] or os.environ.get('AWS_ACCESS_KEY_ID')
         access_key = access_key or token or _ak or ''

--- a/lazyllm/tools/fs/supplier/s3.py
+++ b/lazyllm/tools/fs/supplier/s3.py
@@ -18,7 +18,6 @@ except ImportError:
 
 
 class S3FS(LazyLLMFSBase):
-    _fs_protocol_key = 's3'
 
     def __init__(self, token: str = '', base_url: Optional[str] = None,
                  access_key: Optional[str] = None,

--- a/lazyllm/tools/fs/supplier/yuque.py
+++ b/lazyllm/tools/fs/supplier/yuque.py
@@ -14,10 +14,15 @@ _API_BASE = 'https://www.yuque.com/api/v2'
 
 
 class YuqueFS(LazyLLMFSBase):
+    _fs_protocol_key = 'yuque'
 
-    def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None, **storage_options):
-        token = token or config['yuque_token'] or os.environ.get('YUQUE_TOKEN') or ''
-        super().__init__(token=token, base_url=base_url or _API_BASE, **storage_options)
+    def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
+                 auth: str = 'static', **storage_options):
+        if auth == 'dynamic':
+            token = ''
+        else:
+            token = token or config['yuque_token'] or os.environ.get('YUQUE_TOKEN') or ''
+        super().__init__(token=token, base_url=base_url or _API_BASE, auth=auth, **storage_options)
 
     def _setup_auth(self) -> None:
         self._session.headers.update({

--- a/lazyllm/tools/fs/supplier/yuque.py
+++ b/lazyllm/tools/fs/supplier/yuque.py
@@ -14,7 +14,6 @@ _API_BASE = 'https://www.yuque.com/api/v2'
 
 
 class YuqueFS(LazyLLMFSBase):
-    _fs_protocol_key = 'yuque'
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  auth: str = 'static', **storage_options):

--- a/lazyllm/tools/fs/supplier/yuque.py
+++ b/lazyllm/tools/fs/supplier/yuque.py
@@ -16,19 +16,22 @@ _API_BASE = 'https://www.yuque.com/api/v2'
 class YuqueFS(LazyLLMFSBase):
 
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
-                 auth: str = 'static', **storage_options):
-        if auth == 'dynamic':
+                 dynamic_auth: bool = False, **storage_options):
+        if dynamic_auth:
             token = ''
         else:
             token = token or config['yuque_token'] or os.environ.get('YUQUE_TOKEN') or ''
-        super().__init__(token=token, base_url=base_url or _API_BASE, auth=auth, **storage_options)
+        super().__init__(token=token, base_url=base_url or _API_BASE, dynamic_auth=dynamic_auth, **storage_options)
 
     def _setup_auth(self) -> None:
         self._session.headers.update({
-            'X-Auth-Token': self._secret_key,
             'Content-Type': 'application/json',
             'User-Agent': 'lazyllm-fs (https://github.com/LazyAGI/lazyllm)',
         })
+
+    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+        token = self._dynamic_token if self._dynamic_auth else self._secret_key
+        return {'X-Auth-Token': token} if token else None
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/yuque.py
+++ b/lazyllm/tools/fs/supplier/yuque.py
@@ -18,6 +18,8 @@ class YuqueFS(LazyLLMFSBase):
     def __init__(self, token: Optional[str] = None, base_url: Optional[str] = None,
                  dynamic_auth: bool = False, **storage_options):
         if dynamic_auth:
+            if token:
+                raise ValueError('token must be None when dynamic_auth=True')
             token = ''
         else:
             token = token or config['yuque_token'] or os.environ.get('YUQUE_TOKEN') or ''

--- a/lazyllm/tools/git/review/pre_analysis.py
+++ b/lazyllm/tools/git/review/pre_analysis.py
@@ -941,19 +941,38 @@ def _build_scoped_agent_tools(  # noqa: C901
         return search_in_files(pattern, path=clone_dir, max_results=max_results, root=clone_dir)
 
     def ask_deepwiki(question: str) -> str:
-        '''Ask DeepWiki a question about this repository's architecture or design.
-        Use for high-level questions about module responsibilities, design patterns,
-        or cross-module relationships that are hard to answer from local code alone.
-        Returns a plain text answer.
+        '''Ask DeepWiki a background question about this repository's architecture or design.
+
+        IMPORTANT — data may be 1-3 months stale. Use ONLY as background knowledge, NOT as
+        source of truth for current code. Treat answers as "possibly outdated context" and
+        always cross-verify against the actual diff and local code.
+
+        USE for:
+        - Understanding overall system architecture (module boundaries, layering, responsibilities)
+        - Learning design conventions or usage patterns of public/infrastructure modules
+        - Identifying potential architectural issues (wrong dependency direction, misuse of abstractions)
+        - Supplementing cross-module context not visible in the diff
+
+        DO NOT USE for:
+        - Verifying whether new/modified code in the diff is correct
+        - Determining current function/interface behavior, parameters, or implementation details
+        - Drawing definitive conclusions that depend on the latest code state
+
+        When using the answer, treat it as a hypothesis ("based on background knowledge, this may
+        violate the existing design") rather than a fact. Always verify with local code tools.
 
         Args:
-            question (str): The question to ask about the repository.
+            question (str): Architecture or design question about the repository (not about specific
+                diff correctness). Prefer questions about module roles, design patterns, or
+                cross-module relationships.
         '''
         if not owner_repo:
             return '(DeepWiki not configured for this repo)'
         lazyllm.LOG.info(f'  [Agent] DeepWiki ask: {question!r}')
         answer = _deepwiki_ask_cached(owner_repo, question, max_chars=2000)
-        return answer or '(no answer from DeepWiki)'
+        if not answer:
+            return '(no answer from DeepWiki)'
+        return f'[DeepWiki background knowledge — may be 1-3 months stale, verify with local code]\n{answer}'
 
     tools = [
         read_file_scoped, read_file_skeleton_scoped, read_files_batch,
@@ -1308,7 +1327,12 @@ def _arch_fill_batch_llm(
         title, focus = sec.get('title', ''), sec.get('focus', '')
         question = f'Explain the "{title}" aspect of this project: {focus}'
         answer = _deepwiki_ask_cached(owner_repo, question, max_chars=1200)
-        return f'\n\nDeepWiki reference:\n{answer}' if answer else ''
+        if not answer:
+            return ''
+        return (
+            f'\n\nDeepWiki background reference (may be 1-3 months stale — use as context only, '
+            f'verify against local code):\n{answer}'
+        )
 
     sections_block = '\n---\n'.join(
         f'### Section: {sec.get("title", "")}\nFocus: {sec.get("focus", "")}'
@@ -1617,7 +1641,12 @@ def analyze_repo_architecture(
         lazyllm.LOG.info(f'Fetching DeepWiki summary for {owner_repo}...')
         deepwiki_text = _fetch_deepwiki_summary(owner_repo)
         if deepwiki_text:
-            snapshot = snapshot + f'\n\n## DeepWiki Pre-indexed Summary\n{deepwiki_text}'
+            stale_notice = (
+                '\n\n> NOTE: DeepWiki data may be 1-3 months stale. '
+                'Use as background context only; verify against local code before drawing conclusions.'
+            )
+            header = '\n\n## DeepWiki Pre-indexed Summary (background reference — may be stale)'
+            snapshot = snapshot + header + stale_notice + '\n' + deepwiki_text
             lazyllm.LOG.info(f'DeepWiki summary injected ({len(deepwiki_text)} chars)')
         else:
             lazyllm.LOG.info(f'DeepWiki: no summary available for {owner_repo}')

--- a/lazyllm/tools/git/review/rounds.py
+++ b/lazyllm/tools/git/review/rounds.py
@@ -1231,7 +1231,30 @@ and compare their interfaces.
 - grep_callers: Find call sites to understand impact on callers
 - read_file_scoped: Read actual code (use line ranges for large files)
 - search_scoped: Find related patterns across the repo
+- ask_deepwiki (if available): Background knowledge about repo architecture — see constraints below
 You may call multiple tools in a single round for parallel execution.
+
+## ask_deepwiki Usage Constraints (STRICT)
+ask_deepwiki data may be 1-3 months stale. Apply these rules without exception:
+
+ALLOWED — call ask_deepwiki ONLY for:
+  - Understanding overall module boundaries, layering, or responsibility division
+  - Learning design conventions or usage patterns of public/infrastructure modules
+  - Supplementing cross-module context not visible in the diff (e.g. "what does module X own?")
+  - Identifying potential architectural issues (wrong dependency direction, misuse of abstractions)
+
+FORBIDDEN — never call ask_deepwiki to:
+  - Verify whether new/modified code in the diff is correct
+  - Determine current function/interface behavior, parameters, or implementation details
+  - Draw definitive conclusions that depend on the latest code state
+
+When you receive a DeepWiki answer, you MUST:
+  1. Treat it as a hypothesis, not a fact (e.g. "based on background knowledge, this may violate...")
+  2. Cross-verify the claim using local tools (read_file_scoped, grep_callers, search_scoped)
+  3. Output a conservative judgment if local verification is inconclusive
+
+Priority: for cross-module calls, public module usage, or architecture consistency questions,
+consider ask_deepwiki BEFORE concluding from local code alone — but always verify locally.
 
 ## Strategy Hints
 - Read AGENTS.md first if it exists (project conventions and dynamic dispatch mechanisms)


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

为 Agent 的 Skill 系统引入 Cloud FS 支持，使 Skill 可以存储在飞书、Notion、Confluence 等云端文件系统中，并对 FS 基础设施做了若干 bug 修复和接口改进。

---

# 🎯 问题背景 / Problem Context

原有 `SkillManager` 只支持本地文件系统，Skill 文件必须存放在本地目录。在多用户、多机器的生产场景下，Skill 无法集中管理和共享。

此外，FS 层存在以下问题：
1. `__lazyllm_after_registry_hook__` 里 `name[:-3]` 导致 `protocol` 值截断错误（如 `FeishuFS` → `feish`）
2. `_ensure_token` 在 dynamic auth 路径下把 token 写入 `self._session.headers`，多用户并发时会互相覆盖
3. 各 supplier 手动维护 `_fs_protocol_key`，与 `protocol` 重复且不一致
4. `auth: str = 'static'` 接口不够直观

# 🔍 相关 Issue / Related Issue

无

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [x] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

```python
from lazyllm import fs
from lazyllm.tools import ReactAgent
from lazyllm.tools.agent.skill_manager import SkillManager
import lazyllm

# 1. 上传 skill 到飞书
feishu_fs = fs.feishu(space_id='...', user_refresh_token='auto')
feishu_fs.mkdir('/skills/python-helper')
feishu_fs.write_file('/skills/python-helper/SKILL', skill_content)

# 2. 验证 SkillManager 能加载
sm = SkillManager(dir='/skills', fs=feishu_fs)
assert 'python-helper' in sm._skills_index

# 3. 验证 ReactAgent 端到端
llm = lazyllm.OnlineChatModule(source='openai', ...)
agent = ReactAgent(llm, tools=[], skills=True, fs=feishu_fs, skills_dir='/skills')
result = agent('How do I sort a dict by value in Python?')
assert result
```

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

**场景一：单一云端 FS（飞书 Wiki）**

```python
from lazyllm import fs
from lazyllm.tools import ReactAgent

feishu_fs = fs.feishu(space_id='<wiki_space_id>', user_refresh_token='auto')

agent = ReactAgent(
    llm,
    tools=[],
    skills=True,
    fs=feishu_fs,
    skills_dir='/skills',   # 新增参数，指定云端 skill 根目录
)
result = agent('...')
```

**场景二：通过 `_FSRouter` 同时使用本地目录 + 飞书 Wiki**

`_FSRouter`（全局单例 `FS`）根据路径前缀自动路由到对应 FS 实例，路径格式为 `protocol@space_id:/path`（`@space_id` 可选）。`_FSRouter` 创建 supplier 时默认启用 `dynamic_auth=True`，token 通过 `dynamic_fs_config` 按请求注入，天然支持多用户并发。

```python
from lazyllm.tools.fs.client import FS   # 全局 _FSRouter 单例
from lazyllm.tools import ReactAgent

# skills_dir 同时包含本地路径和飞书路径，用逗号分隔
agent = ReactAgent(
    llm,
    tools=[],
    skills=True,
    fs=FS,
    skills_dir='/local/skills,feishu@<space_id>://skills',
    # ↑ 本地 /local/skills 走 LocalFileSystem
    # ↑ feishu@<space_id>://skills 自动实例化 FeishuFS 并路由
)
result = agent('...')
```

**场景三：dynamic auth（多用户并发）**

```python
from lazyllm.tools.fs.client import dynamic_fs_config

with dynamic_fs_config(feishu='<per_user_token>'):
    result = agent('...')
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# 各 supplier 手动维护 _fs_protocol_key，与 protocol 不一致
class FeishuFSBase(LazyLLMFSBase):
    _fs_protocol_key = 'feishu'   # 手动写

# hook 里截断错误
cls.protocol = name[:-3].lower()  # FeishuFS -> 'feish' ❌

# dynamic auth 把 token 写入共享 session
def _apply_access_token(self, token):
    self._session.headers.update({'Authorization': f'Bearer {token}'})  # 多用户竞争 ❌

# Agent 不支持指定云端 skill 目录
ReactAgent(llm, skills=True, fs=feishu_fs)  # skills_dir 无法传入 ❌

# _iter_skill_files 用纯文件名拼路径
skill_node = name          # 'SKILL'，不含路径前缀 ❌
subdirs.append(name)       # 'python-helper'，下一轮 ls 失败 ❌

# auth 参数语义不清晰
FeishuFS(..., auth='dynamic')
```

## After

```python
# hook 自动设置，无需手动维护
cls.protocol = cls._fs_protocol_key = name[:-2].lower()  # FeishuFS -> 'feishu' ✅

# dynamic auth 每次请求动态获取 header，不污染 session
def _get_auth_header(self):
    if self._dynamic_auth:
        return {'Authorization': f'Bearer {self._dynamic_token}'}  # per-request ✅
    return {'Authorization': f'Bearer {self._access_token}'} if self._access_token else None

def _apply_access_token(self, token):
    self._access_token = token  # 只缓存，不写 session ✅

# Agent 支持 skills_dir 参数
ReactAgent(llm, skills=True, fs=feishu_fs, skills_dir='/skills')  # ✅

# _iter_skill_files 正确拼接完整路径
full_path = name if '/' in name else self._fs_join(cur, basename)  # ✅

# 接口更清晰
FeishuFS(..., dynamic_auth=True)
```

# ⚠️ 注意事项 / Additional Notes

- Cloud FS 的 skill 文件名必须以 `SKILL` 开头（`CLOUD_SKILL_PREFIX`），本地 FS 仍使用 `SKILL.md`
- `dynamic_auth=True` 时，需在调用前通过 `dynamic_fs_config()` 或直接设置 `globals.config['dynamic_fs_auth']` 注入 per-request token
- `_fs_protocol_key` 现在由 `__lazyllm_after_registry_hook__` 自动设置，新增 supplier 无需手动声明

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**

- [x] Cursor（Kiro / Claude 4.6 Opus）
- [ ] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
我观察到，fs的所有supplier都手动写了_fs_protocol_key，能不能模仿LazyLLMOnlineBase，
给基类写一个__lazyllm_after_registry_hook__，实现子类的注册即添加_fs_protocol_key，
而不需要手动写
```

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

## **问题点 / Issues：**

AI 在实现 hook 时发现了一个预存 bug：`name[:-3]` 导致 `protocol` 值截断（`FeishuFS` → `feish`），顺带一并修复。初始输出正确完成了 hook 自动注册 `_fs_protocol_key` 的目标，但需要人工确认 `name[:-2]` 的正确性。

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
我发现一个很严重的bug，_ensure_token的时候，如果是_dynamic_auth，会通过
_apply_access_token把token设置给self，但这个操作是不能被允许的，因为这样会让
多用户无法同时使用，失去了dynamic_auth的价值。合理的做法是，仿照OnlineChatModule，
每次都重新获取header；在获取header的时候，如果是静态token调用函数获取token就
一次性获取；否则动态获取token，得到新的header
```

### **原因 / Reason：**

`_apply_access_token` 写入 `self._session.headers` 是共享状态，多用户并发时 token 会互相覆盖，dynamic auth 的设计目标完全失效。需要改为 per-request header 注入。

### 第二次修正 / Second Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
auth: str = 'static' 改成 dynamic_auth: bool = False 吧，简单清晰一点
```

### **原因 / Reason：**

字符串枚举接口不如 bool 直观，且容易拼写错误。

### 第三次修正 / Third Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
现在，请你帮我调试和验证lazyllm的react以飞书为fs，使用skill的能力。
目前skills目录是空的，请你借助feishufs，上传一些文档，作为skill，并验证可靠性
```

### **原因 / Reason：**

端到端验证时发现两个 bug：
1. `_iter_skill_files` 在 cloud FS 下用纯文件名（不含路径前缀）做子目录遍历和文件读取，导致 skill 始终加载为空
2. `LazyLLMAgentBase` 没有 `skills_dir` 参数，无法将云端 skill 目录传给 `SkillManager`

### 最终策略总结 / Final Strategy Summary

以「发现问题 → AI 修复 → 人工验证 → 再发现问题」的迭代方式推进。每轮 AI 输出后，人工通过实际运行（Python REPL + 飞书真实环境）验证，发现新问题后再给出精确的问题描述让 AI 修复。整体节奏：人工定义问题边界，AI 负责实现，人工负责验证。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`90%`
* 人工修改占比 / Human modifications：`10%`

**主要人工修改点 / Key Human Modifications：**

* [x] 逻辑修正 / Logic fixes（发现 dynamic auth session 竞争问题、`_iter_skill_files` 路径拼接问题）
* [ ] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [ ] 代码风格 / Code style
* [x] 架构调整 / Architecture adjustments（提出 `_get_auth_header` per-request 设计方向、`dynamic_auth: bool` 接口改进）

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```text
（无明确失败 prompt，问题均通过追加描述解决）
```

### ❌ 问题表现 / Issue Description

1. `_iter_skill_files` 修复：AI 首次实现时未考虑 cloud FS 的 `ls` 返回纯文件名（不含路径）的特性，导致子目录遍历和 skill 读取路径均错误，`list_skill()` 始终返回空。需要人工通过实际运行 + 调试输出才能定位。

2. `skills_dir` 参数缺失：AI 在修复 `_iter_skill_files` 时未主动发现 `LazyLLMAgentBase` 缺少 `skills_dir` 透传，需要人工运行报错后再补充。

### ✅ 改进后 Prompt / Improved Prompt

```text
现在，请你帮我调试和验证lazyllm的react以飞书为fs，使用skill的能力。
目前skills目录是空的，请你借助feishufs，上传一些文档，作为skill，并验证可靠性
```

# 🧩 可复用经验 / Reusable Patterns

* Prompt 模板 / Prompt template：描述 bug 时给出「当前行为 + 期望行为 + 设计意图」三要素，AI 修复准确率显著提升
* 常见坑 / Common pitfalls：cloud FS 的 `ls` 返回纯文件名，本地 FS 返回完整路径，两者行为不一致，凡是遍历 FS 的逻辑都需要显式拼接路径
* 推荐做法 / Recommended practices：新功能开发后立即在真实环境（而非 mock）端到端验证，能暴露 AI 未考虑到的 FS 行为差异
