### PR TITLE
add local review and cli

### DIFF
--- a/examples/git_review.py
+++ b/examples/git_review.py
@@ -1,32 +1,46 @@
 #!/usr/bin/env python3
-# Multi-round intelligent code review for GitHub PRs.
-# Usage:
-#   python examples/git_review.py --pr_number=1083
-#   LAZYLLM_RUN_FULL_REVIEW=1 python examples/git_review.py --pr_number=1083 --model=claude-opus-4-6
-#   LAZYLLM_RUN_FULL_REVIEW=1 LAZYLLM_POST_REVIEW_TO_GITHUB=1 \
-#       python examples/git_review.py --pr_number=1083 --model=claude-opus-4-6
+# Multi-round intelligent code review — Python API example.
 #
-# Required:
-#   --pr_number     PR number to review (no default, must be provided)
+# For most use cases, prefer the CLI commands:
+#
+#   Cloud PR review (GitHub):
+#     lazyllm review --pr 1083 --repo LazyAGI/LazyLLM --model claude-opus-4-6
+#     lazyllm review --pr 1083 --post          # also post comments to PR
+#
+#   Local git review:
+#     lazyllm review-local                     # review current branch vs main, output review.json
+#     lazyllm review-local --base develop --output my-review.json
+#     lazyllm review-local --no-uncommitted    # only committed changes
+#
+# This file demonstrates the Python API directly.
+#
+# Usage (cloud PR):
+#   python examples/git_review.py --pr_number=1083
+#   python examples/git_review.py --pr_number=1083 --model=claude-opus-4-6 --post
+#
+# Usage (local):
+#   python examples/git_review.py --local
+#   python examples/git_review.py --local --base develop --output my-review.json
+#
+# Required (cloud mode):
+#   --pr_number     PR number to review
 #
 # Optional:
 #   --repo          GitHub repo in "owner/name" format (default: LazyAGI/LazyLLM)
 #   --model         LLM model name (default: claude-opus-4-6)
-#   --base_url      LLM API base URL, e.g. a proxy URL (default: None, use official endpoint)
+#   --source        LLM source (default: claude)
+#   --base_url      LLM API base URL (default: None)
 #   --language      Review language: cn or en (default: cn)
-#   --max_history_prs  Max historical PRs to analyze for review spec (default: uses review() default of 20)
-#   --keep_clone    Keep cloned repo after review (flag, default: off)
-#   --clear_checkpoint  Clear checkpoint and start fresh (flag, default: off)
-#   --refresh_diff  Fetch latest PR head SHA and diff; rotate checkpoint if changed (flag, default: off)
-#   --resume_from   Resume from a specific stage: clone|arch|spec|pr_summary|r1|r2|r3|r4a|r4|final|upload
-#                   Stages before the specified one will load from cache (if available).
-#                   If a prior stage has no cache, a warning is printed and it re-computes.
-#
-# Environment variables (still supported):
-#   LAZYLLM_RUN_FULL_REVIEW=1       actually run the LLM review (otherwise just fetch PR info)
-#   LAZYLLM_POST_REVIEW_TO_GITHUB=1 post comments to GitHub
-#   LAZYLLM_ARCH_CACHE              path to arch doc cache JSON
-#   LAZYLLM_SPEC_CACHE              path to review spec cache JSON
+#   --post          Post comments to GitHub PR (flag)
+#   --keep_clone    Keep cloned repo after review (flag)
+#   --clear_checkpoint  Clear checkpoint and start fresh (flag)
+#   --refresh_diff  Fetch latest PR head SHA and diff (flag)
+#   --resume_from   Resume from a specific stage
+#   --local         Use local git mode instead of cloud PR
+#   --repo_path     Local repo path (default: .)
+#   --base          Base branch for local diff (default: main)
+#   --no_uncommitted  Exclude uncommitted changes (flag)
+#   --output        Output JSON path for local mode (default: review.json)
 
 import argparse
 import os
@@ -43,117 +57,155 @@ if os.path.isdir(_gh_bin):
 
 
 def _parse_args():
-    parser = argparse.ArgumentParser(description='Multi-round PR code review')
-    parser.add_argument('--pr_number', type=int, required=True,
-                        help='PR number to review (required)')
+    parser = argparse.ArgumentParser(description='Multi-round PR/local code review (Python API example)')
+    # cloud mode
+    parser.add_argument('--pr_number', type=int, default=None,
+                        help='PR number to review (required for cloud mode)')
     parser.add_argument('--source', default='claude',
-                        help='LLM source (default: claude; options: claude, openai, qwen, etc.)')
+                        help='LLM source (default: claude)')
     parser.add_argument('--repo', default='LazyAGI/LazyLLM',
                         help='GitHub repo in owner/name format (default: LazyAGI/LazyLLM)')
     parser.add_argument('--model', default='claude-opus-4-6',
                         help='LLM model name (default: claude-opus-4-6)')
     parser.add_argument('--base_url', default=None,
-                        help='LLM API base URL, e.g. a proxy URL (default: None, use official endpoint)')
+                        help='LLM API base URL (default: None)')
     parser.add_argument('--language', default='cn', choices=['cn', 'en'],
                         help='Review output language (default: cn)')
     parser.add_argument('--max_history_prs', type=int, default=None,
-                        help='Max historical PRs to analyze for review spec (default: review() default=20)')
+                        help='Max historical PRs to analyze for review spec')
     parser.add_argument('--keep_clone', action='store_true',
                         help='Keep cloned repo directory after review')
     parser.add_argument('--clear_checkpoint', action='store_true',
                         help='Clear checkpoint and start fresh')
     parser.add_argument('--refresh_diff', action='store_true',
-                        help='Fetch latest PR head SHA and diff; rotate checkpoint if changed. '
-                             'Without this flag, cached diff/SHA are reused as-is.')
+                        help='Fetch latest PR head SHA and diff')
     parser.add_argument('--resume_from', default=None,
                         choices=['clone', 'arch', 'spec', 'pr_summary',
                                  'r1', 'r2', 'r3', 'r4a', 'r4', 'final', 'upload'],
-                        help='Resume from a specific stage (clone/arch/spec/pr_summary/r1/r2/r3/r4a/r4/final/upload)')
+                        help='Resume from a specific stage')
+    parser.add_argument('--post', action='store_true',
+                        help='Post review comments to GitHub PR')
+    # local mode
+    parser.add_argument('--local', action='store_true',
+                        help='Use local git mode instead of cloud PR')
+    parser.add_argument('--repo_path', default='.',
+                        help='Local repo path (default: current directory)')
+    parser.add_argument('--base', default='main',
+                        help='Base branch for local diff (default: main)')
+    parser.add_argument('--no_uncommitted', action='store_true',
+                        help='Exclude uncommitted changes from diff')
+    parser.add_argument('--output', default='review.json',
+                        help='Output JSON path for local mode (default: review.json)')
     return parser.parse_args()
 
 
 def main():  # noqa C901
     args = _parse_args()
-    repo = args.repo
-    pr_number = args.pr_number
 
     from lazyllm.tools.git import Git, review
-
-    print(f'1. Creating Git backend for {repo} (token from env or gh CLI)...')
-    try:
-        backend = Git(backend='github', repo=repo)
-        print('   Backend ready.')
-    except ValueError as e:
-        print(f'   Failed: {e}')
-        return 1
-
-    print(f'2. Fetching PR #{pr_number} and diff via API...')
-    pr_res = backend.get_pull_request(pr_number)
-    if not pr_res.get('success'):
-        print(f'   Failed to get PR: {pr_res.get("message")}')
-        return 1
-    pr = pr_res['pr']
-    print(f'   PR #{pr.number}: {pr.title}')
-    print(f'   {pr.source_branch} -> {pr.target_branch}')
-
-    diff_res = backend.get_pr_diff(pr_number)
-    if not diff_res.get('success'):
-        print(f'   Failed to get diff: {diff_res.get("message")}')
-        return 1
-    diff_len = len(diff_res.get('diff', ''))
-    print(f'   Diff length: {diff_len} chars')
-
-    if os.environ.get('LAZYLLM_RUN_FULL_REVIEW') != '1':
-        print('3. Skipping full review (set LAZYLLM_RUN_FULL_REVIEW=1 to run).')
-        print('Done.')
-        return 0
 
     import lazyllm
     llm_kwargs = dict(source=args.source, model=args.model)
     if args.base_url:
         llm_kwargs['base_url'] = args.base_url
     llm = lazyllm.OnlineChatModule(**llm_kwargs)
-    post_to_github = os.environ.get('LAZYLLM_POST_REVIEW_TO_GITHUB') == '1'
-    arch_cache = os.environ.get('LAZYLLM_ARCH_CACHE') or None
-    spec_cache = os.environ.get('LAZYLLM_SPEC_CACHE') or None
 
-    print(f'3. Running multi-round review (model={args.model}, language={args.language})...')
-    if post_to_github:
-        print('   Will post line-level comments to PR Files changed.')
-    try:
-        resume_from = ReviewStage(args.resume_from) if args.resume_from else None
-        out = review(
-            pr_number,
-            repo=repo,
-            backend='github',
-            llm=llm,
-            post_to_github=post_to_github,
-            arch_cache_path=arch_cache,
-            review_spec_cache_path=spec_cache,
-            fetch_repo_code=True,
-            language=args.language,
-            keep_clone=args.keep_clone,
-            clear_checkpoint=args.clear_checkpoint,
-            resume_from=resume_from,
-            refresh_diff=args.refresh_diff,
-            **({'max_history_prs': args.max_history_prs} if args.max_history_prs is not None else {}),
-        )
-        print('--- Review result ---')
-        print(out.get('summary', out))
-        comments = out.get('comments', [])
-        print(f'   Total issues: {len(comments)}, posted: {out.get("comments_posted", 0)}')
-        for i, c in enumerate(comments[:10]):
-            cat = c.get('bug_category', '')
-            sev = c.get('severity', '')
-            prob = (c.get('problem') or '')[:60]
-            print(f'   [{i+1}] {c.get("path")} L{c.get("line")} [{sev}][{cat}] {prob}...')
-        if len(comments) > 10:
-            print(f'   ... and {len(comments) - 10} more')
-        if post_to_github and out.get('comments_posted', 0) > 0:
-            print('\n[Posted] Line-level comments posted to PR; check Files changed for inline comments.')
-    except Exception as e:
-        print(f'   Review failed: {e}, backtrace: {traceback.format_exc()}')
-        return 1
+    if args.local:
+        # --- local git mode ---
+        print(f'Running local review: {args.repo_path!r}, base={args.base}, '
+              f'uncommitted={"no" if args.no_uncommitted else "yes"}')
+        try:
+            out = review(
+                pr_number=0,
+                backend='local',
+                llm=llm,
+                post_to_github=False,
+                fetch_repo_code=False,
+                language=args.language,
+                clear_checkpoint=args.clear_checkpoint,
+                output_path=args.output,
+                repo_path=args.repo_path,
+                base=args.base,
+                include_uncommitted=not args.no_uncommitted,
+            )
+            print('--- Review result ---')
+            print(out.get('summary', out))
+            comments = out.get('comments', [])
+            print(f'Total issues: {len(comments)}')
+            print(f'Results written to: {args.output}')
+        except Exception as e:
+            print(f'Review failed: {e}, backtrace: {traceback.format_exc()}')
+            return 1
+    else:
+        # --- cloud PR mode ---
+        if not args.pr_number:
+            print('Error: --pr_number is required for cloud mode (or use --local for local git review)')
+            return 1
+        repo = args.repo
+        pr_number = args.pr_number
+
+        print(f'1. Creating Git backend for {repo}...')
+        try:
+            backend = Git(backend='github', repo=repo)
+            print('   Backend ready.')
+        except ValueError as e:
+            print(f'   Failed: {e}')
+            return 1
+
+        print(f'2. Fetching PR #{pr_number} and diff via API...')
+        pr_res = backend.get_pull_request(pr_number)
+        if not pr_res.get('success'):
+            print(f'   Failed to get PR: {pr_res.get("message")}')
+            return 1
+        pr = pr_res['pr']
+        print(f'   PR #{pr.number}: {pr.title}')
+        print(f'   {pr.source_branch} -> {pr.target_branch}')
+
+        diff_res = backend.get_pr_diff(pr_number)
+        if not diff_res.get('success'):
+            print(f'   Failed to get diff: {diff_res.get("message")}')
+            return 1
+        diff_len = len(diff_res.get('diff', ''))
+        print(f'   Diff length: {diff_len} chars')
+
+        arch_cache = os.environ.get('LAZYLLM_ARCH_CACHE') or None
+        spec_cache = os.environ.get('LAZYLLM_SPEC_CACHE') or None
+
+        print(f'3. Running multi-round review (model={args.model}, language={args.language})...')
+        if args.post:
+            print('   Will post line-level comments to PR Files changed.')
+        try:
+            resume_from = ReviewStage(args.resume_from) if args.resume_from else None
+            out = review(
+                pr_number,
+                repo=repo,
+                backend='github',
+                llm=llm,
+                post_to_github=args.post,
+                arch_cache_path=arch_cache,
+                review_spec_cache_path=spec_cache,
+                fetch_repo_code=True,
+                language=args.language,
+                keep_clone=args.keep_clone,
+                clear_checkpoint=args.clear_checkpoint,
+                resume_from=resume_from,
+                refresh_diff=args.refresh_diff,
+                **({'max_history_prs': args.max_history_prs} if args.max_history_prs is not None else {}),
+            )
+            print('--- Review result ---')
+            print(out.get('summary', out))
+            comments = out.get('comments', [])
+            print(f'   Total issues: {len(comments)}, posted: {out.get("comments_posted", 0)}')
+            for i, c in enumerate(comments[:10]):
+                cat = c.get('bug_category', '')
+                sev = c.get('severity', '')
+                prob = (c.get('problem') or '')[:60]
+                print(f'   [{i+1}] {c.get("path")} L{c.get("line")} [{sev}][{cat}] {prob}...')
+            if len(comments) > 10:
+                print(f'   ... and {len(comments) - 10} more')
+        except Exception as e:
+            print(f'   Review failed: {e}, backtrace: {traceback.format_exc()}')
+            return 1
 
     print('Done.')
     return 0

--- a/lazyllm/cli/main.py
+++ b/lazyllm/cli/main.py
@@ -4,11 +4,13 @@ try:
     from deploy import deploy
     from run import run
     from skills import skills
+    from review import review, review_local
 except ImportError:
     from .install import install
     from .deploy import deploy
     from .run import run
     from .skills import skills
+    from .review import review, review_local
 import logging
 
 def main():
@@ -19,7 +21,9 @@ def main():
                       '  lazyllm skills init\n  lazyllm skills list\n  lazyllm skills info <name>\n'
                       '  lazyllm skills delete <name>\n  lazyllm skills add <path> [-n NAME] [--dir DIR]\n'
                       '  lazyllm skills import <path> [--dir DIR] [--names a,b,c] [--overwrite]\n'
-                      '  lazyllm skills install --agent <name> [--project] [--timeout SEC]\n')
+                      '  lazyllm skills install --agent <name> [--project] [--timeout SEC]\n'
+                      '  lazyllm review --pr <number> [--repo owner/name] [--model ...] [--post] ...\n'
+                      '  lazyllm review-local [--repo-path .] [--base main] [--output review.json] ...\n')
         sys.exit(1)
 
     if len(sys.argv) <= 1: exit()
@@ -33,6 +37,10 @@ def main():
         run(commands)
     elif sys.argv[1] == 'skills':
         skills(commands)
+    elif sys.argv[1] == 'review':
+        review(commands)
+    elif sys.argv[1] == 'review-local':
+        review_local(commands)
     else:
         exit()
 

--- a/lazyllm/cli/review.py
+++ b/lazyllm/cli/review.py
@@ -1,0 +1,155 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import argparse
+import sys
+import traceback
+
+
+def _build_review_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='lazyllm review',
+        description='Multi-round AI code review for cloud-hosted PRs (GitHub, GitLab, Gitee, GitCode).',
+    )
+    p.add_argument('--pr', type=int, required=True, metavar='NUMBER',
+                   help='PR number to review (required)')
+    p.add_argument('--repo', default='LazyAGI/LazyLLM', metavar='OWNER/NAME',
+                   help='Repository in owner/name format (default: LazyAGI/LazyLLM)')
+    p.add_argument('--backend', default=None,
+                   choices=['github', 'gitlab', 'gitee', 'gitcode'],
+                   help='Git backend (default: auto-detect from repo or env)')
+    p.add_argument('--source', default='claude',
+                   help='LLM source, e.g. claude, openai, qwen (default: claude)')
+    p.add_argument('--model', default='claude-opus-4-6',
+                   help='LLM model name (default: claude-opus-4-6)')
+    p.add_argument('--base-url', default=None, metavar='URL',
+                   help='LLM API base URL, e.g. a proxy URL (default: official endpoint)')
+    p.add_argument('--language', default='cn', choices=['cn', 'en'],
+                   help='Review output language (default: cn)')
+    p.add_argument('--post', action='store_true',
+                   help='Post review comments back to the PR (default: off)')
+    p.add_argument('--keep-clone', action='store_true',
+                   help='Keep cloned repo directory after review')
+    p.add_argument('--clear-checkpoint', action='store_true',
+                   help='Clear checkpoint and start fresh')
+    p.add_argument('--refresh-diff', action='store_true',
+                   help='Fetch latest PR head SHA and diff; rotate checkpoint if changed')
+    p.add_argument('--resume-from', default=None,
+                   choices=['clone', 'arch', 'spec', 'pr_summary', 'r1', 'r2', 'r3', 'r4a', 'r4', 'final', 'upload'],
+                   metavar='STAGE',
+                   help='Resume from a specific stage: clone|arch|spec|pr_summary|r1|r2|r3|final|upload')
+    p.add_argument('--max-history-prs', type=int, default=None, metavar='N',
+                   help='Max historical PRs to analyze for review spec (default: 20)')
+    p.add_argument('--arch-cache', default=None, metavar='PATH',
+                   help='Path to architecture doc cache JSON')
+    p.add_argument('--spec-cache', default=None, metavar='PATH',
+                   help='Path to review spec cache JSON')
+    return p
+
+
+def _build_review_local_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog='lazyllm review-local',
+        description='Multi-round AI code review for a local git repository. '
+                    'Diffs current branch against base using git merge-base, '
+                    'so only changes introduced by this branch are reviewed. '
+                    'Results are written to a JSON file.',
+    )
+    p.add_argument('--repo-path', default='.', metavar='PATH',
+                   help='Path to local git repository (default: current directory)')
+    p.add_argument('--base', default='main', metavar='BRANCH',
+                   help='Base branch to diff against (default: main)')
+    p.add_argument('--no-uncommitted', action='store_true',
+                   help='Exclude uncommitted (staged + working tree) changes from diff (default: include)')
+    p.add_argument('--source', default='claude',
+                   help='LLM source, e.g. claude, openai, qwen (default: claude)')
+    p.add_argument('--model', default='claude-opus-4-6',
+                   help='LLM model name (default: claude-opus-4-6)')
+    p.add_argument('--base-url', default=None, metavar='URL',
+                   help='LLM API base URL, e.g. a proxy URL (default: official endpoint)')
+    p.add_argument('--language', default='cn', choices=['cn', 'en'],
+                   help='Review output language (default: cn)')
+    p.add_argument('--output', default='review.json', metavar='PATH',
+                   help='Output JSON file path (default: review.json)')
+    p.add_argument('--clear-checkpoint', action='store_true',
+                   help='Clear checkpoint and start fresh')
+    return p
+
+
+def review(commands):
+    parser = _build_review_parser()
+    args = parser.parse_args(commands)
+
+    import lazyllm
+    from lazyllm.tools.git.review.checkpoint import ReviewStage
+
+    llm_kwargs = dict(source=args.source, model=args.model)
+    if args.base_url:
+        llm_kwargs['base_url'] = args.base_url
+    llm = lazyllm.OnlineChatModule(**llm_kwargs)
+
+    resume_from = ReviewStage(args.resume_from) if args.resume_from else None
+
+    print(f'Reviewing PR #{args.pr} on {args.repo} (model={args.model}, language={args.language})...')  # noqa print
+    try:
+        from lazyllm.tools.git import review as _review
+        out = _review(
+            pr_number=args.pr,
+            repo=args.repo,
+            backend=args.backend,
+            llm=llm,
+            post_to_github=args.post,
+            arch_cache_path=args.arch_cache,
+            review_spec_cache_path=args.spec_cache,
+            fetch_repo_code=True,
+            language=args.language,
+            keep_clone=args.keep_clone,
+            clear_checkpoint=args.clear_checkpoint,
+            resume_from=resume_from,
+            refresh_diff=args.refresh_diff,
+            **({'max_history_prs': args.max_history_prs} if args.max_history_prs is not None else {}),
+        )
+        print('--- Review result ---')  # noqa print
+        print(out.get('summary', ''))  # noqa print
+        comments = out.get('comments', [])
+        print(f'Total issues: {len(comments)}, posted: {out.get("comments_posted", 0)}')  # noqa print
+    except Exception as e:
+        print(f'Review failed: {e}\n{traceback.format_exc()}', file=sys.stderr)  # noqa print
+        sys.exit(1)
+
+
+def review_local(commands):
+    parser = _build_review_local_parser()
+    args = parser.parse_args(commands)
+
+    import lazyllm
+
+    llm_kwargs = dict(source=args.source, model=args.model)
+    if args.base_url:
+        llm_kwargs['base_url'] = args.base_url
+    llm = lazyllm.OnlineChatModule(**llm_kwargs)
+
+    print(f'Reviewing local repo at {args.repo_path!r} '  # noqa print
+          f'(base={args.base}, uncommitted={"no" if args.no_uncommitted else "yes"}, '
+          f'model={args.model}, language={args.language})...')
+    try:
+        from lazyllm.tools.git import review as _review
+        out = _review(
+            pr_number=0,
+            backend='local',
+            llm=llm,
+            post_to_github=False,
+            fetch_repo_code=False,
+            language=args.language,
+            clear_checkpoint=args.clear_checkpoint,
+            output_path=args.output,
+            repo_path=args.repo_path,
+            base=args.base,
+            include_uncommitted=not args.no_uncommitted,
+        )
+        print('--- Review result ---')  # noqa print
+        print(out.get('summary', ''))  # noqa print
+        comments = out.get('comments', [])
+        print(f'Total issues: {len(comments)}')  # noqa print
+        print(f'Results written to: {args.output}')  # noqa print
+    except Exception as e:
+        print(f'Review failed: {e}\n{traceback.format_exc()}', file=sys.stderr)  # noqa print
+        sys.exit(1)

--- a/lazyllm/docs/tools/git.py
+++ b/lazyllm/docs/tools/git.py
@@ -1048,3 +1048,143 @@ _add_review_example('analyze_historical_reviews', '''\
 >>> spec = analyze_historical_reviews(backend, llm, cache_path='/tmp/spec.json', max_prs=30)
 >>> print(spec)
 ''')
+
+# ---------------------------------------------------------------------------
+# LocalGit
+# ---------------------------------------------------------------------------
+try:
+    _local_mod = importlib.import_module('lazyllm.tools.git.supplier.local')
+except ImportError:
+    _local_mod = None
+
+if _local_mod is not None:
+    _add_local_chinese = functools.partial(utils.add_chinese_doc, module=_local_mod)
+    _add_local_english = functools.partial(utils.add_english_doc, module=_local_mod)
+    _add_local_example = functools.partial(utils.add_example, module=_local_mod)
+else:
+    def _add_local_chinese(*args, **kwargs): pass  # noqa: E704
+    def _add_local_english(*args, **kwargs): pass  # noqa: E704
+    def _add_local_example(*args, **kwargs): pass  # noqa: E704
+
+_add_local_chinese('LocalGit', '''\
+本地 Git 仓库后端，无需云端 Token 或网络访问，直接对本地分支做 AI code review。
+
+diff 计算方式：
+    git diff $(git merge-base <base> HEAD) [HEAD]
+
+只包含当前分支引入的变更，<base> 上已有的提交不会出现在 diff 中。
+
+与云端后端（GitHub/GitLab 等）的区别：
+- 无需 Token，无网络依赖
+- 不支持将评审评论发布到平台（post_to_github 自动禁用）
+- 使用本地工作树作为 file-skeleton 提取的 clone_dir
+- checkpoint 路径格式：``cache/<origin_repo>/local/<branch>/checkpoint.json``，
+  与云端模式共享同一 ``<origin_repo>`` 目录下的 arch/spec 缓存
+
+Args:
+    repo_path (str): 本地 git 仓库路径，默认为当前目录 ``'.'``。
+    base (str): diff 基准分支或 commit，默认 ``'main'``。
+    include_uncommitted (bool): 为 ``True``（默认）时，通过 ``git diff <merge-base>`` 包含
+        staged 和 working-tree 的未提交变更；为 ``False`` 时，通过 ``git diff <merge-base> HEAD``
+        只包含已提交的变更。
+    return_trace (bool): 是否返回调用追踪信息，默认 ``False``。
+''')
+
+_add_local_english('LocalGit', '''\
+Local-repository Git backend. Requires no cloud token or network access; reviews a local branch directly.
+
+Diff is computed as:
+    git diff $(git merge-base <base> HEAD) [HEAD]
+
+Only changes introduced by the current branch are included — commits already present on <base> are excluded.
+
+Differences from cloud backends (GitHub / GitLab / …):
+- No token or network required.
+- Posting review comments back to a platform is not supported (post_to_github is disabled automatically).
+- The local working tree is used as the clone_dir for file-skeleton extraction.
+- Checkpoint path format: ``cache/<origin_repo>/local/<branch>/checkpoint.json``;
+  arch/spec caches under ``<origin_repo>`` are shared with cloud-mode reviews of the same repo.
+
+Args:
+    repo_path (str): Path to the local git repository. Defaults to ``'.'`` (current directory).
+    base (str): Base branch or commit to diff against. Defaults to ``'main'``.
+    include_uncommitted (bool): When ``True`` (default), staged and working-tree changes are included
+        via ``git diff <merge-base>``; when ``False``, only committed changes are included
+        via ``git diff <merge-base> HEAD``.
+    return_trace (bool): Whether to return call trace. Defaults to ``False``.
+''')
+
+_add_local_example('LocalGit', '''\
+>>> from lazyllm.tools.git import Git
+>>> # local mode — no token needed
+>>> backend = Git(backend='local', repo_path='.', base='main')
+>>> diff = backend.get_pr_diff(0)
+>>> print(diff['diff'][:500])
+''')
+
+_add_local_chinese('LocalGit.get_origin_repo', '''\
+从 ``git remote -v`` 解析 origin 远端 URL，返回 ``owner/repo`` 格式的仓库标识。
+
+用于推断 checkpoint 和 arch/spec 缓存的存储路径，使本地模式与云端模式共享同一缓存目录。
+
+支持的 URL 格式：
+- HTTPS：``https://github.com/owner/repo.git``
+- SSH：``git@github.com:owner/repo.git``
+
+若无 origin 远端或解析失败，fallback 为项目根目录名（``os.path.basename(repo_path)``）。
+
+Returns:
+    str: ``owner/repo`` 格式的仓库标识，或 fallback 的目录名。
+''')
+
+_add_local_english('LocalGit.get_origin_repo', '''\
+Parse the origin remote URL from ``git remote -v`` and return a ``owner/repo`` repository identifier.
+
+Used to derive the storage path for checkpoints and arch/spec caches, so that local-mode reviews
+share the same cache directory as cloud-mode reviews of the same repository.
+
+Supported URL formats:
+- HTTPS: ``https://github.com/owner/repo.git``
+- SSH: ``git@github.com:owner/repo.git``
+
+Falls back to the project root directory name (``os.path.basename(repo_path)``) if no origin remote
+exists or the URL cannot be parsed.
+
+Returns:
+    str: Repository identifier in ``owner/repo`` format, or the fallback directory name.
+''')
+
+_add_local_example('LocalGit.get_origin_repo', '''\
+>>> from lazyllm.tools.git import Git
+>>> backend = Git(backend='local', repo_path='/path/to/lazyllm')
+>>> backend.get_origin_repo()
+... 'LazyAGI/LazyLLM'
+''')
+
+_add_local_chinese('LocalGit.add_issue_comment', '''\
+本地模式不支持向平台发布评论，调用此方法始终返回失败。
+
+Args:
+    number (int): 占位参数，本地模式无意义。
+    body (str): 占位参数，本地模式无意义。
+
+Returns:
+    dict: ``{'success': False, 'message': 'add_issue_comment is not supported in local mode'}``
+''')
+
+_add_local_english('LocalGit.add_issue_comment', '''\
+Not supported in local mode. Always returns a failure response.
+
+Args:
+    number (int): Placeholder; unused in local mode.
+    body (str): Placeholder; unused in local mode.
+
+Returns:
+    dict: ``{'success': False, 'message': 'add_issue_comment is not supported in local mode'}``
+''')
+
+_add_local_example('LocalGit.add_issue_comment', '''\
+>>> backend = Git(backend='local', repo_path='.')
+>>> backend.add_issue_comment(0, 'hello')
+... {'success': False, 'message': 'add_issue_comment is not supported in local mode'}
+''')

--- a/lazyllm/tools/git/__init__.py
+++ b/lazyllm/tools/git/__init__.py
@@ -9,6 +9,7 @@ from .supplier.github import GitHub
 from .supplier.gitlab import GitLab
 from .supplier.gitee import Gitee
 from .supplier.gitcode import GitCode
+from .supplier.local import LocalGit
 from .review import review, analyze_repo_architecture, analyze_historical_reviews
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     'GitLab',
     'Gitee',
     'GitCode',
+    'LocalGit',
     'review',
     'analyze_repo_architecture',
     'analyze_historical_reviews',

--- a/lazyllm/tools/git/client.py
+++ b/lazyllm/tools/git/client.py
@@ -138,7 +138,19 @@ config.add('git_backend', str, None, 'GIT_BACKEND',
 class Git:
     def __new__(cls, backend: Optional[str] = None, token: Optional[str] = None, repo: Optional[str] = None,
                 user: Optional[str] = None, api_base: Optional[str] = None, return_trace: bool = False,
+                app_id: Optional[str] = None, installation_id: Optional[int] = None,
+                private_key_pem: Optional[str] = None, private_key_path: Optional[str] = None,
+                repo_path: Optional[str] = None, base: Optional[str] = None,
+                include_uncommitted: bool = True,
                 ) -> LazyLLMGitBase:
+        if backend == 'local' or (repo_path is not None and not backend):
+            from .supplier.local import LocalGit
+            return LocalGit(
+                repo_path=repo_path or '.',
+                base=base or 'main',
+                include_uncommitted=include_uncommitted,
+                return_trace=return_trace,
+            )
         # 1. User passed backend -> use it
         # 2. If user passed repo, try to infer backend from URL
         if not backend and repo:
@@ -154,10 +166,17 @@ class Git:
         # 5. Default to github
         if not backend:
             backend = 'github'
-        # Resolve token (from arg, env, or gh) when backend is known
-        token = _resolve_token_for_backend(backend, token)
         # Normalize repo to owner/repo for backend APIs (full URL -> path only)
-        repo_path = _normalize_repo_to_path(repo) if repo else ''
-        return getattr(lazyllm.git, backend)(
-            token=token, repo=repo_path, user=user, api_base=api_base, return_trace=return_trace
-        )
+        repo_norm = _normalize_repo_to_path(repo) if repo else ''
+        kwargs = dict(repo=repo_norm, user=user, api_base=api_base, return_trace=return_trace)
+        if app_id and installation_id:
+            if backend != 'github':
+                raise ValueError(f'app_id/installation_id are only supported for GitHub, got backend={backend!r}')
+            kwargs.update(app_id=app_id, installation_id=installation_id)
+            if private_key_pem:
+                kwargs['private_key_pem'] = private_key_pem
+            if private_key_path:
+                kwargs['private_key_path'] = private_key_path
+        else:
+            kwargs['token'] = _resolve_token_for_backend(backend, token)
+        return getattr(lazyllm.git, backend)(**kwargs)

--- a/lazyllm/tools/git/review/checkpoint.py
+++ b/lazyllm/tools/git/review/checkpoint.py
@@ -298,13 +298,13 @@ class _ReviewCheckpoint:
         return d
 
     @staticmethod
-    def pr_dir(pr_number: int, repo: str) -> str:
+    def pr_dir(pr_number: Any, repo: str) -> str:
         d = os.path.join(_ReviewCheckpoint.repo_cache_dir(repo), str(pr_number))
         os.makedirs(d, exist_ok=True)
         return d
 
     @staticmethod
-    def default_path(pr_number: int, repo: str) -> str:
+    def default_path(pr_number: Any, repo: str) -> str:
         return os.path.join(_ReviewCheckpoint.pr_dir(pr_number, repo), 'checkpoint.json')
 
     # deprecated: use global_cache_dir() directly; will be removed in a future version

--- a/lazyllm/tools/git/review/output.py
+++ b/lazyllm/tools/git/review/output.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import json
+import os
+from typing import Any, Dict
+
+_FIX_GUIDE_INSTRUCTIONS = (
+    'You are reviewing AI-generated code review issues. For each issue:\n\n'
+    'RESPONSIBILITIES:\n'
+    '- Judge whether the issue is reliable (valid concern) or not reliable'
+    ' (misunderstanding, incorrect assumption, already fixed, or invalid constraint)\n'
+    '- If reliable, apply a concrete fix in code\n'
+    '- Do not skip any issue, even if duplicated or low quality\n\n'
+    'IMPORTANT RULES:\n'
+    '- Do not accept an issue just because "others said so"\n'
+    '- New architectural issues introduced by this change MUST be fixed\n'
+    '- Pre-existing issues should be: fixed if trivial, OR tracked via an issue (new or linked)\n'
+    '- Always verify whether the issue is already resolved before acting\n'
+    '- Avoid over-fixing: only modify code when the issue is valid and actionable\n\n'
+    'REQUIRED OUTPUT FORMAT (for each issue):\n'
+    '- Issue ID\n'
+    '- Judgment: Reliable / Not Reliable\n'
+    '- Reasoning\n'
+    '- Action: Fixed / Not Fixed / Not Applicable\n'
+    '- Fix Description (if applicable)\n\n'
+    'Group issues by category: correctness, performance, architecture, style, maintainability.\n'
+    'Every issue must be independently addressable. No issue may be omitted.\n\n'
+    'GOAL: All valid issues fixed. All invalid issues explicitly rejected with reasoning.'
+    ' Report is clear, complete, and auditable.'
+)
+
+
+def write_review_json(result: Dict[str, Any], path: str) -> None:
+    issues = []
+    for idx, c in enumerate(result.get('comments') or [], start=1):
+        if c.get('type') == 'meta':
+            continue
+        issues.append({
+            'id': idx,
+            'file': c.get('path', ''),
+            'line': c.get('line'),
+            'severity': c.get('severity', 'normal'),
+            'category': c.get('bug_category', 'maintainability'),
+            'problem': c.get('problem', ''),
+            'suggestion': c.get('suggestion', ''),
+        })
+
+    pr_info_raw = result.get('pr_info') or {}
+    output = {
+        'instructions': _FIX_GUIDE_INSTRUCTIONS,
+        'pr_info': {
+            'branch': pr_info_raw.get('source_branch', ''),
+            'base': pr_info_raw.get('target_branch', ''),
+            'summary': result.get('pr_summary', ''),
+        },
+        'stats': result.get('comment_stats') or _compute_stats(issues),
+        'issues': issues,
+    }
+
+    os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(output, f, ensure_ascii=False, indent=2)
+
+
+def _compute_stats(issues: list) -> Dict[str, int]:
+    stats: Dict[str, int] = {'total': len(issues), 'critical': 0, 'normal': 0, 'suggestion': 0}
+    for issue in issues:
+        sev = issue.get('severity', 'normal')
+        stats[sev] = stats.get(sev, 0) + 1
+    return stats

--- a/lazyllm/tools/git/review/rounds.py
+++ b/lazyllm/tools/git/review/rounds.py
@@ -173,7 +173,20 @@ or an error message that conflicts with the code). If you are unfamiliar with a 
 API (e.g. GitCode, Gitee, GitLab), do NOT guess its conventions based on other platforms.
 9. When suggesting "add error handling" or "add exception protection", first verify whether \
 the called function already handles exceptions internally. If the callee wraps its body in \
-try/except or returns a safe default, the caller does NOT need redundant protection.'''
+try/except or returns a safe default, the caller does NOT need redundant protection.
+10. Do NOT claim `except Exception` swallows `KeyboardInterrupt`, `SystemExit`, or \
+`GeneratorExit`. In Python 3, these inherit from `BaseException`, NOT `Exception`, so \
+`except Exception` does NOT catch them. Only flag broad exception handling if the code \
+uses `except BaseException` or bare `except:`.
+11. Do NOT report issues that static analysis tools (pyflakes, mypy, pylint, isort) already \
+catch reliably: undefined names / NameError, circular imports, unresolved references, \
+unreachable code, type errors detectable from signatures alone. These are out of scope for \
+a diff-level review — they will be caught by CI.
+12. Do NOT report a design choice as a bug or inconsistency unless you can cite a concrete \
+runtime failure, data corruption, or explicit contract violation that the choice causes. \
+Structural preferences (e.g. two commands vs one flag, composition vs inheritance, \
+separate modules vs merged) are the author's prerogative and must not be flagged without \
+evidence of actual harm.'''
 
 _R1_ISSUE_FIELDS = '''\
 For EVERY issue found, output a JSON object with:
@@ -290,7 +303,7 @@ def _extract_code_tags(
         max_focus=max_focus,
     )
     raw = _safe_llm_call_text(llm, prompt)
-    if not raw:
+    if not raw or not raw.strip():
         return {}
     parsed = _parse_json_with_repair(_extract_json_text(raw))
     return parsed if isinstance(parsed, dict) else {}
@@ -414,6 +427,18 @@ def _analyze_single_hunk(
     file_skeleton: str = '', code_tags: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     file_context = _read_file_context(clone_dir, path, new_start, new_start + new_count) if clone_dir else ''
+    # derive the last line number visible to LLM from file_context header
+    # "full file, N lines" → N; "excerpt lines S–E of T" → E
+    context_end_line: Optional[int] = None
+    if file_context:
+        first_line = file_context.split('\n', 1)[0]
+        m = re.search(r'full file,\s*(\d+)\s*lines', first_line)
+        if m:
+            context_end_line = int(m.group(1))
+        else:
+            m = re.search(r'excerpt lines\s*\d+\s*[–-]\s*(\d+)', first_line)
+            if m:
+                context_end_line = int(m.group(1))
     code_profile = _format_code_profile(code_tags) if code_tags else '(not available)'
     review_focus_block = _format_review_focus(code_tags) if code_tags else ''
     diff_budget = _r1_diff_budget(arch_snippet, spec_snippet, summary_snippet, agent_instructions,
@@ -446,8 +471,9 @@ def _analyze_single_hunk(
         density_rule=issue_density_rule(annotated_content),
     )
     items = _safe_llm_call(llm, prompt)
+    effective_end = max(new_start + actual_count, context_end_line or 0)
     return [n for item in items if (n := _normalize_comment_item(
-        item, new_start=new_start, end_line=new_start + actual_count, default_path=path,
+        item, new_start=new_start, end_line=effective_end, default_path=path,
     )) is not None]
 
 
@@ -518,10 +544,12 @@ def _assign_batch_item(
     item: Dict[str, Any],
     hunks: List[Tuple[int, int, str]],
     path: str,
+    context_end_line: Optional[int] = None,
 ) -> Optional[Tuple[int, Dict[str, Any]]]:
     for new_start, new_count, _ in hunks:
+        effective_end = max(new_start + new_count, context_end_line or 0)
         normalized = _normalize_comment_item(
-            item, new_start=new_start, end_line=new_start + new_count, default_path=path,
+            item, new_start=new_start, end_line=effective_end, default_path=path,
         )
         if normalized is not None:
             return new_start, normalized
@@ -574,11 +602,22 @@ def _analyze_hunk_batch(
         path=path, hunks_content='\n\n'.join(hunk_blocks), density_rule=issue_density_rule('\n'.join(hunk_blocks)),
     )
     items = _safe_llm_call(llm, prompt)
+    # derive context_end_line from file_context header (same logic as _analyze_single_hunk)
+    context_end_line: Optional[int] = None
+    if file_context:
+        first_line = file_context.split('\n', 1)[0]
+        m = re.search(r'full file,\s*(\d+)\s*lines', first_line)
+        if m:
+            context_end_line = int(m.group(1))
+        else:
+            m = re.search(r'excerpt lines\s*\d+\s*[–-]\s*(\d+)', first_line)
+            if m:
+                context_end_line = int(m.group(1))
     results: Dict[int, List[Dict[str, Any]]] = {s: [] for s, _, _ in hunks}
     for item in (items if isinstance(items, list) else []):
         if not isinstance(item, dict) or item.get('problem') is None:
             continue
-        assigned = _assign_batch_item(item, hunks, path)
+        assigned = _assign_batch_item(item, hunks, path, context_end_line=context_end_line)
         if assigned is not None:
             results[assigned[0]].append(assigned[1])
     return results
@@ -660,10 +699,12 @@ def _r1_task_batch(
     file_skeleton = _extract_file_skeleton(clone_dir, path) if clone_dir else ''
     first_hunk_content = hunks[idxs[0]][3] if idxs else ''
     code_tags: Dict[str, Any] = {}
-    try:
-        code_tags = _extract_code_tags(llm, file_skeleton, first_hunk_content[:1500])
-    except Exception as e:
-        lazyllm.LOG.warning(f'Round 1: code tag extraction failed for {path}: {e}')
+    # skip code tag extraction for trivially short files to avoid wasted LLM calls
+    if file_skeleton and len(file_skeleton.strip()) >= 50:
+        try:
+            code_tags = _extract_code_tags(llm, file_skeleton, first_hunk_content[:1500])
+        except Exception as e:
+            lazyllm.LOG.warning(f'Round 1: code tag extraction failed for {path}: {e}')
     uncached_idxs: List[int] = []
     for idx in idxs:
         _, new_start, new_count, _ = hunks[idx]
@@ -1353,6 +1394,16 @@ If it does, DISCARD the issue — the caller does NOT need redundant protection.
    - For "wrong API endpoint/field" claims: DISCARD unless the diff itself contains contradictory \
 evidence (e.g. a test, a docstring, or an error message that conflicts with the code). \
 Do NOT guess third-party API conventions based on other platforms.
+   - For "variable may be uninitialized / NameError / circular import / unresolved reference" \
+claims: DISCARD. These are reliably caught by static analysis tools (pyflakes, mypy, pylint) \
+and are out of scope for diff-level review.
+   - For "`except Exception` swallows KeyboardInterrupt/SystemExit" claims: DISCARD. In Python 3, \
+`KeyboardInterrupt` and `SystemExit` inherit from `BaseException`, not `Exception`. \
+`except Exception` does NOT catch them. Only flag if the code uses bare `except:` or \
+`except BaseException`.
+   - For "design inconsistency / should use X pattern instead of Y" claims: DISCARD unless \
+you can cite a concrete runtime failure, data corruption, or explicit contract violation \
+that the choice causes. Structural preferences are the author's prerogative.
 2. Find NEW issues that require cross-file or cross-function context to detect:
    - Interface inconsistencies (method signatures changed but callers not updated)
    - Abstraction violations (bypassing base class contracts)

--- a/lazyllm/tools/git/review/runner.py
+++ b/lazyllm/tools/git/review/runner.py
@@ -12,6 +12,7 @@ from .checkpoint import _ReviewCheckpoint, ReviewStage
 from .pre_analysis import _run_pre_analysis, _pre_round_pr_summary
 from .rounds import _run_four_rounds
 from .poster import _fetch_existing_pr_comments, _post_review_comments, _build_commentable_lines, _filter_commentable
+from .output import write_review_json
 from .utils import (
     _get_default_llm, _ensure_non_streaming_llm, _get_model_name,
     _get_head_sha_from_pr, _parse_unified_diff, _Progress,
@@ -140,6 +141,10 @@ def review(  # noqa: C901
     language: str = 'cn',
     keep_clone: bool = False,
     refresh_diff: bool = False,
+    output_path: Optional[str] = None,
+    repo_path: Optional[str] = None,
+    base: Optional[str] = None,
+    include_uncommitted: bool = True,
 ) -> Dict[str, Any]:
     try:
         import lazyllm.tools.git.review as _self_mod
@@ -147,8 +152,23 @@ def review(  # noqa: C901
     except Exception:
         original_review_code = ''
 
-    pr_dir = _ReviewCheckpoint.pr_dir(pr_number, repo)
-    ckpt_path = checkpoint_path or _ReviewCheckpoint.default_path(pr_number, repo)
+    backend_inst = Git(backend=backend, token=token, repo=repo, api_base=api_base,
+                       repo_path=repo_path, base=base, include_uncommitted=include_uncommitted)
+
+    # local mode: resolve checkpoint key from branch name before building paths
+    from ..supplier.local import LocalGit
+    _local_repo_path: Optional[str] = None
+    _ckpt_key: Any = pr_number  # used as the "pr identifier" for checkpoint paths
+    if isinstance(backend_inst, LocalGit):
+        post_to_github = False
+        fetch_repo_code = False
+        _local_repo_path = backend_inst.local_repo_path
+        # derive repo name from git remote origin so arch/spec cache is shared with cloud mode
+        repo = backend_inst.get_origin_repo()
+        branch = backend_inst._current_branch().replace('/', '_')
+        _ckpt_key = f'local/{branch}'
+        pr_dir = _ReviewCheckpoint.pr_dir(_ckpt_key, repo)
+    ckpt_path = checkpoint_path or _ReviewCheckpoint.default_path(_ckpt_key, repo)
     if clear_checkpoint:
         # clear_checkpoint takes priority over resume_from
         ckpt = _ReviewCheckpoint(ckpt_path)
@@ -159,9 +179,8 @@ def review(  # noqa: C901
     else:
         ckpt = _ReviewCheckpoint(ckpt_path, resume_from=resume_from)
 
-    prog_main = _Progress(f'Review PR #{pr_number} @ {repo}')
-
-    backend_inst = Git(backend=backend, token=token, repo=repo, api_base=api_base)
+    prog_main = _Progress(f'Review PR #{pr_number} @ {repo}' if not _local_repo_path
+                          else f'Review local branch {_ckpt_key.split("/", 1)[-1]} @ {repo}')
 
     # always need PR metadata for title/body
     pr_res = backend_inst.get_pull_request(pr_number)
@@ -248,6 +267,10 @@ def review(  # noqa: C901
         pr_dir=pr_dir, head_sha=head_sha,
     )
 
+    # local mode: use the local repo path directly as clone_dir for file skeleton extraction
+    if _local_repo_path and os.path.isdir(_local_repo_path):
+        clone_dir = _local_repo_path
+
     pr_summary = ckpt.get('pr_summary')
     if pr_summary is None:
         pr_summary = _pre_round_pr_summary(
@@ -291,8 +314,9 @@ def review(  # noqa: C901
         ckpt.mark_stage_done(ReviewStage.FINAL)
 
     # clean up only the clone subdirectory (not the whole pr_dir which contains checkpoint)
+    # local mode: clone_dir IS the user's repo, never delete it
     clone_subdir = os.path.join(pr_dir, 'clone')
-    if not keep_clone and os.path.isdir(clone_subdir):
+    if not keep_clone and not _local_repo_path and os.path.isdir(clone_subdir):
         shutil.rmtree(clone_subdir, ignore_errors=True)
 
     posted = 0
@@ -345,13 +369,19 @@ def review(  # noqa: C901
         'lint_issues_count': len(lint_issues),
     }
 
-    return {
+    result = {
         'summary': summary,
         'comments': final_comments,
         'comments_posted': posted,
         'comment_stats': stats,
         'pr_summary': pr_summary,
+        'pr_info': {'source_branch': getattr(pr, 'source_branch', ''),
+                    'target_branch': getattr(pr, 'target_branch', '')},
         'pr_design_doc': ckpt.get('pr_design_doc') or '',
         'original_review_code': original_review_code,
         'metrics': metrics,
     }
+    if output_path:
+        write_review_json(result, output_path)
+        lazyllm.LOG.info(f'Review result written to {output_path}')
+    return result

--- a/lazyllm/tools/git/review/utils.py
+++ b/lazyllm/tools/git/review/utils.py
@@ -195,10 +195,10 @@ JSON_OUTPUT_INSTRUCTION = (
     f'{JSON_END_MARKER}'
 )
 JSON_OBJ_OUTPUT_INSTRUCTION = (
-    f'Wrap your JSON object with exactly these delimiters (no other text outside them):\n'
-    f'{JSON_START_MARKER}\n'
-    f'{{ ... }}\n'
-    f'{JSON_END_MARKER}'
+    'Wrap your JSON object with exactly these delimiters (no other text outside them):\n'
+    + JSON_START_MARKER + '\n'
+    '{{...}}\n'
+    + JSON_END_MARKER
 )
 
 
@@ -406,10 +406,12 @@ def _normalize_comment_item(
         # Allow a generous tolerance: LLM may reference lines slightly outside the hunk
         # (e.g. from file_context). Hard-reject only clearly out-of-range lines.
         hunk_size = max(end_line - new_start, 1)
-        tolerance = max(50, hunk_size // 2)
-        if not (new_start - tolerance <= line < end_line + tolerance):
+        tolerance = max(50, hunk_size // 4)
+        low = max(1, new_start - tolerance)
+        high = end_line + tolerance
+        if not (low <= line < high):
             lazyllm.LOG.info(
-                f'[NORMALIZE_SKIP] line={line} out of range [{new_start - tolerance}, {end_line + tolerance}): '
+                f'[NORMALIZE_SKIP] line={line} out of range [{low}, {high}): '
                 f'{str(item)[:200]}'
             )
             return None

--- a/lazyllm/tools/git/supplier/github.py
+++ b/lazyllm/tools/git/supplier/github.py
@@ -1,16 +1,54 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
+import os
+import time
 from typing import Any, Dict, List, Optional
 
 import requests
+from lazyllm import config
+from lazyllm.thirdparty import jwt
 
 from ..base import LazyLLMGitBase, PrInfo, ReviewCommentInfo, _sanitize_path
 
+config.add('github_app_private_key_path', str,
+           os.path.expanduser('~/.config/lazyllm/github-app-private-key.pem'),
+           'GITHUB_APP_PRIVATE_KEY_PATH',
+           description='Path to GitHub App private key PEM file for App authentication.')
+
+
+def _get_installation_token(app_id: str, private_key_pem: str, installation_id: int,
+                            api_base: str = 'https://api.github.com') -> str:
+    now = int(time.time())
+    payload = {'iat': now - 60, 'exp': now + 600, 'iss': str(app_id)}
+    j = jwt.encode(payload, private_key_pem, algorithm='RS256')
+    r = requests.post(
+        f'{api_base}/app/installations/{installation_id}/access_tokens',
+        headers={'Authorization': f'Bearer {j}', 'Accept': 'application/vnd.github.v3+json'},
+        timeout=30,
+    )
+    if r.status_code not in (200, 201):
+        raise RuntimeError(f'Failed to get installation token: {r.status_code} {r.text}')
+    return r.json()['token']
+
 
 class GitHub(LazyLLMGitBase):
-    def __init__(self, token: str, repo: Optional[str] = None, user: Optional[str] = None,
-                 api_base: Optional[str] = None, return_trace: bool = False):
+    def __init__(self, token: Optional[str] = None, repo: Optional[str] = None, user: Optional[str] = None,
+                 api_base: Optional[str] = None, return_trace: bool = False,
+                 app_id: Optional[str] = None, installation_id: Optional[int] = None,
+                 private_key_pem: Optional[str] = None, private_key_path: Optional[str] = None):
+        if app_id and installation_id:
+            pem = private_key_pem
+            if not pem:
+                path = private_key_path or config['github_app_private_key_path']
+                with open(path, 'r') as f:
+                    pem = f.read()
+            resolved_token = _get_installation_token(app_id, pem, installation_id,
+                                                     api_base or 'https://api.github.com')
+        else:
+            if not token:
+                raise ValueError('Provide either token or (app_id + installation_id) for GitHub App auth.')
+            resolved_token = token
         super().__init__(
-            token=token,
+            token=resolved_token,
             repo=repo,
             api_base=api_base or 'https://api.github.com',
             user=user,

--- a/lazyllm/tools/git/supplier/local.py
+++ b/lazyllm/tools/git/supplier/local.py
@@ -21,6 +21,23 @@ def _git(args: List[str], cwd: str, timeout: int = 30) -> str:
 
 
 class LocalGit(LazyLLMGitBase):
+    # Git backend for local repositories. Produces a diff by running
+    #   git diff $(git merge-base <base> HEAD) [HEAD]
+    # so only changes introduced by the current branch are reviewed —
+    # commits already present on <base> are excluded.
+    #
+    # Unlike cloud backends (GitHub/GitLab/…), LocalGit:
+    #   - requires no token or network access
+    #   - does not support posting review comments back to a PR
+    #   - uses the local working tree as the "clone dir" for file-skeleton extraction
+    #
+    # Args:
+    #   repo_path:           path to the local git repository (default: current directory)
+    #   base:                branch/commit to diff against (default: 'main')
+    #   include_uncommitted: when True (default), staged and working-tree changes are
+    #                        included via `git diff <merge-base>`; when False, only
+    #                        committed changes are included via `git diff <merge-base> HEAD`
+    #   return_trace:        passed through to LazyLLMGitBase for debug tracing
     def __init__(self, repo_path: str = '.', base: str = 'main',
                  include_uncommitted: bool = True, return_trace: bool = False):
         super().__init__(token='', repo='', api_base='', return_trace=return_trace)
@@ -30,6 +47,7 @@ class LocalGit(LazyLLMGitBase):
 
     @property
     def local_repo_path(self) -> str:
+        # Absolute path to the local repository root.
         return self._repo_path
 
     def _merge_base(self) -> str:

--- a/lazyllm/tools/git/supplier/local.py
+++ b/lazyllm/tools/git/supplier/local.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import os
+import re
+import subprocess
+from typing import Any, Dict, List, Optional
+
+from ..base import LazyLLMGitBase, PrInfo
+
+
+def _git(args: List[str], cwd: str, timeout: int = 30) -> str:
+    try:
+        out = subprocess.run(['git'] + args, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+    except subprocess.TimeoutExpired as e:
+        if e.process is not None:
+            e.process.kill()
+            e.process.communicate()
+        raise RuntimeError(f'git {" ".join(args)} timed out after {timeout}s')
+    if out.returncode != 0:
+        raise RuntimeError(f'git {" ".join(args)} failed: {out.stderr.strip() or out.stdout.strip() or "(no output)"}')
+    return out.stdout.strip()
+
+
+class LocalGit(LazyLLMGitBase):
+    def __init__(self, repo_path: str = '.', base: str = 'main',
+                 include_uncommitted: bool = True, return_trace: bool = False):
+        super().__init__(token='', repo='', api_base='', return_trace=return_trace)
+        self._repo_path = os.path.abspath(repo_path)
+        self._base = base
+        self._include_uncommitted = include_uncommitted
+
+    @property
+    def local_repo_path(self) -> str:
+        return self._repo_path
+
+    def _merge_base(self) -> str:
+        return _git(['merge-base', self._base, 'HEAD'], cwd=self._repo_path)
+
+    def _current_branch(self) -> str:
+        try:
+            return _git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd=self._repo_path)
+        except RuntimeError:
+            return 'HEAD'
+
+    def get_origin_repo(self) -> str:
+        # parse "owner/repo" from git remote -v origin URL
+        # supports https://github.com/owner/repo.git and git@github.com:owner/repo.git
+        try:
+            out = _git(['remote', '-v'], cwd=self._repo_path)
+        except RuntimeError:
+            return os.path.basename(self._repo_path)
+        for line in out.splitlines():
+            if not line.startswith('origin'):
+                continue
+            url = line.split()[1] if len(line.split()) >= 2 else ''
+            url = re.sub(r'\.git$', '', url)
+            m = re.match(r'https?://[^/]+/(.+)', url)
+            if m:
+                return m.group(1)
+            m = re.match(r'git@[^:]+:(.+)', url)
+            if m:
+                return m.group(1)
+        return os.path.basename(self._repo_path)
+
+    def get_pull_request(self, number: int) -> Dict[str, Any]:
+        branch = self._current_branch()
+        return {
+            'success': True,
+            'pr': PrInfo(
+                number=0,
+                title=f'Local review: {branch} -> {self._base}',
+                state='open',
+                body='',
+                source_branch=branch,
+                target_branch=self._base,
+                html_url='',
+            ),
+        }
+
+    def get_pr_diff(self, number: int) -> Dict[str, Any]:
+        try:
+            merge_base = self._merge_base()
+            if self._include_uncommitted:
+                diff = _git(['diff', merge_base], cwd=self._repo_path, timeout=60)
+            else:
+                diff = _git(['diff', merge_base, 'HEAD'], cwd=self._repo_path, timeout=60)
+            return {'success': True, 'diff': diff + '\n' if diff and not diff.endswith('\n') else diff}
+        except RuntimeError as e:
+            return {'success': False, 'message': str(e)}
+        except subprocess.TimeoutExpired:
+            return {'success': False, 'message': 'git diff timed out'}
+
+    def list_review_comments(self, number: int) -> Dict[str, Any]:
+        return {'success': True, 'comments': []}
+
+    def list_issue_comments(self, number: int) -> Dict[str, Any]:
+        return {'success': True, 'comments': []}
+
+    def _not_supported(self, op: str) -> Dict[str, Any]:
+        return {'success': False, 'message': f'{op} is not supported in local mode'}
+
+    def create_pull_request(self, source_branch: str, target_branch: str,
+                            title: str, body: str = '') -> Dict[str, Any]:
+        return self._not_supported('create_pull_request')
+
+    def update_pull_request(self, number: int, title: Optional[str] = None,
+                            body: Optional[str] = None, state: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('update_pull_request')
+
+    def add_pr_labels(self, number: int, labels: List[str]) -> Dict[str, Any]:
+        return self._not_supported('add_pr_labels')
+
+    def list_pull_requests(self, state: str = 'open', head: Optional[str] = None,
+                           base: Optional[str] = None, max_results: int = 100) -> Dict[str, Any]:
+        return self._not_supported('list_pull_requests')
+
+    def create_review_comment(self, number: int, body: str, path: str,
+                              line: Optional[int] = None, side: str = 'RIGHT',
+                              commit_id: Optional[str] = None,
+                              in_reply_to: Optional[Any] = None,
+                              start_line: Optional[int] = None,
+                              start_side: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('create_review_comment')
+
+    def add_issue_comment(self, number: int, body: str) -> Dict[str, Any]:
+        return self._not_supported('add_issue_comment')
+
+    def submit_review(self, number: int, event: str, body: str = '',
+                      comments: Optional[List[Dict[str, Any]]] = None,
+                      commit_id: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('submit_review')
+
+    def approve_pull_request(self, number: int) -> Dict[str, Any]:
+        return self._not_supported('approve_pull_request')
+
+    def merge_pull_request(self, number: int, merge_method: Optional[str] = None,
+                           commit_title: Optional[str] = None,
+                           commit_message: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('merge_pull_request')
+
+    def list_repo_stargazers(self, page: int = 1, per_page: int = 20) -> Dict[str, Any]:
+        return self._not_supported('list_repo_stargazers')
+
+    def reply_to_review_comment(self, number: int, comment_id: Any, body: str,
+                                path: str, line: Optional[int] = None,
+                                commit_id: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('reply_to_review_comment')
+
+    def resolve_review_comment(self, number: int, comment_id: Any) -> Dict[str, Any]:
+        return self._not_supported('resolve_review_comment')
+
+    def get_user_info(self, username: Optional[str] = None) -> Dict[str, Any]:
+        return self._not_supported('get_user_info')
+
+    def list_user_starred_repos(self, username: Optional[str] = None,
+                                page: int = 1, per_page: int = 20) -> Dict[str, Any]:
+        return self._not_supported('list_user_starred_repos')


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 新增 `LocalGit` 适配器，支持对本地 git 仓库直接做 AI code review，无需云端 PR
- 新增 `lazyllm review` 和 `lazyllm review-local` 两个 CLI 子命令
- 新增 `write_review_json`，将 review 结果输出为结构化 JSON 文件
- 修复 review agent 的多个 prompt bug，提升 review 准确率

---

# 🎯 问题背景 / Problem Context

- 原有 review 工具只支持云端 PR（GitHub/GitLab/Gitee/GitCode），开发者无法在提 PR 前对本地分支做 review
- review agent 存在 `KeyError` 导致 code tag 提取静默失败（`_CODE_TAG_PROMPT_TMPL.format()` 中 `{ ... }` 被当成占位符）
- 行号校验逻辑不准确：小文件 `file_context` 包含全文，但 `end_line` 只算 hunk 范围，导致合法行号被误 skip

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `make lint-only-diff` 通过
2. 在 LazyLLM 仓库本地分支上运行 `lazyllm review-local`，完整跑通 14 个文件、25 条 issue
3. 验证 checkpoint 路径格式：`cache/<origin_repo>/local/<branch>/checkpoint.json`，与云端共享 arch/spec 缓存

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```bash
# 云端 PR review
lazyllm review --pr 1097 --repo LazyAGI/LazyLLM --model claude-opus-4-6
lazyllm review --pr 1097 --post   # 同时将评论发布到 PR

# 本地分支 review（diff 当前分支 vs main，输出 review.json）
lazyllm review-local
lazyllm review-local --base develop --output my-review.json
lazyllm review-local --no-uncommitted   # 只看已提交的变更
```

```python
# Python API
from lazyllm.tools.git import review
result = review(pr_number=0, backend='local', repo_path='.', base='main', output_path='review.json')
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# 只能 review 云端 PR，无本地模式，无 CLI
from lazyllm.tools.git import Git, review
git = Git(backend='github', token='...', repo='owner/repo')
result = review(pr_number=123, repo='owner/repo')
```

## After

```python
# 本地模式，无需 token，直接用 git diff
from lazyllm.tools.git import Git, review
git = Git(backend='local', repo_path='.', base='main')
result = review(pr_number=0, backend='local', repo_path='.', base='main', output_path='review.json')
```

# ⚠️ 注意事项 / Additional Notes

- 本地模式不支持将评论发布到 GitHub（`post_to_github` 自动禁用）
- checkpoint 路径通过 `git remote -v` 推断 origin repo，与云端模式共享 arch/spec 缓存；无 origin 时 fallback 到项目目录名
- branch 名中的 `/` 替换为 `_`（如 `feature/foo` → `feature_foo`）

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [x] Cursor
- [ ] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
在现有 review 工具基础上增加本地 git 模式：不依赖云端 API，直接用 git merge-base 获取精确 diff，
review 结果输出为 JSON 文件，并集成到 lazyllm CLI。
```

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

## **问题点 / Issues：**

- `client.py` 里新增的 `repo_path` 参数与已有局部变量命名冲突，导致 `repo` 参数被覆盖
- checkpoint 路径最初用 `pr_number=0`，路径为 `cache/local/0/`，不能区分不同分支
- `_CODE_TAG_PROMPT_TMPL` 拼接 `JSON_OBJ_OUTPUT_INSTRUCTION` 后 `.format()` 抛 `KeyError: ' '`，AI 未主动发现，需人工调试定位

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
clone dir 要传入；
cache/local/0/checkpoint.json -> cache/${origin}/local/${branch}/checkpoint.json，
branch name 中的 / 用下划线代替
```

**原因 / Reason：**

AI 初始实现中 `clone_dir` 在本地模式下为 `None`，导致 file skeleton 提取失败，LLM 上下文不足；
checkpoint 路径用 `0` 无法区分不同分支，且没有利用 git remote origin 共享缓存。

### 第二次修正 / Second Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
如果 git remote -v 没有 origin，fallback 到 local，路径变为 cache/local/local/<branch>/，
这里为什么是两层 local，可否用项目根目录的文件夹名代替第二个 local 呢
```

**原因 / Reason：**

AI 将 fallback 值硬编码为字符串 `"local"`，与 `_ckpt_key = "local/<branch>"` 拼接后出现两层 `local`，
应改为用 `os.path.basename(repo_path)` 取项目目录名作为 fallback。

### 最终策略总结 / Final Strategy Summary

- 对于涉及路径/缓存设计的需求，需要明确给出完整路径格式示例（含 fallback 场景），AI 容易遗漏边界情况
- 对于 prompt 模板字符串拼接，需人工验证 `.format()` 不会因字面量 `{}` 抛 `KeyError`
- review agent 的 strict rules 需根据实际误报案例持续迭代，不能一次性写完

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`80%`
* 人工修改占比 / Human modifications：`20%`

**主要人工修改点 / Key Human Modifications：**

* [ ] 逻辑修正 / Logic fixes
* [x] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [ ] 代码风格 / Code style
* [x] 架构调整 / Architecture adjustments

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```text
cache/local/${branch}/checkpoint.json，branch name 中的 / 用下划线代替
```

### ❌ 问题表现 / Issue Description

- AI 将 fallback repo 名硬编码为 `"local"`，与 `_ckpt_key = "local/<branch>"` 拼接后路径变为 `cache/local/local/<branch>/`，出现两层 `local`

### ✅ 改进后 Prompt / Improved Prompt

```text
如果 git remote -v 没有 origin，用项目根目录的文件夹名代替，避免两层 local
```

# 🧩 可复用经验 / Reusable Patterns

* Prompt 模板 / Prompt template：给出完整路径格式示例（含 fallback 场景），避免 AI 自行猜测
* 常见坑 / Common pitfalls：字符串模板拼接后需验证 `.format()` 不会因字面量 `{}` 抛 `KeyError`；新参数命名避免与函数内局部变量冲突
* 推荐做法 / Recommended practices：review agent 的 strict rules 需根据实际误报案例持续迭代，不能一次性写完

### 最终策略总结 / Final Strategy Summary

- 路径/缓存设计需给出完整格式示例（含 fallback 场景），AI 容易在边界情况遗漏
- 字符串模板拼接后需验证 `.format()` 不会因字面量 `{}` 抛 `KeyError`
- review agent 的 strict rules 需根据实际误报案例持续迭代，不能一次性写完
