### PR TITLE
[Bug Fix] Fix tracing hook import issue

### DIFF
--- a/lazyllm/hook.py
+++ b/lazyllm/hook.py
@@ -120,17 +120,15 @@ def register_builtin_hook_provider(provider: Callable[[Any], list]):
 
 def _ensure_builtin_hook_providers_loaded():
     global _builtin_hook_providers_state
-    if _builtin_hook_providers_state != 'pending':
+    if _builtin_hook_providers_state == 'loaded':
         return
-    _builtin_hook_providers_state = 'loading'
     try:
         from .tracing.collect.hook import resolve_tracing_hooks  # noqa: F401
+        _builtin_hook_providers_state = 'loaded'
     except Exception as exc:
         _builtin_hook_providers_state = 'pending'
         if not isinstance(exc, ImportError):
             raise
-    else:
-        _builtin_hook_providers_state = 'loaded'
 
 
 def resolve_builtin_hooks(obj):

--- a/lazyllm/hook.py
+++ b/lazyllm/hook.py
@@ -109,6 +109,7 @@ def _raise_hook_phase_errors(phase: str, errors):
 
 
 _builtin_hook_providers: list[Callable[[Any], list]] = []
+_builtin_hook_providers_state = 'pending'
 
 
 def register_builtin_hook_provider(provider: Callable[[Any], list]):
@@ -117,7 +118,23 @@ def register_builtin_hook_provider(provider: Callable[[Any], list]):
     return provider
 
 
+def _ensure_builtin_hook_providers_loaded():
+    global _builtin_hook_providers_state
+    if _builtin_hook_providers_state != 'pending':
+        return
+    _builtin_hook_providers_state = 'loading'
+    try:
+        from .tracing.collect.hook import resolve_tracing_hooks  # noqa: F401
+    except Exception as exc:
+        _builtin_hook_providers_state = 'pending'
+        if not isinstance(exc, ImportError):
+            raise
+    else:
+        _builtin_hook_providers_state = 'loaded'
+
+
 def resolve_builtin_hooks(obj):
+    _ensure_builtin_hook_providers_loaded()
     hooks = []
     for provider in _builtin_hook_providers:
         provided_hooks = provider(obj)
@@ -267,9 +284,3 @@ def execution_with_hooks(
         obj = None
         return decorator(fn)
     return decorator
-
-
-try:
-    from .tracing.collect.hook import resolve_tracing_hooks  # noqa: F401, E402
-except ImportError:
-    pass

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -569,4 +569,4 @@ class UrlDocument(ModuleBase):
 
     def __getattr__(self, name):
         if name in self.__dict__.get('_missing_keys', []):
-            raise RuntimeError(f'Document generated with url and name has no attribute `{name}`')
+            raise AttributeError(f'Document generated with url and name has no attribute `{name}`')

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -536,10 +536,8 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
 
 class UrlDocument(ModuleBase):
     def __init__(self, url: str, name: str = None):
-        # Initialize before ModuleBase hooks run to avoid __getattr__ recursion
-        # during attribute probing in hook registration.
-        object.__setattr__(self, '_missing_keys', set(dir(Document)) - set(dir(UrlDocument)))
         super().__init__()
+        self._missing_keys = set(dir(Document)) - set(dir(UrlDocument))
         self._manager = lazyllm.UrlModule(url=ensure_call_endpoint(url))
         self._curr_group = name or RAG_DEFAULT_GROUP_NAME
 
@@ -570,10 +568,5 @@ class UrlDocument(ModuleBase):
         return self._forward('active_node_groups')
 
     def __getattr__(self, name):
-        try:
-            missing_keys = object.__getattribute__(self, '_missing_keys')
-        except AttributeError:
-            missing_keys = set(dir(Document)) - set(dir(UrlDocument))
-            object.__setattr__(self, '_missing_keys', missing_keys)
-        if name in missing_keys:
-            raise RuntimeError(f'Document generated with url and name has noattribute `{name}`')
+        if name in self.__dict__.get('_missing_keys', []):
+            raise RuntimeError(f'Document generated with url and name has no attribute `{name}`')


### PR DESCRIPTION
<!-- 
在提交 PR 前，请确保 / Before submitting a PR, please ensure:
1. 每行不超过 120 字符 / Max 120 characters per line
2. 单引号优先（修改文件需统一）/ Prefer single quotes (be consistent within modified files)
3. 禁止 print / No print statements
4. 注释需解释"为什么"和"怎么做"，而不是"是什么" / Comments should explain "why" and "how", not "what"
5. 执行 / Run:
   pip install flake8-quotes
   pip install flake8-bugbear
   make lint-only-diff
6. 删除本模板的全部注释 / Delete all template comments before submitting
-->

# 📌 PR 内容 / PR Description

- 将 tracing hook provider 从 `lazyllm.hook` 模块加载阶段改为按需加载。
- 避免 `lazyllm.hook` 与 `lazyllm.tracing.collect.hook` 在启动期形成循环导入。
- 保留现有 builtin hook provider 注册机制，只调整 tracing provider 的加载时机。

---

# 🎯 问题背景 / Problem Context

<!-- 为什么要做这个改动 / Why is this change needed -->
- lazyrag 镜像启动时，`lazyllm.hook` 文件末尾会提前导入 tracing hook。
- `tracing.collect.hook` 又会从 `lazyllm.hook` 导入 `register_builtin_hook_provider`。
- 在部分启动路径下，`lazyllm.hook` 仍处于半初始化状态。
- 此时 `register_builtin_hook_provider` 尚未完成定义，会触发 `ImportError`。
- tracing hook 实际只需要在解析 builtin hooks 时加载，不需要在 `hook.py` 导入时立即加载。

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. from lazyllm.tools.rag.document import UrlDocument
2. 本地构造 url_document 对象并打印，检查是否有循环问题

---

# ⚡ 更新后的用法示例 / Usage After Update

<img width="724" height="211" alt="截屏2026-04-30 15 24 31" src="https://github.com/user-attachments/assets/24304459-0a5c-4e05-adf3-e85d953cbde4" />

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
try:
    from .tracing.collect.hook import resolve_tracing_hooks
except ImportError:
    pass
```

## After

```python
def resolve_builtin_hooks(obj):
    _ensure_builtin_hook_providers_loaded()
    ...
```

# ⚠️ 注意事项 / Additional Notes

- lazyllm.hook 不再在模块导入阶段加载 tracing hook。
- tracing hook provider 会在首次调用 resolve_builtin_hooks() 时按需加载。
- 如果 tracing hook import 失败，状态会恢复为 pending，后续调用可重试。

---


# 🧠 AI 参与情况 / AI Involvement

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
<!-- 最开始你是怎么问 AI 的 / How did you initially prompt the AI -->
```text
分析 lazyrag 镜像启动时 lazyllm.hook 与 tracing.collect.hook 的循环导入问题，
给出修复方案并保留现有 builtin hook provider 注册机制。
```

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

## **问题点 / Issues：**

初始讨论包含了另一个 UrlDocument 初始化问题，后续确认该问题应在
lazyllm.tools.rag.document 中单独修复，不属于本 PR 范围。

## 🔧 人工干预过程 / Human Intervention

<!-- 重点：这是核心 / Key section: this is the core -->

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
不要直接修改代码。先分析根因、方案和取舍，审批后再改。
```

### **原因 / Reason：**

需要先明确 tracing hook 的边界和修复策略，避免只做局部 patch。

### 最终策略总结 / Final Strategy Summary

<!-- 这一步非常关键：沉淀经验 / This step is critical: capture learnings -->

* tracing hook provider 改为按需加载，避免 hook.py 与 tracing hook 启动期循环导入。
* tracing 读取业务对象元信息统一走 trace_attrs.py，避免触发业务 __getattr__。
* hook.py 仍保持现有 provider 注册机制，只改变 tracing provider 的加载时机。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

<!-- 粗略评估 / Rough estimate -->

* AI 生成代码占比 / AI-generated code：`60%`
* 人工修改占比 / Human modifications：`40%`

**主要人工修改点 / Key Human Modifications：**

* [x] 逻辑修正 / Logic fixes
* [x] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [x] 代码风格 / Code style
* [x] 架构调整 / Architecture adjustments
