### PR TITLE
add retry for llm

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -4,9 +4,9 @@ import os
 import requests
 import re
 import random
+import time
 from typing import Tuple, List, Dict, Union, Any, Optional
 from urllib.parse import urljoin
-import time
 from operator import itemgetter as itemget
 
 import lazyllm
@@ -127,9 +127,72 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
             return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
         return src[-1]
 
+    def _extract_partial_content(self, msg_json: list) -> str:
+        if not msg_json:
+            return ''
+        try:
+            extractor = self._extract_specified_key_fields(self._merge_stream_result(msg_json))
+            return extractor.get('content', '') or ''
+        except Exception:
+            return ''
+
+    def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
+                      proxies: Optional[Dict]) -> List[Dict[str, Any]]:
+        with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
+                           proxies=proxies) as r:
+            if r.status_code != 200:
+                err_msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)]) \
+                    if stream_output else r.text
+                raise requests.RequestException(f'{r.status_code}: {err_msg}')
+
+            with self.stream_output(stream_output):
+                msg_json = list(filter(lambda x: x, (
+                    [self._str_to_json(line, stream_output) for line in r.iter_lines() if len(line)]
+                    if stream_output
+                    else [self._str_to_json(r.text, stream_output)]
+                )))
+        return msg_json
+
+    def _forward_with_retry(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
+                            proxies: Optional[Dict], max_retries: int) -> List[Dict[str, Any]]:
+        _RETRY_DELAYS = [3, 10, 30]
+        _CONTINUATION_PROMPT = (
+            'Your previous response was interrupted. '
+            'Please continue your response exactly from where it left off. '
+            'Do NOT repeat any content that was already provided. '
+            'Do NOT add any transitional phrases like "Continuing..." or "As I was saying...". '
+            'Just seamlessly continue the response. '
+            'Keep the same language as your previous response.'
+        )
+        msg_json = []
+        partial_content = ''
+        for attempt in range(max_retries):
+            if attempt > 0 and partial_content:
+                data['messages'].append({'role': 'assistant', 'content': partial_content})
+                data['messages'].append({'role': 'user', 'content': _CONTINUATION_PROMPT})
+                partial_content = ''
+            try:
+                msg_json = self._forward_impl(data, runtime_url=runtime_url,
+                                              stream_output=stream_output, proxies=proxies)
+            except (requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError):
+                if attempt < max_retries - 1:
+                    partial_content = self._extract_partial_content(msg_json)
+                    lazyllm.LOG.warning(f'Stream interrupted (attempt {attempt + 1}), retrying...')
+                    time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
+                    continue
+                raise
+            except requests.RequestException:
+                if attempt < max_retries - 1:
+                    lazyllm.LOG.warning(f'Request failed (attempt {attempt + 1}), retrying...')
+                    time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
+                    continue
+                raise
+            break
+        return msg_json
+
     def forward(self, __input: Union[Dict, str] = None, *, llm_chat_history: List[List[str]] = None,
                 tools: List[Dict[str, Any]] = None, stream_output: bool = None, stream: bool = None,
-                lazyllm_files=None, url: str = None, model: str = None, **kw):
+                lazyllm_files=None, url: str = None, model: str = None, max_retries: int = 3, **kw):
         stream_output = stream_output if stream_output is not None else stream
         stream_output = stream_output if stream_output is not None else self._stream
         __input, files = self._get_files(__input, lazyllm_files)
@@ -155,23 +218,16 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
 
         data = self._prepare_request_data(data)
         proxies = {'http': None, 'https': None} if self.NO_PROXY else None
-        with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
-                           proxies=proxies) as r:
-            if r.status_code != 200:  # request error
-                msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)]) if stream_output else r.text
-                raise requests.RequestException(f'{r.status_code}: {msg}')
+        msg_json = self._forward_with_retry(data, runtime_url=runtime_url, stream_output=stream_output,
+                                            proxies=proxies, max_retries=max_retries)
 
-            with self.stream_output(stream_output):
-                msg_json = list(filter(lambda x: x, ([self._str_to_json(line, stream_output) for line in r.iter_lines()
-                                if len(line)] if stream_output else [self._str_to_json(r.text, stream_output)]),))
-
-            usage = {'prompt_tokens': -1, 'completion_tokens': -1}
-            if len(msg_json) > 0 and 'usage' in msg_json[-1] and isinstance(msg_json[-1]['usage'], dict):
-                for k in usage:
-                    usage[k] = msg_json[-1]['usage'].get(k, usage[k])
-            self._record_usage(usage)
-            extractor = self._extract_specified_key_fields(self._merge_stream_result(msg_json))
-            return self._formatter(extractor) if extractor else ''
+        usage = {'prompt_tokens': -1, 'completion_tokens': -1}
+        if len(msg_json) > 0 and 'usage' in msg_json[-1] and isinstance(msg_json[-1]['usage'], dict):
+            for k in usage:
+                usage[k] = msg_json[-1]['usage'].get(k, usage[k])
+        self._record_usage(usage)
+        extractor = self._extract_specified_key_fields(self._merge_stream_result(msg_json))
+        return self._formatter(extractor) if extractor else ''
 
     def _record_usage(self, usage: dict):
         globals['usage'][self._module_id] = usage

--- a/lazyllm/module/llms/trainablemodule.py
+++ b/lazyllm/module/llms/trainablemodule.py
@@ -6,6 +6,7 @@ import os
 import copy
 import uuid
 import re
+import time
 import requests
 from lazyllm.thirdparty import deepdiff
 
@@ -516,16 +517,18 @@ class TrainableModule(UrlModule):
                 globals['usage'][par_muduleid][k] += usage[k]
 
     def forward(self, __input: Union[Tuple[Union[str, Dict], str], str, Dict] = package(),  # noqa B008
-                *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False, **kw):
+                *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False,
+                max_retries: int = 3, **kw):
         if self._url.endswith('/v1/'):
             return self.forward_openai(__input, llm_chat_history=llm_chat_history, lazyllm_files=lazyllm_files,
-                                       tools=tools, stream_output=stream_output, **kw)
+                                       tools=tools, stream_output=stream_output, max_retries=max_retries, **kw)
         else:
             return self.forward_standard(__input, llm_chat_history=llm_chat_history, lazyllm_files=lazyllm_files,
-                                         tools=tools, stream_output=stream_output, **kw)
+                                         tools=tools, stream_output=stream_output, max_retries=max_retries, **kw)
 
     def forward_openai(self, __input: Union[Tuple[Union[str, Dict], str], str, Dict] = package(),  # noqa B008
-                       *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False, **kw):
+                       *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False,
+                       max_retries: int = 3, **kw):
         if not getattr(self, '_openai_module', None):
             model_type = self.type.lower()
             if model_type in ['llm', 'vlm']:
@@ -542,10 +545,11 @@ class TrainableModule(UrlModule):
                 raise ValueError(f'Unsupported type: {model_type} for openai compatible module')
             self._openai_module.used_by(self._module_id)
         return self._openai_module.forward(__input, llm_chat_history=llm_chat_history, lazyllm_files=lazyllm_files,
-                                           tools=tools, stream_output=stream_output, **kw)
+                                           tools=tools, stream_output=stream_output, max_retries=max_retries, **kw)
 
     def forward_standard(self, __input: Union[Tuple[Union[str, Dict], str], str, Dict] = package(),  # noqa B008
-                         *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False, **kw):
+                         *, llm_chat_history=None, lazyllm_files=None, tools=None, stream_output=False,
+                         max_retries: int = 3, **kw):
         __input, files = self._get_files(__input, lazyllm_files)
         text_input_for_token_usage = __input = self._prompt.generate_prompt(__input, llm_chat_history, tools)
         url = self._url
@@ -570,14 +574,44 @@ class TrainableModule(UrlModule):
             stop_key = next((k for k in data if k.startswith('stop')), 'stop')
             data[stop_key] = (data.get(stop_key) or []) + [self._tool_end_token]
 
+        inputs_key = self.keys_name_handle.get('inputs', 'inputs')
+        original_input = data.get(inputs_key, '') if isinstance(data, dict) else data
+        _RETRY_DELAYS = [3, 10, 30]
+        partial_out: List = []
+
         with self.stream_output((stream_output := (stream_output or self._stream))):
-            return self._forward_impl(data, stream_output=stream_output, url=url, text_input=text_input_for_token_usage)
+            for attempt in range(max_retries):
+                if attempt > 0 and partial_out:
+                    partial_messages = partial_out[0]
+                    if isinstance(data, dict):
+                        data = dict(data)
+                        data[inputs_key] = original_input + partial_messages
+                    else:
+                        data = original_input + partial_messages
+                    partial_out.clear()
+                try:
+                    return self._forward_impl(data, stream_output=stream_output, url=url,
+                                              text_input=text_input_for_token_usage, partial_out=partial_out)
+                except (requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError):
+                    if attempt < max_retries - 1:
+                        LOG.warning(f'Stream interrupted (attempt {attempt + 1}), retrying...')
+                        time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
+                        continue
+                    raise
+                except requests.RequestException:
+                    if attempt < max_retries - 1:
+                        LOG.warning(f'Request failed (attempt {attempt + 1}), retrying...')
+                        time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
+                        continue
+                    raise
 
     def _maybe_has_fc(self, token: str, chunk: str) -> bool:
         return token and (token.startswith(chunk if token.startswith('\n') else chunk.lstrip('\n')) or token in chunk)
 
     def _forward_impl(self, data: Union[Tuple[Union[str, Dict], str], str, Dict] = package(), *,  # noqa B008
-                      url: str, stream_output: Optional[Union[bool, Dict]] = None, text_input: Optional[str] = None):
+                      url: str, stream_output: Optional[Union[bool, Dict]] = None,
+                      text_input: Optional[str] = None,
+                      partial_out: Optional[List] = None) -> Tuple[Any, str]:
         headers = self.template_headers or {'Content-Type': 'application/json'}
         parse_parameters = self.stream_parse_parameters if stream_output else {'delimiter': b'<|lazyllm_delimiter|>'}
 
@@ -597,6 +631,7 @@ class TrainableModule(UrlModule):
                 chunk = self._prompt.get_response(self.extract_result_func(line, data))
                 chunk = chunk[len(messages):] if isinstance(chunk, str) and chunk.startswith(messages) else chunk
                 messages = chunk if not isinstance(chunk, str) else messages + chunk
+                if partial_out is not None: partial_out[:] = [messages]
 
                 if not stream_output: continue
                 if not cache: cache = chunk if self._maybe_has_fc(token, chunk) else self._stream_output(chunk, color)
@@ -607,9 +642,9 @@ class TrainableModule(UrlModule):
                     cache += chunk
                     if not self._maybe_has_fc(token, cache): cache = self._stream_output(cache, color)
 
-            if text_input: self._record_usage(text_input, messages)
-            temp_output = self._extract_and_format(messages)
-            return self._formatter(temp_output)
+        if text_input: self._record_usage(text_input, messages)
+        temp_output = self._extract_and_format(messages)
+        return self._formatter(temp_output)
 
     def _modify_parameters(self, paras: dict, kw: dict, *, optional_keys: Union[List[str], str] = None):
         for key, value in paras.items():


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

为 LLM 的 forward 调用添加有限次重试逻辑，支持流式中断续写和连接失败重试。

---

# 🎯 问题背景 / Problem Context

在流式输出场景下，LLM 推理服务可能在输出到一半时中断连接（`ChunkedEncodingError` / `ConnectionError`），导致用户只收到部分响应。此前没有任何重试机制，中断即失败。

---

# 🔍 相关 Issue / Related Issue

N/A

---

# ✅ 变更类型 / Type of Change

- [x] New feature
- [x] Refactor

---

# 🧪 如何测试 / How Has This Been Tested?

手动测试 import 正常，lint 通过（`make lint-only-diff`）。

---

# ⚡ 更新后的用法示例 / Usage After Update

`max_retries` 参数默认值为 3，无需改动现有调用代码：

```python
# 默认 3 次重试
m = lazyllm.OnlineChatModule(source='openai', ...)
result = m('你好')

# 自定义重试次数
result = m.forward('你好', max_retries=5)
```

---

# 🔄 重构对比 / Refactor Comparison

## Before

- `OnlineChatModule.forward`：单次请求，失败即抛异常
- `TrainableModule._forward_impl`：单次请求，流式中断丢失已收到内容

## After

**`onlineChatModuleBase.py`**
- 新增 `_forward_impl`：单次 HTTP 请求，返回 `msg_json`，逻辑干净
- 新增 `_forward_with_retry`：重试循环，流式中断时构造 continuation prompt 追加到 `data['messages']` 末尾，不重调 `generate_prompt`，避免重复插入 system prompt 和 special token
- 新增 `_extract_partial_content`：从已收到的 chunks 中提取部分内容
- `forward` 职责收窄为 data 构造 + 调用 `_forward_with_retry`

**`trainablemodule.py`**
- `_forward_impl` 恢复为单次请求，通过 `partial_out` 列表实时暴露已收到的 `messages`
- `forward_standard` 负责重试循环，中断时把 `partial_out[0]` 拼接到 `original_input` 末尾（纯字符串操作，不经过 `generate_prompt`）
- `forward` / `forward_openai` / `forward_standard` 均透传 `max_retries` 参数

**重试等待策略**：依次等待 3、10、30、30、... 秒

**Continuation prompt**（仅 online / openai 兼容路径）：
```
Your previous response was interrupted.
Please continue your response exactly from where it left off.
Do NOT repeat any content that was already provided.
Do NOT add any transitional phrases like "Continuing..." or "As I was saying...".
Just seamlessly continue the response.
Keep the same language as your previous response.
```

---

# ⚠️ 注意事项 / Additional Notes

- `_RETRY_DELAYS` 和 `_CONTINUATION_PROMPT` 目前定义在 `_forward_with_retry` 方法内部，可在后续 PR 中提到类级别
- 非 OpenAI 格式（`TrainableModule.forward_standard`）续写时直接拼接字符串，不构造 continuation prompt，因为推理服务收到的是纯文本 completion，不是 chat messages
- `data` 是 dict 时续写前做浅拷贝（`dict(data)`），不修改调用方持有的原始对象

---

# 🧠 AI 参与情况 / AI Involvement

- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：** Cursor

---

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```
我需要给大模型加一个有限次重试的逻辑，如果直接连接失败，就比较简单；
但如果流式输出到一半中断了，那么需要特殊处理。
对于非openai接口的，直接拼接 tokens → retry；
而对于openai接口的，我需要构造 continuation prompt → retry
请你帮我看看lazyllm/module/llms，告诉我加在哪里最为合适
```

## AI 初始输出质量 / Initial Output Quality

- [x] 部分正确 / Partially correct

## 问题点 / Issues

AI 初始分析遗漏了 `TrainableModule`，错误地将所有路径都归类为需要 continuation prompt。经人工指出后重新分析，确认了正确的分叉点：`/v1/` 结尾走 `forward_openai`（委托给 `OnlineChatModule`，需要 continuation prompt），其他走 `forward_standard`（纯字符串拼接）。

## 🔧 人工干预过程 / Human Intervention

### 第一次修正

**操作：** 指出 AI 遗漏了 `TrainableModule` 的分析，要求重新看完整路径

**原因：** AI 只看了 `onlineChatModule`，没有看 `TrainableModule.forward` 的两条分支

### 第二次修正

**操作：** 要求将重试逻辑移到 `_forward_impl` 之外，对 online 新建独立的 `_forward_impl`

**原因：** 初版实现把重试循环嵌套在 `_forward_impl` 内部，层级加深，对原有代码入侵较大

### 第三次修正

**操作：** 要求将 continuation prompt 改为英文，并补充"保持原语言"的指令

**原因：** 初版使用中文 prompt，模型可能切换回复语言

### 最终策略总结

先做架构分析（Ask/Plan mode），确认改动位置后切换到 Agent mode 实现，过程中多次根据人工反馈调整架构设计。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

- AI 生成代码占比 / AI-generated code：`85%`
- 人工修改占比 / Human modifications：`15%`

**主要人工修改点 / Key Human Modifications：**

- [x] 架构调整 / Architecture adjustments（指出 TrainableModule 分支、要求重试逻辑外移）
- [x] 逻辑修正 / Logic fixes（continuation prompt 语言和内容）
- [x] 代码风格 / Code style（lint 修复、复杂度降低）

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例

```
请你帮我看看lazyllm/module/llms，告诉我加在哪里最为合适
```

### ❌ 问题表现

AI 只分析了 `onlineChatModule`，遗漏了 `TrainableModule` 的 `forward_openai` / `forward_standard` 分支，导致初始方案对所有路径都使用 continuation prompt，逻辑有误。

### ✅ 改进后 Prompt

```
你没有看TrainableModule，事实上，onlineChatModule都是需要构造continuation Prompt的，
而trainable在不用openai格式的时候，才可以直接拼接
```

---

# 🧩 可复用经验 / Reusable Patterns

- **Prompt 模板**：让 AI 先做架构分析（Ask/Plan mode），确认改动位置后再切换到实现模式，避免方向性错误
- **常见坑**：AI 在分析多路径代码时容易只看到一条路径，需要明确要求"看完整的调用链"
- **推荐做法**：重试逻辑与单次请求逻辑分离，保持内层函数干净，重试状态管理在外层处理