### PR TITLE
[Refactor] warn when base formatter receives tool_calls instead of patching it

### DIFF
--- a/docs/en/Best Practice/functionCall.md
+++ b/docs/en/Best Practice/functionCall.md
@@ -376,6 +376,8 @@ The design process of [FunctionCall][lazyllm.tools.agent.FunctionCall] is carrie
 
     - In the tool call information, besides the tool name and arguments, there are also the id, type, and function fields.
 
+    - Any model that produces `tool_calls` must be configured with `FunctionCallFormatter`. The base formatter (and `EmptyFormatter`) collapses an assistant message to plain text and drops `tool_calls` and `reasoning_content`, so a provider-compatible multi-turn history can no longer be replayed — for example, DeepSeek thinking models reject a tool-calling request whose previous assistant turn omits `reasoning_content`. The base formatter logs a warning if it is used on such a message.
+
 ### FunctionCall Output Flow
 
 [FunctionCall][lazyllm.tools.agent.FunctionCall] handles single-turn tool calls.

--- a/docs/zh/Best Practice/functionCall.md
+++ b/docs/zh/Best Practice/functionCall.md
@@ -372,6 +372,8 @@ config['sandbox_fusion_base_url'] = 'http://your-sandbox-host:port'
 
     - 工具调用的信息里面，除了工具的 `name` 和 `arguments` 之外，还有 `id` 、`type` 和 `function` 字段。
 
+    - 任何会产生 `tool_calls` 的模型都必须配置 `FunctionCallFormatter`。基础 formatter（以及 `EmptyFormatter`）会把 assistant 消息压成纯文本，从而丢弃 `tool_calls` 和 `reasoning_content`，导致无法回放与服务商兼容的多轮历史 —— 例如 DeepSeek 思考模型会拒绝上一轮 assistant 缺少 `reasoning_content` 的工具调用请求。基础 formatter 在遇到这类消息时会打印一条 warning。
+
 
 ### FunctionCall 的输出流程
 

--- a/lazyllm/components/formatter/formatterbase.py
+++ b/lazyllm/components/formatter/formatterbase.py
@@ -31,6 +31,12 @@ class LazyLLMFormatterBase(metaclass=LazyLLMRegisterMetaClass):
 
     def format(self, msg):
         if _is_chat_message(msg):
+            if msg.get('tool_calls'):
+                # When tool_calls are present, the full dict must be returned so that
+                # reasoning_content is preserved for provider-compatible history replay.
+                # DeepSeek (and compatible providers) reject multi-turn tool-calling
+                # requests whose previous assistant turn omits reasoning_content.
+                return msg
             if reasoning_content := msg.get('reasoning_content'):
                 msg = f'<think>{reasoning_content}</think>' + msg['content']
             else:

--- a/lazyllm/components/formatter/formatterbase.py
+++ b/lazyllm/components/formatter/formatterbase.py
@@ -32,11 +32,18 @@ class LazyLLMFormatterBase(metaclass=LazyLLMRegisterMetaClass):
     def format(self, msg):
         if _is_chat_message(msg):
             if msg.get('tool_calls'):
-                # When tool_calls are present, the full dict must be returned so that
-                # reasoning_content is preserved for provider-compatible history replay.
-                # DeepSeek (and compatible providers) reject multi-turn tool-calling
-                # requests whose previous assistant turn omits reasoning_content.
-                return msg
+                # The base formatter collapses chat messages to plain text, which drops
+                # `tool_calls` and `reasoning_content`. Tool-calling models must be
+                # configured with `FunctionCallFormatter`, which keeps those structured
+                # fields so a provider-compatible multi-turn history can be replayed
+                # (e.g. DeepSeek rejects a tool-calling request whose previous assistant
+                # turn omits `reasoning_content`). Warn rather than drop them silently.
+                lazyllm.LOG.warning(
+                    f'{type(self).__name__}: formatting an assistant message that '
+                    'contains `tool_calls`; `tool_calls` and `reasoning_content` will be '
+                    'dropped. Configure the model with `FunctionCallFormatter` for tool '
+                    'calling.'
+                )
             if reasoning_content := msg.get('reasoning_content'):
                 msg = f'<think>{reasoning_content}</think>' + msg['content']
             else:
@@ -159,6 +166,15 @@ class EmptyFormatter(LazyLLMFormatterBase):
         return msg
 
 class FunctionCallFormatter(LazyLLMFormatterBase):
+    '''Formatter for tool-calling (FunctionCall) models.
+
+    Unlike the base formatter, which collapses an assistant message to plain text,
+    this keeps the structured ``role`` / ``content`` / ``tool_calls`` /
+    ``reasoning_content`` fields. Any model that produces ``tool_calls`` must be
+    configured with this formatter so that a provider-compatible multi-turn history
+    can be replayed (e.g. DeepSeek rejects a tool-calling request whose previous
+    assistant turn omits ``reasoning_content``).
+    '''
     def format(self, msg):
         assert isinstance(msg, dict), 'FunctionCallFormatter only supports dict input.'
         return {k: msg[k] for k in ('role', 'content', 'tool_calls', 'reasoning_content') if k in msg}

--- a/lazyllm/components/formatter/formatterbase.py
+++ b/lazyllm/components/formatter/formatterbase.py
@@ -166,15 +166,6 @@ class EmptyFormatter(LazyLLMFormatterBase):
         return msg
 
 class FunctionCallFormatter(LazyLLMFormatterBase):
-    '''Formatter for tool-calling (FunctionCall) models.
-
-    Unlike the base formatter, which collapses an assistant message to plain text,
-    this keeps the structured ``role`` / ``content`` / ``tool_calls`` /
-    ``reasoning_content`` fields. Any model that produces ``tool_calls`` must be
-    configured with this formatter so that a provider-compatible multi-turn history
-    can be replayed (e.g. DeepSeek rejects a tool-calling request whose previous
-    assistant turn omits ``reasoning_content``).
-    '''
     def format(self, msg):
         assert isinstance(msg, dict), 'FunctionCallFormatter only supports dict input.'
         return {k: msg[k] for k in ('role', 'content', 'tool_calls', 'reasoning_content') if k in msg}

--- a/lazyllm/docs/components.py
+++ b/lazyllm/docs/components.py
@@ -2659,7 +2659,9 @@ add_example('EmptyFormatter', """\
 add_chinese_doc('formatter.formatterbase.FunctionCallFormatter', '''\
 函数调用格式化器，用于处理包含函数调用信息的消息字典。
 
-该格式化器专门用于处理函数调用场景下的模型输出，只提取字典中的 'role'、'content' 和 'tool_calls' 字段，过滤掉其他不需要的字段。
+该格式化器专门用于处理函数调用场景下的模型输出，保留字典中的 'role'、'content'、'tool_calls' 以及 'reasoning_content' 字段，过滤掉其他不需要的字段。
+
+与基础格式化器不同：基础格式化器会把 assistant 消息折叠为纯文本，从而丢弃 ``tool_calls`` 与 ``reasoning_content``。任何会产生 ``tool_calls`` 的模型都必须配置本格式化器，以便可以按 provider 兼容的方式回放多轮历史（例如 DeepSeek 在工具调用请求中，要求上一轮 assistant 消息保留 ``reasoning_content``，否则会拒绝请求）。当模型携带 ``tool_calls`` 却仍命中基础格式化器时，框架会输出 warning 日志，提示切换到本格式化器。
 
 主要用于 FunctionCall 等工具调用相关的功能模块。
 
@@ -2668,13 +2670,15 @@ Args:
 
 注意:
     - 输入必须是字典类型，否则会抛出断言错误
-    - 只保留字典中存在的 'role'、'content'、'tool_calls' 字段
+    - 只保留字典中存在的 'role'、'content'、'tool_calls'、'reasoning_content' 字段
 ''')
 
 add_english_doc('formatter.formatterbase.FunctionCallFormatter', '''\
 Function call formatter for processing message dictionaries containing function call information.
 
-This formatter is specifically designed for handling model outputs in function calling scenarios. It extracts only the 'role', 'content', and 'tool_calls' fields from the input dictionary, filtering out other unnecessary fields.
+This formatter is specifically designed for handling model outputs in function calling scenarios. It preserves the 'role', 'content', 'tool_calls', and 'reasoning_content' fields from the input dictionary, filtering out other unnecessary fields.
+
+Unlike the base formatter, which collapses an assistant message to plain text and therefore drops ``tool_calls`` and ``reasoning_content``, this keeps those structured fields. Any model that produces ``tool_calls`` must be configured with this formatter so that a provider-compatible multi-turn history can be replayed (e.g. DeepSeek rejects a tool-calling request whose previous assistant turn omits ``reasoning_content``). When a message carrying ``tool_calls`` still hits the base formatter, the framework emits a warning log suggesting that this formatter be used instead.
 
 Primarily used in function calling-related modules such as FunctionCall.
 
@@ -2683,7 +2687,7 @@ Args:
 
 Note:
     - Input must be a dictionary type, otherwise an assertion error will be raised
-    - Only preserves 'role', 'content', and 'tool_calls' fields if they exist in the dictionary
+    - Only preserves 'role', 'content', 'tool_calls', and 'reasoning_content' fields if they exist in the dictionary
 ''')
 
 add_example('formatter.formatterbase.FunctionCallFormatter', '''\

--- a/tests/basic_tests/Components/test_formatter.py
+++ b/tests/basic_tests/Components/test_formatter.py
@@ -5,14 +5,21 @@ import pytest
 
 class TestFormatter(object):
 
-    def test_empty_formatter_preserves_dict_when_tool_calls_present(self):
-        # When tool_calls are present the full assistant dict must be returned so
-        # that reasoning_content survives for provider-compatible history replay
-        # (e.g. DeepSeek rejects the next request if reasoning_content is missing).
-        ef = formatter.EmptyFormatter
+    def test_empty_formatter_warns_when_tool_calls_present(self, monkeypatch):
+        # The base / Empty formatter collapses chat messages to plain text, dropping
+        # `tool_calls` and `reasoning_content`. It must not do so silently: a warning
+        # has to point the user at `FunctionCallFormatter`, which is the formatter
+        # tool-calling models should be configured with.
+        warnings_seen = []
+
+        class _FakeLog:
+            def warning(self, msg, *args, **kwargs):
+                warnings_seen.append(msg)
+
+        monkeypatch.setattr(lazyllm, 'LOG', _FakeLog())
         msg = {
             'role': 'assistant',
-            'content': '',
+            'content': 'done',
             'reasoning_content': 'I should look up the weather.',
             'tool_calls': [{
                 'id': 'call_1',
@@ -20,11 +27,11 @@ class TestFormatter(object):
                 'function': {'name': 'get_weather', 'arguments': '{"city":"Beijing"}'},
             }],
         }
-        result = ef()(msg)
-        assert isinstance(result, dict)
-        assert result['reasoning_content'] == 'I should look up the weather.'
-        assert result['tool_calls'] == msg['tool_calls']
-        assert result['content'] == ''
+        result = formatter.EmptyFormatter()(msg)
+        # The base formatter still collapses to text (its documented behaviour) ...
+        assert isinstance(result, str)
+        # ... but emits a warning naming the formatter that preserves the fields.
+        assert any('FunctionCallFormatter' in w for w in warnings_seen)
 
     def test_empty_formatter_wraps_reasoning_content_when_no_tool_calls(self):
         ef = formatter.EmptyFormatter

--- a/tests/basic_tests/Components/test_formatter.py
+++ b/tests/basic_tests/Components/test_formatter.py
@@ -5,6 +5,48 @@ import pytest
 
 class TestFormatter(object):
 
+    def test_empty_formatter_preserves_dict_when_tool_calls_present(self):
+        # When tool_calls are present the full assistant dict must be returned so
+        # that reasoning_content survives for provider-compatible history replay
+        # (e.g. DeepSeek rejects the next request if reasoning_content is missing).
+        ef = formatter.EmptyFormatter
+        msg = {
+            'role': 'assistant',
+            'content': '',
+            'reasoning_content': 'I should look up the weather.',
+            'tool_calls': [{
+                'id': 'call_1',
+                'type': 'function',
+                'function': {'name': 'get_weather', 'arguments': '{"city":"Beijing"}'},
+            }],
+        }
+        result = ef()(msg)
+        assert isinstance(result, dict)
+        assert result['reasoning_content'] == 'I should look up the weather.'
+        assert result['tool_calls'] == msg['tool_calls']
+        assert result['content'] == ''
+
+    def test_empty_formatter_wraps_reasoning_content_when_no_tool_calls(self):
+        ef = formatter.EmptyFormatter
+        msg = {'role': 'assistant', 'content': 'Hello!', 'reasoning_content': 'Some thought.'}
+        result = ef()(msg)
+        assert result == '<think>Some thought.</think>Hello!'
+
+    def test_function_call_formatter_preserves_dict(self):
+        fc = formatter.FunctionCallFormatter
+        msg = {
+            'role': 'assistant',
+            'content': '',
+            'reasoning_content': 'Deciding which tool to call.',
+            'tool_calls': [{'id': 'c1', 'type': 'function',
+                             'function': {'name': 'search', 'arguments': '{}'}}],
+        }
+        result = fc()(msg)
+        assert isinstance(result, dict)
+        assert result['reasoning_content'] == 'Deciding which tool to call.'
+        assert result['tool_calls'] == msg['tool_calls']
+
+
     def test_jsonlike_formatter_base(self):
         jsf = formatter.JsonLike
 

--- a/tests/basic_tests/Components/test_formatter.py
+++ b/tests/basic_tests/Components/test_formatter.py
@@ -39,13 +39,12 @@ class TestFormatter(object):
             'content': '',
             'reasoning_content': 'Deciding which tool to call.',
             'tool_calls': [{'id': 'c1', 'type': 'function',
-                             'function': {'name': 'search', 'arguments': '{}'}}],
+                            'function': {'name': 'search', 'arguments': '{}'}}],
         }
         result = fc()(msg)
         assert isinstance(result, dict)
         assert result['reasoning_content'] == 'Deciding which tool to call.'
         assert result['tool_calls'] == msg['tool_calls']
-
 
     def test_jsonlike_formatter_base(self):
         jsf = formatter.JsonLike


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

Reworked per review feedback from @Yuang-Deng.

`LazyLLMFormatterBase` (and `EmptyFormatter`) is a plain-text formatter by
design — collapsing an assistant message to a string. Special-casing
`tool_calls` to return a `dict` there would make the base formatter's return
type inconsistent. So instead of patching the base formatter:

- **`LazyLLMFormatterBase.format()`** now **logs a warning** when it receives an
  assistant message containing `tool_calls`, pointing the user at
  `FunctionCallFormatter` — rather than silently dropping `tool_calls` /
  `reasoning_content`.
- **`FunctionCallFormatter`** keeps the structured
  `role`/`content`/`tool_calls`/`reasoning_content` fields and remains the
  formatter that tool-calling models must be configured with. Added a docstring
  so this surfaces in the API reference.
- **Docs**: the FunctionCall best-practice guide (en + zh) now states the
  constraint explicitly.

# 🎯 问题背景 / Problem Context

DeepSeek thinking models require that when a previous assistant turn included
`tool_calls`, the raw `reasoning_content` is passed back in the next request.
If a tool-calling model is configured with the base/`EmptyFormatter`, the
assistant dict is collapsed to a `<think>…</think>content` string, destroying
`tool_calls` and `reasoning_content`, and the provider-compatible history can
no longer be replayed:

```json
{"error":{"message":"The `reasoning_content` in the thinking mode must be passed back to the API."}}
```

The correct fix is to use `FunctionCallFormatter` for tool-calling models. This
PR does not change that contract — it makes the misconfiguration **loud**
(a warning) and **documented**, instead of silently failing downstream.

# 🔍 相关 Issue / Related Issue

Related to #1107.

# ✅ 变更类型 / Type of Change

* [x] Refactor / guardrail + docs

# 🧪 如何测试 / How Has This Been Tested?

`tests/basic_tests/Components/test_formatter.py`:

1. `test_empty_formatter_warns_when_tool_calls_present` — the base formatter
   still collapses the message to text, but emits a warning naming
   `FunctionCallFormatter`.
2. `test_empty_formatter_wraps_reasoning_content_when_no_tool_calls` — existing
   `<think>` wrapping for non-tool-call responses is unchanged.
3. `test_function_call_formatter_preserves_dict` — regression check that
   `FunctionCallFormatter` preserves the full dict.

All `TestFormatter` cases pass; `flake8` is clean on the touched files.
