### PR TITLE
[Feature] Local-File Tracing Backend

### DIFF
--- a/lazyllm/tracing/backends/__init__.py
+++ b/lazyllm/tracing/backends/__init__.py
@@ -21,7 +21,7 @@ def _load_backend_classes(specs: Tuple[Tuple[str, str, str], ...]) -> Tuple[Dict
             module = import_module(module_path, package=__package__)
             backend_cls = getattr(module, class_name)
             classes[backend_cls.name] = backend_cls
-        except ImportError as exc:
+        except (ImportError, AttributeError) as exc:
             import_errors[backend_name] = exc
 
     return classes, import_errors

--- a/lazyllm/tracing/backends/__init__.py
+++ b/lazyllm/tracing/backends/__init__.py
@@ -2,8 +2,14 @@ from importlib import import_module
 from threading import Lock
 from typing import Dict, Tuple, Type
 
-_TRACE_BACKEND_SPECS = (('langfuse', '.langfuse.backend', 'LangfuseBackend'),)
-_CONSUME_BACKEND_SPECS = (('langfuse', '.langfuse', 'LangfuseConsumeBackend'),)
+_TRACE_BACKEND_SPECS = (
+    ('langfuse', '.langfuse.backend', 'LangfuseBackend'),
+    ('local', '.local.backend', 'LocalBackend'),
+)
+_CONSUME_BACKEND_SPECS = (
+    ('langfuse', '.langfuse', 'LangfuseConsumeBackend'),
+    ('local', '.local', 'LocalConsumeBackend'),
+)
 
 
 def _load_backend_classes(specs: Tuple[Tuple[str, str, str], ...]) -> Tuple[Dict[str, Type], Dict[str, Exception]]:

--- a/lazyllm/tracing/backends/langfuse/backend.py
+++ b/lazyllm/tracing/backends/langfuse/backend.py
@@ -1,6 +1,5 @@
 import json
 import time
-from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode, urlparse
 
@@ -8,10 +7,11 @@ import requests
 
 from lazyllm.common import LOG
 from lazyllm.thirdparty import opentelemetry
+from lazyllm.tracing.backends.base import ConsumeBackend, TracingBackend
+from lazyllm.tracing.backends.utils import extract_trace_metadata, iso_to_epoch
 from lazyllm.tracing.datamodel.raw import RawSpanRecord, RawTracePayload, RawTraceRecord
 from lazyllm.tracing.errors import ConsumeBackendError, TraceNotFound
 from lazyllm.tracing.semantics import SemanticType, is_valid_span_id
-from lazyllm.tracing.backends.base import ConsumeBackend, TracingBackend
 from .config import (
     build_basic_auth_header,
     build_otlp_traces_endpoint,
@@ -59,12 +59,6 @@ class LangfuseBackend(TracingBackend):
             attrs['langfuse.trace.input'] = otel_attrs['lazyllm.io.input']
         if 'lazyllm.io.output' in otel_attrs:
             attrs['langfuse.trace.output'] = otel_attrs['lazyllm.io.output']
-
-    def _copy_trace_metadata(self, attrs: Dict[str, Any], otel_attrs: Dict[str, Any]) -> None:
-        prefix = 'lazyllm.trace.metadata.'
-        for key, value in otel_attrs.items():
-            if key.startswith(prefix):
-                attrs[f'langfuse.trace.metadata.{key[len(prefix):]}'] = value
 
     def build_exporter(self):
         cfg = read_langfuse_connection()
@@ -118,7 +112,7 @@ class LangfuseBackend(TracingBackend):
 
         if is_root_span:
             self._copy_trace_attrs(attrs, otel_attrs)
-            self._copy_trace_metadata(attrs, otel_attrs)
+            attrs.update(extract_trace_metadata(otel_attrs, target_prefix='langfuse.trace.metadata.'))
 
         return attrs
 
@@ -143,19 +137,6 @@ class LangfuseConsumeBackend(ConsumeBackend):
         'metadata',
         'observations',
     })
-
-    def _iso_to_epoch(self, value: Optional[str]) -> Optional[float]:
-        if not value or not isinstance(value, str):
-            return None
-        text = value.replace('Z', '+00:00')
-        try:
-            dt = datetime.fromisoformat(text)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt.timestamp()
-        except ValueError:
-            LOG.warning(f'Failed to parse Langfuse timestamp: {value!r}')
-            return None
 
     def _raw_span_from_obs(self, trace_id: str, obs: Dict[str, Any]) -> RawSpanRecord:
         if 'id' not in obs:
@@ -191,7 +172,7 @@ class LangfuseConsumeBackend(ConsumeBackend):
             attributes.setdefault('gen_ai.request.model', obs['model'])
 
         name = obs.get('name') or ''
-        st = self._iso_to_epoch(obs.get('startTime'))
+        st = iso_to_epoch(obs.get('startTime'))
         if st is None:
             raise ValueError('observation missing startTime')
 
@@ -201,7 +182,7 @@ class LangfuseConsumeBackend(ConsumeBackend):
             parent_span_id=parent_span_id,
             name=name,
             start_time=st,
-            end_time=self._iso_to_epoch(obs.get('endTime')),
+            end_time=iso_to_epoch(obs.get('endTime')),
             status='error' if obs.get('level') == 'ERROR' else 'ok',
             attributes=attributes,
             input=obs.get('input'),
@@ -401,7 +382,7 @@ class LangfuseConsumeBackend(ConsumeBackend):
                 metadata=dict(metadata),
                 input=body.get('input'),
                 output=body.get('output'),
-                start_time=self._iso_to_epoch(body.get('timestamp')),
+                start_time=iso_to_epoch(body.get('timestamp')),
                 end_time=None,
                 status=None,
                 raw=trace_raw,

--- a/lazyllm/tracing/backends/langfuse/backend.py
+++ b/lazyllm/tracing/backends/langfuse/backend.py
@@ -173,8 +173,8 @@ class LangfuseConsumeBackend(ConsumeBackend):
 
         name = obs.get('name') or ''
         st = iso_to_epoch(obs.get('startTime'))
-        if st is None:
-            raise ValueError('observation missing startTime')
+        raw_end_time = obs.get('endTime')
+        end_time = iso_to_epoch(raw_end_time) if raw_end_time else None
 
         return RawSpanRecord(
             trace_id=trace_id,
@@ -182,7 +182,7 @@ class LangfuseConsumeBackend(ConsumeBackend):
             parent_span_id=parent_span_id,
             name=name,
             start_time=st,
-            end_time=iso_to_epoch(obs.get('endTime')),
+            end_time=end_time,
             status='error' if obs.get('level') == 'ERROR' else 'ok',
             attributes=attributes,
             input=obs.get('input'),
@@ -373,6 +373,8 @@ class LangfuseConsumeBackend(ConsumeBackend):
             if key not in self._PROMOTED_TRACE_FIELDS
         }
         try:
+            raw_start_time = body.get('timestamp')
+            start_time = iso_to_epoch(raw_start_time) if raw_start_time else None
             return RawTraceRecord(
                 trace_id=str(tid),
                 name=body.get('name'),
@@ -382,7 +384,7 @@ class LangfuseConsumeBackend(ConsumeBackend):
                 metadata=dict(metadata),
                 input=body.get('input'),
                 output=body.get('output'),
-                start_time=iso_to_epoch(body.get('timestamp')),
+                start_time=start_time,
                 end_time=None,
                 status=None,
                 raw=trace_raw,

--- a/lazyllm/tracing/backends/local/__init__.py
+++ b/lazyllm/tracing/backends/local/__init__.py
@@ -1,0 +1,9 @@
+from .backend import LocalBackend, LocalConsumeBackend, LocalFileSpanExporter
+from .config import read_local_storage_dir
+
+__all__ = [
+    'LocalBackend',
+    'LocalConsumeBackend',
+    'LocalFileSpanExporter',
+    'read_local_storage_dir',
+]

--- a/lazyllm/tracing/backends/local/__init__.py
+++ b/lazyllm/tracing/backends/local/__init__.py
@@ -1,9 +1,8 @@
-from .backend import LocalBackend, LocalConsumeBackend, LocalFileSpanExporter
+from .backend import LocalBackend, LocalConsumeBackend
 from .config import read_local_storage_dir
 
 __all__ = [
     'LocalBackend',
     'LocalConsumeBackend',
-    'LocalFileSpanExporter',
     'read_local_storage_dir',
 ]

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from filelock import FileLock, Timeout
 
@@ -28,7 +28,7 @@ def _strip_otel_id_prefix(value: str) -> str:
     return value[2:] if value.startswith('0x') else value
 
 
-def _span_to_json_line(span: opentelemetry.sdk.trace.ReadableSpan) -> str:
+def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> str:
     raw = span.to_json(indent=None)
     payload = json.loads(raw)
     if not isinstance(payload, dict):
@@ -130,7 +130,7 @@ class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
         self.storage_dir = Path(storage_dir) if storage_dir is not None else read_local_storage_dir()
         self._shutdown = False
 
-    def export(self, spans: Sequence[opentelemetry.sdk.trace.ReadableSpan]):
+    def export(self, spans: Sequence['opentelemetry.sdk.trace.ReadableSpan']):
         SpanExportResult = opentelemetry.sdk.trace.export.SpanExportResult
         if self._shutdown:
             return SpanExportResult.FAILURE

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -24,8 +24,8 @@ def _trace_lock(path: Path, timeout_seconds: Optional[float] = None) -> FileLock
     return FileLock(str(path) + '.lock', timeout=timeout)
 
 
-def _strip_otel_id_prefix(value: str) -> str:
-    return value[2:] if value.startswith('0x') else value
+def _strip_otel_id_prefix(value):
+    return value[2:] if isinstance(value, str) and value.startswith('0x') else value
 
 
 def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> str:
@@ -47,33 +47,35 @@ def _choose_root_span(spans: List[RawSpanRecord]) -> Optional[RawSpanRecord]:
 
 
 def _raw_span_from_otel_json(row: Dict[str, Any]) -> RawSpanRecord:
-    trace_id = _strip_otel_id_prefix(row['context'].get('trace_id'))
-    span_id = _strip_otel_id_prefix(row['context'].get('span_id'))
+    context = row.get('context')
+    if not isinstance(context, dict):
+        raise ConsumeBackendError('local span context field is missing or not a JSON object')
+
+    trace_id = _strip_otel_id_prefix(context.get('trace_id'))
+    span_id = _strip_otel_id_prefix(context.get('span_id'))
     if not is_valid_trace_id(trace_id) or not is_valid_span_id(span_id):
         raise ConsumeBackendError('local span context field is invalid')
-    parent_span_id = None
-    parent = row.get('parent_id')
-    if parent not in (None, ''):
-        candidate = _strip_otel_id_prefix(parent)
-        if is_valid_span_id(candidate):
-            parent_span_id = candidate
+
+    parent_span_id = _strip_otel_id_prefix(row.get('parent_id'))
+    parent_span_id = parent_span_id if is_valid_span_id(parent_span_id) else None
 
     attributes = row.get('attributes')
-    if attributes is None:
-        attributes = {}
     if not isinstance(attributes, dict):
         raise ConsumeBackendError('local span attributes field is not a JSON object')
 
     start_time = iso_to_epoch(row.get('start_time'))
-    if start_time is None:
-        raise ConsumeBackendError('local span missing start_time')
+    raw_end_time = row.get('end_time')
+    end_time = iso_to_epoch(raw_end_time) if raw_end_time else None
 
-    status_body = row.get('status') if isinstance(row.get('status'), dict) else {}
+    status_value = row.get('status')
+    status_body = status_value if isinstance(status_value, dict) else {}
     status_code = status_body.get('status_code')
     lazy_status = attributes.get('lazyllm.status')
     status = 'error' if status_code == 'ERROR' or lazy_status == 'error' else 'ok'
-    resource = row.get('resource') if isinstance(row.get('resource'), dict) else {}
-    resource_attrs = resource.get('attributes') if isinstance(resource.get('attributes'), dict) else {}
+    resource_value = row.get('resource')
+    resource = resource_value if isinstance(resource_value, dict) else {}
+    resource_attrs_value = resource.get('attributes')
+    resource_attrs = resource_attrs_value if isinstance(resource_attrs_value, dict) else {}
 
     metadata = {
         'attributes': dict(attributes),
@@ -86,7 +88,7 @@ def _raw_span_from_otel_json(row: Dict[str, Any]) -> RawSpanRecord:
         parent_span_id=parent_span_id,
         name=str(row.get('name') or ''),
         start_time=start_time,
-        end_time=iso_to_epoch(row.get('end_time')),
+        end_time=end_time,
         status=status,
         attributes=dict(attributes),
         input=attributes.get('lazyllm.io.input'),
@@ -125,9 +127,51 @@ def _raw_trace_from_spans(trace_id: str, spans: List[RawSpanRecord]) -> RawTrace
     )
 
 
+def _read_trace_lines(
+    path: Path,
+    trace_id: str,
+    timeout_seconds: Optional[float],
+) -> List[str]:
+    try:
+        with _trace_lock(path, timeout_seconds=timeout_seconds):
+            if not path.exists():
+                raise TraceNotFound(trace_id)
+            with path.open('r', encoding='utf-8') as file_obj:
+                return file_obj.readlines()
+    except Timeout as exc:
+        raise ConsumeBackendError(f'timed out waiting for local trace file lock: {path.name}') from exc
+
+
+def _raw_spans_from_lines(path_name: str, lines: List[str]) -> List[RawSpanRecord]:
+    spans = []
+    for line_no, line in enumerate(lines, start=1):
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            row = json.loads(text)
+        except ValueError as exc:
+            raise ConsumeBackendError(
+                f'invalid JSON in local trace file {path_name} at line {line_no}'
+            ) from exc
+        if not isinstance(row, dict):
+            raise ConsumeBackendError(
+                f'local trace file {path_name} line {line_no} is not a JSON object'
+            )
+
+        try:
+            spans.append(_raw_span_from_otel_json(row))
+        except (ConsumeBackendError, ValueError) as exc:
+            raise ConsumeBackendError(
+                f'invalid span in local trace file {path_name} at line {line_no}: {exc}'
+            ) from exc
+    return spans
+
+
 class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
     def __init__(self, storage_dir: Optional[Path] = None):
         self.storage_dir = Path(storage_dir) if storage_dir is not None else read_local_storage_dir()
+        self.storage_dir.mkdir(parents=True, exist_ok=True)
         self._shutdown = False
 
     def export(self, spans: Sequence['opentelemetry.sdk.trace.ReadableSpan']):
@@ -146,12 +190,11 @@ class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
             return SpanExportResult.FAILURE
 
         try:
-            self.storage_dir.mkdir(parents=True, exist_ok=True)
             for trace_id, lines in grouped.items():
                 path = _trace_path(self.storage_dir, trace_id)
                 with _trace_lock(path):
                     with path.open('a', encoding='utf-8') as file_obj:
-                        file_obj.write(''.join(line + '\n' for line in lines))
+                        file_obj.writelines(f'{line}\n' for line in lines)
         except Exception as exc:
             LOG.warning(f'LocalFileSpanExporter failed to write spans: {exc}')
             return SpanExportResult.FAILURE
@@ -172,6 +215,7 @@ class LocalBackend(TracingBackend):
         return LocalFileSpanExporter()
 
     def map_attributes(self, otel_attrs: Dict[str, Any]) -> Dict[str, Any]:
+        # Local exports keep the original OTel attributes in the JSONL payload.
         return {}
 
 
@@ -186,32 +230,7 @@ class LocalConsumeBackend(ConsumeBackend):
             raise ValueError(f'invalid trace_id: {trace_id!r}')
 
         path = _trace_path(self.storage_dir, trace_id)
-        if not path.exists():
-            raise TraceNotFound(trace_id)
-
-        rows: List[Dict[str, Any]] = []
-        try:
-            with _trace_lock(path, timeout_seconds=timeout_seconds):
-                with path.open('r', encoding='utf-8') as file_obj:
-                    for line_no, line in enumerate(file_obj, start=1):
-                        text = line.strip()
-                        if not text:
-                            continue
-                        try:
-                            row = json.loads(text)
-                        except ValueError as exc:
-                            raise ConsumeBackendError(
-                                f'invalid JSON in local trace file {path.name} at line {line_no}'
-                            ) from exc
-                        if not isinstance(row, dict):
-                            raise ConsumeBackendError(
-                                f'local trace file {path.name} line {line_no} is not a JSON object'
-                            )
-                        rows.append(row)
-        except Timeout as exc:
-            raise ConsumeBackendError(f'timed out waiting for local trace file lock: {path.name}') from exc
-
-        spans = [_raw_span_from_otel_json(row) for row in rows]
+        spans = _raw_spans_from_lines(path.name, _read_trace_lines(path, trace_id, timeout_seconds))
         spans = [span for span in spans if span.trace_id == trace_id]
         spans.sort(key=lambda span: (span.start_time, span.name, span.span_id))
         return RawTracePayload(

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
@@ -15,13 +16,27 @@ from lazyllm.tracing.semantics import is_valid_span_id, is_valid_trace_id
 from .config import read_local_storage_dir
 
 
+def _find_trace_path(storage_dir: Path, trace_id: str) -> Optional[Path]:
+    paths = sorted(storage_dir.glob(f'*_{trace_id}.jsonl'))
+    if len(paths) > 1:
+        LOG.warning(
+            f'Found multiple local trace files for trace_id={trace_id!r}: '
+            f'{[path.name for path in paths]}'
+        )
+    return paths[0] if paths else None
+
+
 def _trace_path(storage_dir: Path, trace_id: str) -> Path:
-    return storage_dir / f'{trace_id}.jsonl'
+    path = _find_trace_path(storage_dir, trace_id)
+    if path is not None:
+        return path
+    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    return storage_dir / f'{timestamp}_{trace_id}.jsonl'
 
 
-def _trace_lock(path: Path, timeout_seconds: Optional[float] = None) -> FileLock:
+def _trace_lock(storage_dir: Path, trace_id: str, timeout_seconds: Optional[float] = None) -> FileLock:
     timeout = timeout_seconds if timeout_seconds is not None else -1
-    return FileLock(str(path) + '.lock', timeout=timeout)
+    return FileLock(str(storage_dir / f'.{trace_id}.lock'), timeout=timeout)
 
 
 def _strip_otel_id_prefix(value):
@@ -127,19 +142,20 @@ def _raw_trace_from_spans(trace_id: str, spans: List[RawSpanRecord]) -> RawTrace
     )
 
 
-def _read_trace_lines(
-    path: Path,
+def _read_trace_file(
+    storage_dir: Path,
     trace_id: str,
     timeout_seconds: Optional[float],
-) -> List[str]:
+) -> tuple[str, List[str]]:
     try:
-        with _trace_lock(path, timeout_seconds=timeout_seconds):
-            if not path.exists():
+        with _trace_lock(storage_dir, trace_id, timeout_seconds=timeout_seconds):
+            path = _find_trace_path(storage_dir, trace_id)
+            if path is None:
                 raise TraceNotFound(trace_id)
             with path.open('r', encoding='utf-8') as file_obj:
-                return file_obj.readlines()
+                return path.name, file_obj.readlines()
     except Timeout as exc:
-        raise ConsumeBackendError(f'timed out waiting for local trace file lock: {path.name}') from exc
+        raise ConsumeBackendError(f'timed out waiting for local trace file lock: {trace_id}') from exc
 
 
 def _raw_spans_from_lines(path_name: str, lines: List[str]) -> List[RawSpanRecord]:
@@ -191,8 +207,8 @@ class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
 
         try:
             for trace_id, lines in grouped.items():
-                path = _trace_path(self.storage_dir, trace_id)
-                with _trace_lock(path):
+                with _trace_lock(self.storage_dir, trace_id):
+                    path = _trace_path(self.storage_dir, trace_id)
                     with path.open('a', encoding='utf-8') as file_obj:
                         file_obj.writelines(f'{line}\n' for line in lines)
         except Exception as exc:
@@ -229,8 +245,8 @@ class LocalConsumeBackend(ConsumeBackend):
         if not is_valid_trace_id(trace_id):
             raise ValueError(f'invalid trace_id: {trace_id!r}')
 
-        path = _trace_path(self.storage_dir, trace_id)
-        spans = _raw_spans_from_lines(path.name, _read_trace_lines(path, trace_id, timeout_seconds))
+        path_name, lines = _read_trace_file(self.storage_dir, trace_id, timeout_seconds)
+        spans = _raw_spans_from_lines(path_name, lines)
         return RawTracePayload(
             trace=_raw_trace_from_spans(trace_id, spans),
             spans=spans,

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -1,0 +1,220 @@
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from filelock import FileLock, Timeout
+
+from lazyllm.common import LOG
+from lazyllm.thirdparty import opentelemetry
+from lazyllm.tracing.backends.base import ConsumeBackend, TracingBackend
+from lazyllm.tracing.backends.utils import extract_trace_metadata, iso_to_epoch
+from lazyllm.tracing.datamodel.raw import RawSpanRecord, RawTracePayload, RawTraceRecord
+from lazyllm.tracing.errors import ConsumeBackendError, TraceNotFound
+from lazyllm.tracing.semantics import is_valid_span_id, is_valid_trace_id
+
+from .config import read_local_storage_dir
+
+
+def _trace_path(storage_dir: Path, trace_id: str) -> Path:
+    return storage_dir / f'{trace_id}.jsonl'
+
+
+def _trace_lock(path: Path, timeout_seconds: Optional[float] = None) -> FileLock:
+    timeout = timeout_seconds if timeout_seconds is not None else -1
+    return FileLock(str(path) + '.lock', timeout=timeout)
+
+
+def _strip_otel_id_prefix(value: str) -> str:
+    return value[2:] if value.startswith('0x') else value
+
+
+def _span_to_json_line(span: opentelemetry.sdk.trace.ReadableSpan) -> str:
+    raw = span.to_json(indent=None)
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise TypeError(f'span.to_json() must return JSON object, got {type(payload).__name__}')
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _choose_root_span(spans: List[RawSpanRecord]) -> Optional[RawSpanRecord]:
+    for span in spans:
+        if span.attributes.get('lazyllm.span.is_root') is True:
+            return span
+    for span in spans:
+        if span.parent_span_id is None:
+            return span
+    return spans[0] if spans else None
+
+
+def _raw_span_from_otel_json(row: Dict[str, Any]) -> RawSpanRecord:
+    trace_id = _strip_otel_id_prefix(row['context'].get('trace_id'))
+    span_id = _strip_otel_id_prefix(row['context'].get('span_id'))
+    if not is_valid_trace_id(trace_id) or not is_valid_span_id(span_id):
+        raise ConsumeBackendError('local span context field is invalid')
+    parent_span_id = None
+    parent = row.get('parent_id')
+    if parent not in (None, ''):
+        candidate = _strip_otel_id_prefix(parent)
+        if is_valid_span_id(candidate):
+            parent_span_id = candidate
+
+    attributes = row.get('attributes')
+    if attributes is None:
+        attributes = {}
+    if not isinstance(attributes, dict):
+        raise ConsumeBackendError('local span attributes field is not a JSON object')
+
+    start_time = iso_to_epoch(row.get('start_time'))
+    if start_time is None:
+        raise ConsumeBackendError('local span missing start_time')
+
+    status_body = row.get('status') if isinstance(row.get('status'), dict) else {}
+    status_code = status_body.get('status_code')
+    lazy_status = attributes.get('lazyllm.status')
+    status = 'error' if status_code == 'ERROR' or lazy_status == 'error' else 'ok'
+    resource = row.get('resource') if isinstance(row.get('resource'), dict) else {}
+    resource_attrs = resource.get('attributes') if isinstance(resource.get('attributes'), dict) else {}
+
+    metadata = {
+        'attributes': dict(attributes),
+        'resourceAttributes': dict(resource_attrs),
+    }
+
+    return RawSpanRecord(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_span_id=parent_span_id,
+        name=str(row.get('name') or ''),
+        start_time=start_time,
+        end_time=iso_to_epoch(row.get('end_time')),
+        status=status,
+        attributes=dict(attributes),
+        input=attributes.get('lazyllm.io.input'),
+        output=attributes.get('lazyllm.io.output'),
+        metadata=metadata,
+        error_message=attributes.get('lazyllm.error.message') or status_body.get('description'),
+        raw=dict(row),
+    )
+
+
+def _raw_trace_from_spans(trace_id: str, spans: List[RawSpanRecord]) -> RawTraceRecord:
+    root = _choose_root_span(spans)
+    root_attrs = root.attributes if root is not None else {}
+    start_time = min((span.start_time for span in spans), default=None)
+    end_values = [span.end_time for span in spans if span.end_time is not None]
+    end_time = max(end_values) if end_values else None
+    status = 'error' if any(span.status == 'error' for span in spans) else 'ok'
+    tags = root_attrs.get('lazyllm.trace.tags')
+    if not isinstance(tags, list):
+        tags = []
+    metadata = extract_trace_metadata(root_attrs)
+
+    return RawTraceRecord(
+        trace_id=trace_id,
+        name=root_attrs.get('lazyllm.trace.name') or (root.name if root is not None else trace_id),
+        session_id=root_attrs.get('session.id'),
+        user_id=root_attrs.get('user.id'),
+        tags=[str(item) for item in tags],
+        metadata=metadata,
+        input=root_attrs.get('lazyllm.io.input'),
+        output=root_attrs.get('lazyllm.io.output'),
+        start_time=start_time,
+        end_time=end_time,
+        status=status,
+        raw={'backend': 'local', 'span_count': len(spans)},
+    )
+
+
+class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
+    def __init__(self, storage_dir: Optional[Path] = None):
+        self.storage_dir = Path(storage_dir) if storage_dir is not None else read_local_storage_dir()
+        self._shutdown = False
+
+    def export(self, spans: Sequence[opentelemetry.sdk.trace.ReadableSpan]):
+        SpanExportResult = opentelemetry.sdk.trace.export.SpanExportResult
+        if self._shutdown:
+            return SpanExportResult.FAILURE
+
+        grouped: Dict[str, List[str]] = {}
+        try:
+            for span in spans:
+                context = span.get_span_context()
+                trace_id = f'{context.trace_id:032x}'
+                grouped.setdefault(trace_id, []).append(_span_to_json_line(span))
+        except Exception as exc:
+            LOG.warning(f'LocalFileSpanExporter failed to serialize spans: {exc}')
+            return SpanExportResult.FAILURE
+
+        try:
+            self.storage_dir.mkdir(parents=True, exist_ok=True)
+            for trace_id, lines in grouped.items():
+                path = _trace_path(self.storage_dir, trace_id)
+                with _trace_lock(path):
+                    with path.open('a', encoding='utf-8') as file_obj:
+                        file_obj.write(''.join(line + '\n' for line in lines))
+        except Exception as exc:
+            LOG.warning(f'LocalFileSpanExporter failed to write spans: {exc}')
+            return SpanExportResult.FAILURE
+
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+class LocalBackend(TracingBackend):
+    name = 'local'
+
+    def build_exporter(self):
+        return LocalFileSpanExporter()
+
+    def map_attributes(self, otel_attrs: Dict[str, Any]) -> Dict[str, Any]:
+        return {}
+
+
+class LocalConsumeBackend(ConsumeBackend):
+    name = 'local'
+
+    def __init__(self, storage_dir: Optional[Path] = None):
+        self.storage_dir = Path(storage_dir) if storage_dir is not None else read_local_storage_dir()
+
+    def fetch_trace_payload(self, trace_id: str, *, timeout_seconds: Optional[float] = None) -> RawTracePayload:
+        if not is_valid_trace_id(trace_id):
+            raise ValueError(f'invalid trace_id: {trace_id!r}')
+
+        path = _trace_path(self.storage_dir, trace_id)
+        if not path.exists():
+            raise TraceNotFound(trace_id)
+
+        rows: List[Dict[str, Any]] = []
+        try:
+            with _trace_lock(path, timeout_seconds=timeout_seconds):
+                with path.open('r', encoding='utf-8') as file_obj:
+                    for line_no, line in enumerate(file_obj, start=1):
+                        text = line.strip()
+                        if not text:
+                            continue
+                        try:
+                            row = json.loads(text)
+                        except ValueError as exc:
+                            raise ConsumeBackendError(
+                                f'invalid JSON in local trace file {path.name} at line {line_no}'
+                            ) from exc
+                        if not isinstance(row, dict):
+                            raise ConsumeBackendError(
+                                f'local trace file {path.name} line {line_no} is not a JSON object'
+                            )
+                        rows.append(row)
+        except Timeout as exc:
+            raise ConsumeBackendError(f'timed out waiting for local trace file lock: {path.name}') from exc
+
+        spans = [_raw_span_from_otel_json(row) for row in rows]
+        spans = [span for span in spans if span.trace_id == trace_id]
+        spans.sort(key=lambda span: (span.start_time, span.name, span.span_id))
+        return RawTracePayload(
+            trace=_raw_trace_from_spans(trace_id, spans),
+            spans=spans,
+        )

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -231,8 +231,6 @@ class LocalConsumeBackend(ConsumeBackend):
 
         path = _trace_path(self.storage_dir, trace_id)
         spans = _raw_spans_from_lines(path.name, _read_trace_lines(path, trace_id, timeout_seconds))
-        spans = [span for span in spans if span.trace_id == trace_id]
-        spans.sort(key=lambda span: (span.start_time, span.name, span.span_id))
         return RawTracePayload(
             trace=_raw_trace_from_spans(trace_id, spans),
             spans=spans,

--- a/lazyllm/tracing/backends/local/config.py
+++ b/lazyllm/tracing/backends/local/config.py
@@ -18,9 +18,7 @@ config.add(
 def read_local_storage_dir() -> Path:
     value = config['trace_local_storage_dir']
     if not value:
-        LOG.warning(
-            f'LAZYLLM_TRACE_LOCAL_STORAGE_DIR is empty; falling back to {_DEFAULT_STORAGE_DIR}'
-        )
+        LOG.warning(f'LAZYLLM_TRACE_LOCAL_STORAGE_DIR is empty; using {_DEFAULT_STORAGE_DIR}')
         value = str(_DEFAULT_STORAGE_DIR)
     return Path(value).expanduser().resolve()
 

--- a/lazyllm/tracing/backends/local/config.py
+++ b/lazyllm/tracing/backends/local/config.py
@@ -1,13 +1,28 @@
-import os
 from pathlib import Path
 
+from lazyllm.common import LOG
+from lazyllm.configs import config
 
-_DEFAULT_STORAGE_DIR = Path(__file__).resolve().parent / '.temp'
+
+_DEFAULT_STORAGE_DIR = Path(config['home']) / 'traces'
+
+config.add(
+    'trace_local_storage_dir',
+    str,
+    str(_DEFAULT_STORAGE_DIR),
+    'TRACE_LOCAL_STORAGE_DIR',
+    description='Directory used by the local tracing backend to store JSONL trace files.',
+)
 
 
 def read_local_storage_dir() -> Path:
-    value = os.getenv('LAZYLLM_TRACE_LOCAL_STORAGE_DIR')
-    return Path(value).expanduser() if value else _DEFAULT_STORAGE_DIR
+    value = config['trace_local_storage_dir']
+    if not value:
+        LOG.warning(
+            f'LAZYLLM_TRACE_LOCAL_STORAGE_DIR is empty; falling back to {_DEFAULT_STORAGE_DIR}'
+        )
+        value = str(_DEFAULT_STORAGE_DIR)
+    return Path(value).expanduser().resolve()
 
 
 __all__ = ['read_local_storage_dir']

--- a/lazyllm/tracing/backends/local/config.py
+++ b/lazyllm/tracing/backends/local/config.py
@@ -1,0 +1,13 @@
+import os
+from pathlib import Path
+
+
+_DEFAULT_STORAGE_DIR = Path(__file__).resolve().parent / '.temp'
+
+
+def read_local_storage_dir() -> Path:
+    value = os.getenv('LAZYLLM_TRACE_LOCAL_STORAGE_DIR')
+    return Path(value).expanduser() if value else _DEFAULT_STORAGE_DIR
+
+
+__all__ = ['read_local_storage_dir']

--- a/lazyllm/tracing/backends/utils.py
+++ b/lazyllm/tracing/backends/utils.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from lazyllm.common import LOG
+
+
+_TRACE_METADATA_PREFIX = 'lazyllm.trace.metadata.'
+
+
+def extract_trace_metadata(attrs: Dict[str, Any], target_prefix: str = '') -> Dict[str, Any]:
+    return {
+        f'{target_prefix}{key[len(_TRACE_METADATA_PREFIX):]}': value
+        for key, value in attrs.items()
+        if key.startswith(_TRACE_METADATA_PREFIX)
+    }
+
+
+def iso_to_epoch(value: Optional[str]) -> Optional[float]:
+    if not value or not isinstance(value, str):
+        return None
+    text = value.replace('Z', '+00:00')
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        LOG.warning(f'Failed to parse tracing backend timestamp: {value!r}')
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.timestamp()
+
+
+__all__ = ['extract_trace_metadata', 'iso_to_epoch']

--- a/lazyllm/tracing/backends/utils.py
+++ b/lazyllm/tracing/backends/utils.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
-
-from lazyllm.common import LOG
+from typing import Any, Dict
 
 
 _TRACE_METADATA_PREFIX = 'lazyllm.trace.metadata.'
@@ -15,15 +13,14 @@ def extract_trace_metadata(attrs: Dict[str, Any], target_prefix: str = '') -> Di
     }
 
 
-def iso_to_epoch(value: Optional[str]) -> Optional[float]:
-    if not value or not isinstance(value, str):
-        return None
-    text = value.replace('Z', '+00:00')
+def iso_to_epoch(value: str) -> float:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f'invalid tracing backend timestamp: {value!r}')
     try:
+        text = value.removesuffix('Z') + '+00:00' if value.endswith('Z') else value
         dt = datetime.fromisoformat(text)
-    except ValueError:
-        LOG.warning(f'Failed to parse tracing backend timestamp: {value!r}')
-        return None
+    except ValueError as exc:
+        raise ValueError(f'invalid tracing backend timestamp: {value!r}') from exc
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.timestamp()

--- a/tests/basic_tests/Tracing/test_local_backend.py
+++ b/tests/basic_tests/Tracing/test_local_backend.py
@@ -1,5 +1,6 @@
 import json
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 
 import pytest
 
@@ -9,18 +10,24 @@ from lazyllm.thirdparty import opentelemetry
 TRACE_ID_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 
-def _new_tracer_with_exporter(storage_dir):
-    from lazyllm.tracing.backends.local import LocalFileSpanExporter
+@contextmanager
+def _tracer_with_exporter(storage_dir):
+    from lazyllm.tracing.backends.local.backend import LocalFileSpanExporter
 
     exporter = LocalFileSpanExporter(storage_dir=storage_dir)
     provider = opentelemetry.sdk.trace.TracerProvider()
     provider.add_span_processor(opentelemetry.sdk.trace.export.SimpleSpanProcessor(exporter))
-    return provider, provider.get_tracer('lazyllm.tracing.local.test')
+    try:
+        yield provider.get_tracer('lazyllm.tracing.local.test')
+    finally:
+        try:
+            provider.force_flush()
+        finally:
+            provider.shutdown()
 
 
 def _emit_real_trace(storage_dir, root_name, child_names=()):
-    provider, tracer = _new_tracer_with_exporter(storage_dir)
-    try:
+    with _tracer_with_exporter(storage_dir) as tracer:
         with tracer.start_as_current_span(root_name) as root:
             root.set_attribute('lazyllm.span.kind', 'flow')
             root.set_attribute('lazyllm.span.is_root', True)
@@ -30,10 +37,7 @@ def _emit_real_trace(storage_dir, root_name, child_names=()):
                 with tracer.start_as_current_span(child_name) as child:
                     child.set_attribute('lazyllm.span.kind', 'callable')
                     child.set_attribute('lazyllm.status', 'ok')
-        provider.force_flush()
-        return trace_id
-    finally:
-        provider.shutdown()
+    return trace_id
 
 
 @pytest.mark.parametrize(
@@ -67,32 +71,28 @@ def test_local_backend_writes_and_reads_trace(tmp_path, root_name, child_names, 
 def test_local_backend_consumes_concurrent_appends_to_same_trace(tmp_path):
     from lazyllm.tracing.backends.local import LocalConsumeBackend
 
-    provider, tracer = _new_tracer_with_exporter(tmp_path)
-    parent_span_id = '1111111111111111'
-    parent_context = opentelemetry.trace.set_span_in_context(
-        opentelemetry.trace.NonRecordingSpan(
-            opentelemetry.trace.SpanContext(
-                trace_id=int(TRACE_ID_A, 16),
-                span_id=int(parent_span_id, 16),
-                is_remote=False,
-                trace_flags=opentelemetry.trace.TraceFlags(0x01),
+    with _tracer_with_exporter(tmp_path) as tracer:
+        parent_span_id = '1111111111111111'
+        parent_context = opentelemetry.trace.set_span_in_context(
+            opentelemetry.trace.NonRecordingSpan(
+                opentelemetry.trace.SpanContext(
+                    trace_id=int(TRACE_ID_A, 16),
+                    span_id=int(parent_span_id, 16),
+                    is_remote=False,
+                    trace_flags=opentelemetry.trace.TraceFlags(0x01),
+                )
             )
         )
-    )
 
-    def emit_one(idx):
-        with tracer.start_as_current_span(f'span-{idx}', context=parent_context) as span:
-            span.set_attribute('lazyllm.span.kind', 'callable')
-            span.set_attribute('lazyllm.status', 'ok')
+        def emit_one(idx):
+            with tracer.start_as_current_span(f'span-{idx}', context=parent_context) as span:
+                span.set_attribute('lazyllm.span.kind', 'callable')
+                span.set_attribute('lazyllm.status', 'ok')
 
-    num_spans = 64
+        num_spans = 64
 
-    try:
         with ThreadPoolExecutor(max_workers=16) as pool:
             list(pool.map(emit_one, range(1, num_spans + 1)))
-        provider.force_flush()
-    finally:
-        provider.shutdown()
 
     lines = (tmp_path / f'{TRACE_ID_A}.jsonl').read_text(encoding='utf-8').splitlines()
     payloads = [json.loads(line) for line in lines]
@@ -110,8 +110,7 @@ def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
     from lazyllm.tracing.backends.local import LocalConsumeBackend
     from lazyllm.tracing.consume.reconstruction import rebuild
 
-    provider, tracer = _new_tracer_with_exporter(tmp_path)
-    try:
+    with _tracer_with_exporter(tmp_path) as tracer:
         with tracer.start_as_current_span('root') as root:
             root_context = root.get_span_context()
             trace_id = f'{root_context.trace_id:032x}'
@@ -132,9 +131,6 @@ def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
                 child.set_attribute('lazyllm.status', 'ok')
                 child.set_attribute('lazyllm.io.input', '{"args":["hello"],"kwargs":{}}')
                 child.set_attribute('lazyllm.io.output', 'world')
-        provider.force_flush()
-    finally:
-        provider.shutdown()
 
     payload = LocalConsumeBackend(storage_dir=tmp_path).fetch_trace_payload(trace_id)
     structured = rebuild(payload.trace, payload.spans)

--- a/tests/basic_tests/Tracing/test_local_backend.py
+++ b/tests/basic_tests/Tracing/test_local_backend.py
@@ -10,6 +10,12 @@ from lazyllm.thirdparty import opentelemetry
 TRACE_ID_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
 
 
+def _read_trace_jsonl_lines(storage_dir, trace_id):
+    stored_files = list(storage_dir.glob(f'*_{trace_id}.jsonl'))
+    assert len(stored_files) == 1
+    return stored_files[0].read_text(encoding='utf-8').splitlines()
+
+
 @contextmanager
 def _tracer_with_exporter(storage_dir):
     from lazyllm.tracing.backends.local.backend import LocalFileSpanExporter
@@ -54,7 +60,7 @@ def test_local_backend_writes_and_reads_trace(tmp_path, root_name, child_names, 
     trace_id = _emit_real_trace(tmp_path, root_name, child_names=child_names)
 
     backend = LocalConsumeBackend(storage_dir=tmp_path)
-    lines = (tmp_path / f'{trace_id}.jsonl').read_text(encoding='utf-8').splitlines()
+    lines = _read_trace_jsonl_lines(tmp_path, trace_id)
     payloads = [json.loads(line) for line in lines]
     raw = backend.fetch_trace_payload(trace_id)
 
@@ -94,7 +100,7 @@ def test_local_backend_consumes_concurrent_appends_to_same_trace(tmp_path):
         with ThreadPoolExecutor(max_workers=16) as pool:
             list(pool.map(emit_one, range(1, num_spans + 1)))
 
-    lines = (tmp_path / f'{TRACE_ID_A}.jsonl').read_text(encoding='utf-8').splitlines()
+    lines = _read_trace_jsonl_lines(tmp_path, TRACE_ID_A)
     payloads = [json.loads(line) for line in lines]
     raw = LocalConsumeBackend(storage_dir=tmp_path).fetch_trace_payload(TRACE_ID_A)
 
@@ -136,9 +142,10 @@ def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
     structured = rebuild(payload.trace, payload.spans)
     stored_rows = [
         json.loads(line)
-        for line in (tmp_path / f'{trace_id}.jsonl').read_text(encoding='utf-8').splitlines()
+        for line in _read_trace_jsonl_lines(tmp_path, trace_id)
     ]
     stored_by_name = {row['name']: row for row in stored_rows}
+    spans_by_id = {span.span_id: span for span in payload.spans}
 
     assert payload.trace.trace_id == trace_id
     assert payload.trace.name == 'root'
@@ -152,11 +159,11 @@ def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
     assert stored_by_name['child']['parent_id'] == f'0x{root_id}'
     assert {span.span_id for span in payload.spans} == {root_id, child_id}
     assert all(not span.span_id.startswith('0x') for span in payload.spans)
-    assert payload.spans[0].parent_span_id is None
-    assert payload.spans[1].parent_span_id == root_id
-    assert payload.spans[1].attributes['lazyllm.semantic_type'] == 'llm'
-    assert payload.spans[1].input == '{"args":["hello"],"kwargs":{}}'
-    assert payload.spans[1].output == 'world'
+    assert spans_by_id[root_id].parent_span_id is None
+    assert spans_by_id[child_id].parent_span_id == root_id
+    assert spans_by_id[child_id].attributes['lazyllm.semantic_type'] == 'llm'
+    assert spans_by_id[child_id].input == '{"args":["hello"],"kwargs":{}}'
+    assert spans_by_id[child_id].output == 'world'
     assert structured.trace_id == trace_id
     assert structured.execution_tree.name == 'root'
     assert structured.execution_tree.children[0].name == 'child'

--- a/tests/basic_tests/Tracing/test_local_backend.py
+++ b/tests/basic_tests/Tracing/test_local_backend.py
@@ -150,7 +150,7 @@ def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
     assert stored_by_name['root']['context']['span_id'] == f'0x{root_id}'
     assert stored_by_name['child']['context']['span_id'] == f'0x{child_id}'
     assert stored_by_name['child']['parent_id'] == f'0x{root_id}'
-    assert [span.span_id for span in payload.spans] == [root_id, child_id]
+    assert {span.span_id for span in payload.spans} == {root_id, child_id}
     assert all(not span.span_id.startswith('0x') for span in payload.spans)
     assert payload.spans[0].parent_span_id is None
     assert payload.spans[1].parent_span_id == root_id

--- a/tests/basic_tests/Tracing/test_local_backend.py
+++ b/tests/basic_tests/Tracing/test_local_backend.py
@@ -1,0 +1,166 @@
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from lazyllm.thirdparty import opentelemetry
+
+
+TRACE_ID_A = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+
+def _new_tracer_with_exporter(storage_dir):
+    from lazyllm.tracing.backends.local import LocalFileSpanExporter
+
+    exporter = LocalFileSpanExporter(storage_dir=storage_dir)
+    provider = opentelemetry.sdk.trace.TracerProvider()
+    provider.add_span_processor(opentelemetry.sdk.trace.export.SimpleSpanProcessor(exporter))
+    return provider, provider.get_tracer('lazyllm.tracing.local.test')
+
+
+def _emit_real_trace(storage_dir, root_name, child_names=()):
+    provider, tracer = _new_tracer_with_exporter(storage_dir)
+    try:
+        with tracer.start_as_current_span(root_name) as root:
+            root.set_attribute('lazyllm.span.kind', 'flow')
+            root.set_attribute('lazyllm.span.is_root', True)
+            root.set_attribute('lazyllm.status', 'ok')
+            trace_id = f'{root.get_span_context().trace_id:032x}'
+            for child_name in child_names:
+                with tracer.start_as_current_span(child_name) as child:
+                    child.set_attribute('lazyllm.span.kind', 'callable')
+                    child.set_attribute('lazyllm.status', 'ok')
+        provider.force_flush()
+        return trace_id
+    finally:
+        provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    'root_name, child_names, expected_count',
+    [
+        ('root-only', (), 1),
+        ('root-one-child', ('child-a',), 2),
+        ('root-many-children', tuple(f'step-{i}' for i in range(5)), 6),
+    ],
+)
+def test_local_backend_writes_and_reads_trace(tmp_path, root_name, child_names, expected_count):
+    from lazyllm.tracing.backends.local import LocalConsumeBackend
+
+    trace_id = _emit_real_trace(tmp_path, root_name, child_names=child_names)
+
+    backend = LocalConsumeBackend(storage_dir=tmp_path)
+    lines = (tmp_path / f'{trace_id}.jsonl').read_text(encoding='utf-8').splitlines()
+    payloads = [json.loads(line) for line in lines]
+    raw = backend.fetch_trace_payload(trace_id)
+
+    assert len(lines) == expected_count
+    assert all('\n' not in line for line in lines)
+    assert {payload['name'] for payload in payloads} == {root_name, *child_names}
+    assert all(payload['context']['trace_id'] == f'0x{trace_id}' for payload in payloads)
+    assert raw.trace.trace_id == trace_id and raw.trace.name == root_name
+    assert {span.name for span in raw.spans} == {root_name, *child_names}
+    assert all(span.trace_id == trace_id for span in raw.spans)
+    assert all(not span.span_id.startswith('0x') for span in raw.spans)
+
+
+def test_local_backend_consumes_concurrent_appends_to_same_trace(tmp_path):
+    from lazyllm.tracing.backends.local import LocalConsumeBackend
+
+    provider, tracer = _new_tracer_with_exporter(tmp_path)
+    parent_span_id = '1111111111111111'
+    parent_context = opentelemetry.trace.set_span_in_context(
+        opentelemetry.trace.NonRecordingSpan(
+            opentelemetry.trace.SpanContext(
+                trace_id=int(TRACE_ID_A, 16),
+                span_id=int(parent_span_id, 16),
+                is_remote=False,
+                trace_flags=opentelemetry.trace.TraceFlags(0x01),
+            )
+        )
+    )
+
+    def emit_one(idx):
+        with tracer.start_as_current_span(f'span-{idx}', context=parent_context) as span:
+            span.set_attribute('lazyllm.span.kind', 'callable')
+            span.set_attribute('lazyllm.status', 'ok')
+
+    num_spans = 64
+
+    try:
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            list(pool.map(emit_one, range(1, num_spans + 1)))
+        provider.force_flush()
+    finally:
+        provider.shutdown()
+
+    lines = (tmp_path / f'{TRACE_ID_A}.jsonl').read_text(encoding='utf-8').splitlines()
+    payloads = [json.loads(line) for line in lines]
+    raw = LocalConsumeBackend(storage_dir=tmp_path).fetch_trace_payload(TRACE_ID_A)
+
+    assert len(lines) == num_spans and len(raw.spans) == num_spans
+    assert {payload['name'] for payload in payloads} == {f'span-{idx}' for idx in range(1, num_spans + 1)}
+    assert all(payload['context']['trace_id'] == f'0x{TRACE_ID_A}' for payload in payloads)
+    assert {span.name for span in raw.spans} == {f'span-{idx}' for idx in range(1, num_spans + 1)}
+    assert all(span.trace_id == TRACE_ID_A for span in raw.spans)
+    assert all(span.parent_span_id == parent_span_id for span in raw.spans)
+
+
+def test_consume_backend_rebuilds_raw_payload_from_local_jsonl(tmp_path):
+    from lazyllm.tracing.backends.local import LocalConsumeBackend
+    from lazyllm.tracing.consume.reconstruction import rebuild
+
+    provider, tracer = _new_tracer_with_exporter(tmp_path)
+    try:
+        with tracer.start_as_current_span('root') as root:
+            root_context = root.get_span_context()
+            trace_id = f'{root_context.trace_id:032x}'
+            root_id = f'{root_context.span_id:016x}'
+            root.set_attribute('lazyllm.span.kind', 'flow')
+            root.set_attribute('lazyllm.span.is_root', True)
+            root.set_attribute('lazyllm.status', 'ok')
+            root.set_attribute('lazyllm.trace.name', 'root')
+            root.set_attribute('lazyllm.trace.tags', ['local', 'poc'])
+            root.set_attribute('lazyllm.trace.metadata.case', 'unit')
+            root.set_attribute('session.id', 'session-1')
+            root.set_attribute('user.id', 'user-1')
+
+            with tracer.start_as_current_span('child') as child:
+                child_id = f'{child.get_span_context().span_id:016x}'
+                child.set_attribute('lazyllm.span.kind', 'callable')
+                child.set_attribute('lazyllm.semantic_type', 'llm')
+                child.set_attribute('lazyllm.status', 'ok')
+                child.set_attribute('lazyllm.io.input', '{"args":["hello"],"kwargs":{}}')
+                child.set_attribute('lazyllm.io.output', 'world')
+        provider.force_flush()
+    finally:
+        provider.shutdown()
+
+    payload = LocalConsumeBackend(storage_dir=tmp_path).fetch_trace_payload(trace_id)
+    structured = rebuild(payload.trace, payload.spans)
+    stored_rows = [
+        json.loads(line)
+        for line in (tmp_path / f'{trace_id}.jsonl').read_text(encoding='utf-8').splitlines()
+    ]
+    stored_by_name = {row['name']: row for row in stored_rows}
+
+    assert payload.trace.trace_id == trace_id
+    assert payload.trace.name == 'root'
+    assert payload.trace.session_id == 'session-1'
+    assert payload.trace.user_id == 'user-1'
+    assert payload.trace.tags == ['local', 'poc']
+    assert payload.trace.metadata == {'case': 'unit'}
+    assert stored_by_name['root']['context']['trace_id'] == f'0x{trace_id}'
+    assert stored_by_name['root']['context']['span_id'] == f'0x{root_id}'
+    assert stored_by_name['child']['context']['span_id'] == f'0x{child_id}'
+    assert stored_by_name['child']['parent_id'] == f'0x{root_id}'
+    assert [span.span_id for span in payload.spans] == [root_id, child_id]
+    assert all(not span.span_id.startswith('0x') for span in payload.spans)
+    assert payload.spans[0].parent_span_id is None
+    assert payload.spans[1].parent_span_id == root_id
+    assert payload.spans[1].attributes['lazyllm.semantic_type'] == 'llm'
+    assert payload.spans[1].input == '{"args":["hello"],"kwargs":{}}'
+    assert payload.spans[1].output == 'world'
+    assert structured.trace_id == trace_id
+    assert structured.execution_tree.name == 'root'
+    assert structured.execution_tree.children[0].name == 'child'


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 新增 local file tracing backend，将 trace 数据以 JSONL 格式写入本地文件，不依赖外部服务即可完成 trace 的导出和消费
- 从 langfuse backend 中提取 `iso_to_epoch`、`extract_trace_metadata` 到公共 `utils.py`，langfuse backend 改为调用公共实现

---

# 🎯 问题背景 / Problem Context

- 当前 tracing 只有 langfuse 一个 backend，使用门槛较高（需要部署 Langfuse 服务），无法在本地开发或无外网环境下快速查看 trace 数据

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `pytest tests/basic_tests/Tracing/test_local_backend.py` — 验证本地 backend 的写入、读取、并发追加、完整 payload 重建
2. 跑 lint: `make lint-only-diff`

---

# ⚡ 更新后的用法示例 / Usage After Update

导出 trace（写入）：

```python
import os
os.environ['LAZYLLM_TRACE_BACKEND'] = 'local'
# 可选：自定义存储目录，默认 ~/.lazyllm/traces/
# os.environ['LAZYLLM_TRACE_LOCAL_STORAGE_DIR'] = '/tmp/traces'
# 之后正常使用 LazyLLM，trace 会自动写入本地 JSONL 文件
```

消费 trace（读取）：

```python
import os
os.environ['LAZYLLM_TRACE_CONSUME_BACKEND'] = 'local'
os.environ['LAZYLLM_TRACE_CONSUME_TIMEOUT'] = '30'

from lazyllm.tracing.backends import get_consume_backend
from lazyllm.tracing.consume.reconstruction import rebuild

backend = get_consume_backend('local')
raw = backend.fetch_trace_payload(trace_id)
structured = rebuild(raw.trace, raw.spans)
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

`iso_to_epoch`、`extract_trace_metadata` 作为私有方法写在 `langfuse/backend.py` 中，无法复用。

## After

提取到 `lazyllm/tracing/backends/utils.py`，langfuse 和 local backend 共用。

# ⚠️ 注意事项 / Additional Notes

* 存储目录默认为 `~/.lazyllm/traces/`，可通过环境变量 `LAZYLLM_TRACE_LOCAL_STORAGE_DIR` 自定义
* 并发写入同一 trace 文件时使用 filelock 保证安全

---


# 🧠 AI 参与情况 / AI Involvement

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
```text
[Using Superpowers]
 针对 [tracing](./lazyllm/tracing) 目录下构建的链路追踪和链路消费的观测系统，目前是强依赖于langfuse后端才能跑通的，我希望能够有一个本地的基于文件存储的后端(用于替换langfuse)，这样在启用追踪时无需拥有真实的langfuse系统了，并且性能也更好。我目前的方案如下：
1. 在 [backends](./lazyllm/tracing/backends) 下新建一个local文件夹，类似同级目录下的langfuse，定义相关的类型。
2. 自定义一个LocalFileSpanExporter，继承OTel的SpanExporter，在export函数中把spans的每个span通过to_json导出（还需要转化为单行json），后续写入到以[trace_id].jsonl命名的文件之中。
3. 导出的spans按照这样的目录结构存储：在新建的local文件夹内创建一个 .temp 文件夹(已被gitignore忽略)用于存储多个[trace_id].jsonl文件，每个jsonl文件按行存储的是相同trace_id的spans。
4. 新定义消费端LocalBackend和LocalConsumeBackend，其中LocalConsumeBackend需要所实现的几个函数需要读取某个[trace_id].jsonl文件来把相关span组装起来，并进行字段的匹配。
5. 注意在自定义的SpanExporter中写文件时，需要考虑并发问题。
6. [poc](./lazyllm/tracing/poc) 目录下分别是tracing写入和consume消费的两个py的poc，是可以直接运行的，运行的结果为该目录下的json文件，是消费端读取后打印的。请你交付前确保这两个poc能够成功运行并符合预期（需要略微修改poc的代码）
```

生成 `2026-05-07-local-file-tracing-backend.md` 计划方案。

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

## **问题点 / Issues：**

1. 同一个trace_id写入span时的并发问题
2. 测试中使用自定义的Span，而不是直接采用OTel Span
3. 不应添加全局config参数污染环境
4. 兜底操作过多，try-catch包裹的代码段过长
5. langfuse和local的backend中，公共函数提取存在问题

## 🔧 人工干预过程 / Human Intervention

依次让codex更正计划文档中的上述问题点。

### 最终策略总结 / Final Strategy Summary

仔细阅读计划文档，能有效保证AI的后续代码编写正确

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`80%`
* 人工修改占比 / Human modifications：`20%`

**主要人工修改点 / Key Human Modifications：**

* [ ] 逻辑修正 / Logic fixes
* [x] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [x] 代码风格 / Code style
* [ ] 架构调整 / Architecture adjustments

---

# ⚠️ AI 问题记录 / AI Failure Cases

本次撰写代码的过程中，没有仔细阅读AI对于两个后端(langfuse和local)公共函数的提取操作的文档，导致后续AI生成的相关代码不可用，需要重新修改。