### PR TITLE
---

### DIFF
--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -151,37 +151,50 @@ class MilvusStore(LazyLLMStoreBase):
         finally:
             self._client_pool.release(c)
 
-    def _row_has_valid_embedding(self, d: dict) -> bool:
-        '''True if row has every required embed key with a non-empty value (Milvus requires all columns same length).'''
+    def _row_has_valid_embedding(self, d: dict, required_embed_keys: Set[str]) -> bool:
+        '''True if row has every collection-required embed key with a non-empty value.'''
         emb = d.get('embedding')
         if not emb or not isinstance(emb, dict):
             return False
-        for k in self._embed_datatypes:
+        for k in required_embed_keys:
             if _is_empty_embedding_value(emb.get(k)):
                 return False
         return True
+
+    def _collection_embed_keys(self, client, collection_name: str) -> Set[str]:
+        desc = client.describe_collection(collection_name=collection_name)
+        return {
+            field.get('name')[len(EMBED_PREFIX):]
+            for field in desc.get('fields', [])
+            if field.get('name', '').startswith(EMBED_PREFIX)
+        }
 
     @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:  # noqa: C901
         try:
             if not data: return True
-            # Only upsert rows that have valid embedding for every key. _serialize_data omits missing/empty
-            # embedding fields, which would make pymilvus build columns with different lengths (e.g. uid 230 vs
-            # embedding___default__ 229) and raise num_rows mismatch.
-            valid_data = [d for d in data if self._row_has_valid_embedding(d)]
-            dropped = len(data) - len(valid_data)
-            if dropped:
-                LOG.warning(f'[Milvus Store - upsert] Dropping {dropped} rows with missing/empty embedding for '
-                            f'collection {collection_name}.')
-            data = valid_data
-            if not data:
-                return True
-            data_embeddings = data[0].get('embedding', {})
-            if not data_embeddings: return True
             with self._client_context() as client:
-                if not client.has_collection(collection_name):
+                collection_exists = client.has_collection(collection_name)
+                required_embed_keys = (
+                    self._collection_embed_keys(client, collection_name)
+                    if collection_exists else set(self._embed_datatypes.keys())
+                )
+                if not required_embed_keys:
+                    return True
+
+                # Validate rows only against schema-required embedding fields.
+                valid_data = [d for d in data if self._row_has_valid_embedding(d, required_embed_keys)]
+                dropped = len(data) - len(valid_data)
+                if dropped:
+                    LOG.warning(f'[Milvus Store - upsert] Dropping {dropped} rows with missing/empty embedding for '
+                                f'collection {collection_name}, required embeddings: {sorted(required_embed_keys)}.')
+                data = valid_data
+                if not data:
+                    return True
+
+                if not collection_exists:
                     embed_kwargs = {}
-                    for embed_key in data_embeddings.keys():
+                    for embed_key in sorted(required_embed_keys):
                         assert self._embed_datatypes.get(embed_key), \
                             f'cannot find embedding params for embed [{embed_key}]'
                         if embed_key not in embed_kwargs:
@@ -193,7 +206,8 @@ class MilvusStore(LazyLLMStoreBase):
 
                 for i in range(0, len(data), MILVUS_UPSERT_BATCH_SIZE):
                     client.upsert(collection_name=collection_name,
-                                  data=[self._serialize_data(d) for d in data[i:i + MILVUS_UPSERT_BATCH_SIZE]])
+                                  data=[self._serialize_data(d, required_embed_keys)
+                                        for d in data[i:i + MILVUS_UPSERT_BATCH_SIZE]])
             return True
         except Exception as e:
             LOG.error(f'[Milvus Store - upsert] error: {e}')
@@ -445,12 +459,14 @@ class MilvusStore(LazyLLMStoreBase):
                 # if user passed a non-dict (exception), replace it with the default dict
                 index_item['params'] = dict(default_params)
 
-    def _serialize_data(self, d: dict) -> dict:
+    def _serialize_data(self, d: dict, allowed_embed_keys: Optional[Set[str]] = None) -> dict:
         # only keep primary_key, embedding and global_meta
         res = {
             self._primary_key: d.get(self._primary_key, '')
         }
         for embed_key, value in d.get('embedding', {}).items():
+            if allowed_embed_keys is not None and embed_key not in allowed_embed_keys:
+                continue
             res[self._gen_embed_key(embed_key)] = value
         global_meta = d.get('global_meta', {})
         for name, desc in self._global_metadata_desc.items():

--- a/lazyllm/tools/rag/utils.py
+++ b/lazyllm/tools/rag/utils.py
@@ -18,7 +18,7 @@ from lazyllm import config
 from lazyllm.common import override
 from lazyllm.thirdparty import tarfile
 
-from .doc_node import DocNode, MetadataMode
+from .doc_node import DocNode, MetadataMode, ImageDocNode
 from .global_metadata import RAG_DOC_PATH
 from .index_base import IndexBase
 
@@ -199,7 +199,7 @@ def parallel_do_embedding(embed: Dict[str, Callable], embed_keys: Optional[Union
     def _process_key(k: str, knodes: List[DocNode]):
         try:
             fn = embed[k]
-            if _check_batch(fn):
+            if _check_batch(fn) and not any(isinstance(n, ImageDocNode) for n in knodes):
                 texts = [n.get_text(MetadataMode.EMBED) for n in knodes]
                 vecs = fn(texts)
                 if len(vecs) != len(texts):


### PR DESCRIPTION
Modified `lazyllm/tools/rag/store/vector/milvus_store.py`: enforce collection-level fixed embedding schema, validate rows only against schema-required embedding keys, and filter out non-schema embedding fields during upsert.

Original:
Text; bge, bge, siglip;
Img; siglip;
Img will be droppedd

<img width="1372" height="290" alt="image" src="https://github.com/user-attachments/assets/dc12fbdb-8dad-44bd-8974-459d6ecc6742" />

Now:
Text Collection:
<img width="509" height="623" alt="image" src="https://github.com/user-attachments/assets/ef084b3b-4edb-4dbe-a1b3-1ee04baa2037" />

Img Collection:
<img width="799" height="750" alt="image" src="https://github.com/user-attachments/assets/b2a696f3-df7f-4ffd-a42f-455728d682fc" />

============================================================================
Modified `/home/mnt/cuishaoting/LazyLLM/lazyllm/tools/rag/utils.py`, fix the image group embedding issues.
<img width="1746" height="346" alt="image" src="https://github.com/user-attachments/assets/60289524-c1c4-4002-812d-8396b4d97510" />

Can't use ImageDocNode.get_text(MetadataMode.EMBED)
<img width="1409" height="175" alt="image" src="https://github.com/user-attachments/assets/c7129b64-54b3-4051-88f7-d8ceff21327b" />

Also fixed issue: all images returned a random embedding value.
<img width="2486" height="923" alt="image" src="https://github.com/user-attachments/assets/a98a1181-0ac7-4a5e-a368-c3649cdf4b33" />



