### PR TITLE
fix: ToolUseToSFTFormatter restore input_key/output_key parameters

### DIFF
--- a/lazyllm/tools/data/operators/tool_use_ops.py
+++ b/lazyllm/tools/data/operators/tool_use_ops.py
@@ -353,12 +353,21 @@ class ToolUseToSFTFormatter(ToolUseOps):
     FORMAT_ALPACA = 'alpaca'
     FORMAT_CHATML = 'chatml'
 
-    def __init__(self, format_type=FORMAT_CHATML, system_prompt=None, **kwargs):
+    def __init__(
+        self,
+        format_type=FORMAT_CHATML,
+        system_prompt=None,
+        input_key='conversation',
+        output_key=None,
+        **kwargs,
+    ):
         if format_type not in (self.FORMAT_ALPACA, self.FORMAT_CHATML):
             raise ValueError(f'Unknown format_type: {format_type!r}')
         super().__init__(**kwargs)
         self.format_type = format_type
         self.system_prompt = system_prompt or 'You are a helpful assistant that can use tools to help users.'
+        self.input_key = input_key
+        self.output_key = output_key
 
     def _format_functions(self, functions):
         if not functions:
@@ -368,7 +377,13 @@ class ToolUseToSFTFormatter(ToolUseOps):
     def _unpack_data(self, data):
         content = data.get('content', '')
         functions = data.get('functions', [])
-        messages = data.get('conversation', {}).get('messages', [])
+        conversation = data.get(self.input_key, {})
+        if isinstance(conversation, dict):
+            messages = conversation.get('messages', [])
+        elif isinstance(conversation, list):
+            messages = conversation
+        else:
+            messages = []
         return content, functions, messages
 
     def _convert_to_alpaca(self, data):
@@ -435,12 +450,19 @@ class ToolUseToSFTFormatter(ToolUseOps):
 
         assert isinstance(data, dict)
 
-        if 'conversation' not in data or 'functions' not in data:
+        if self.input_key not in data or 'functions' not in data:
             return []
 
         if self.format_type == self.FORMAT_ALPACA:
-            return self._convert_to_alpaca(data)
-        return self._convert_to_chatml(data)
+            formatted = self._convert_to_alpaca(data)
+        else:
+            formatted = self._convert_to_chatml(data)
+
+        if not self.output_key:
+            return formatted
+
+        data[self.output_key] = formatted
+        return data
 
 
 class ToolUseQualityFilter(ToolUseOps):


### PR DESCRIPTION
# 📌 PR 内容 / PR Description                                                                    
  
  - 为 `ToolUseToSFTFormatter` 增加 `input_key` 和 `output_key` 参数，使其支持自定义输入/输出字段名
  - `_unpack_data` 兼容 `conversation` 为 dict（含 `messages`）或 list（直接为 messages）两种结构
  - `forward` 在指定 `output_key` 时将结果写回 `data[output_key]` 并返回 data；未指定时仍返回
  formatted（保持向后兼容）                                                                        
  
  ---                                                                                              
                  
  # 🎯 问题背景 / Problem Context                                                                  
  
  - 原实现硬编码 `'conversation'` 作为输入字段，且只能直接返回 formatted 结果，无法在 pipeline     
  中保留原 data 字段
  - 实际数据中 `conversation` 字段存在两种格式（dict 包 messages / 直接是 messages                 
  list），原版本只兼容 dict，list 形式会得到空 messages                                            
  - pipeline 串联多个 op 时希望把格式化结果挂在 data 的某个 key 上，便于下游继续消费
                                                                                                   
  # 🔍 相关 Issue / Related Issue
                                                                                                   
  *（如有 issue 编号在此填写）*

  ---                                                                                              
  
  # ✅ 变更类型 / Type of Change                                                                   
                  
  * [x] Bug fix                                                                                    
  * [x] New feature
  * [ ] Refactor                                                                                   
  * [ ] Breaking change
  * [ ] Documentation
  * [ ] Performance optimization
                                                                                                   
  ---
                                                                                                   
  # 🧪 如何测试 / How Has This Been Tested?

  1. 构造 `conversation` 为 dict（带 messages）的数据，验证 `_unpack_data` 正确取出 messages       
  2. 构造 `conversation` 为 list 的数据,验证同样能取出 messages
  3. 不指定 `output_key`，验证返回 formatted（与旧行为一致）                                       
  4. 指定 `output_key='formatted'`，验证 data 中新增该字段且返回 data 整体                         
                                                                                                   
  ---                                                                                              
                                                                                                   
  # ⚡ 更新后的用法示例 / Usage After Update                                                       
  
  ```python                                                                                        
  from lazyllm.tools.data.operators.tool_use_ops import ToolUseToSFTFormatter
                                                                                                   
  # 默认行为：直接返回 formatted
  fmt = ToolUseToSFTFormatter(format_type='chatml')                                                
  result = fmt(data)  # -> {'messages': [...]}                                                     
  
  # 自定义 input_key + 写回 data                                                                   
  fmt = ToolUseToSFTFormatter(                                                                     
      format_type='alpaca',
      input_key='dialog',                                                                          
      output_key='formatted',                                                                      
  )
  result = fmt(data)  # -> data with data['formatted'] = {...}                                     
                                                                                                   
  ---
  🔄 重构对比 / Refactor Comparison                                                                
                                                                                                   
  Before
                                                                                                   
  def __init__(self, format_type=FORMAT_CHATML, system_prompt=None, **kwargs):
      ...                                                                                          
  
  def _unpack_data(self, data):                                                                    
      messages = data.get('conversation', {}).get('messages', [])
      ...

  def forward(self, data, **kwargs):                                                               
      if 'conversation' not in data or 'functions' not in data:
          return []                                                                                
      if self.format_type == self.FORMAT_ALPACA:
          return self._convert_to_alpaca(data)                                                     
      return self._convert_to_chatml(data)
                                                                                                   
  After           

  def __init__(self, format_type=FORMAT_CHATML, system_prompt=None,
               input_key='conversation', output_key=None, **kwargs):                               
      ...
      self.input_key = input_key                                                                   
      self.output_key = output_key
                                                                                                   
  def _unpack_data(self, data):
      conversation = data.get(self.input_key, {})                                                  
      if isinstance(conversation, dict):
          messages = conversation.get('messages', [])
      elif isinstance(conversation, list):                                                         
          messages = conversation
      else:                                                                                        
          messages = []
      ...

  def forward(self, data, **kwargs):
      if self.input_key not in data or 'functions' not in data:
          return []                                                                                
      formatted = (self._convert_to_alpaca if self.format_type == self.FORMAT_ALPACA
                   else self._convert_to_chatml)(data)                                             
      if not self.output_key:
          return formatted                                                                         
      data[self.output_key] = formatted
      return data
                                                                                                   
  ⚠️  注意事项 / Additional Notes
                                                                                                   
  - 默认 input_key='conversation' 与 output_key=None，行为与改动前一致，对现有调用方无影响         
  - 仅修改 ToolUseToSFTFormatter 一个类，其他 op 未变动
                                                                                                   
  ---             
  🧠 AI 参与情况 / AI Involvement                                                                  
                                                                                                   
  - 未使用 AI / No AI used
  - 使用 AI 辅助（局部代码）/ AI-assisted (partial code)                                           
  - 使用 AI 主导（大部分代码）/ AI-led (majority of code)                                          
                                                                                                   
  使用工具 / Tools Used：                                                                          
  - ClaudeCode    
                                                                                                   
  📊 AI vs 人工贡献占比 / AI vs Human Contribution
                                                                                                   
  - AI 生成代码占比：30%                                                                           
  - 人工修改占比：70%                                                                              
                                                                                                   
  主要人工修改点：
  - 逻辑修正
  - 边界处理