### PR TITLE
add CredentialMixin for all modules with auth info

### DIFF
--- a/lazyllm/common/__init__.py
+++ b/lazyllm/common/__init__.py
@@ -17,6 +17,9 @@ from .globals import (globals, locals, LazyLlmResponse, LazyLlmRequest, encode_r
 from .bind import Bind as bind, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, Placeholder
 from .queue import RecentQueue, FileSystemQueue
 from .utils import compile_func, obj2str, str2obj, str2bool, dump_obj, load_obj
+from .auth import (Credential, AuthStrategy, BearerTokenStrategy,
+                   ApiKeyHeaderStrategy, QueryParamStrategy)
+from .credential_mixin import CredentialMixin
 
 __all__ = [
     # registry
@@ -121,4 +124,12 @@ __all__ = [
     # queue
     'RecentQueue',
     'FileSystemQueue',
+
+    # auth
+    'Credential',
+    'AuthStrategy',
+    'BearerTokenStrategy',
+    'ApiKeyHeaderStrategy',
+    'QueryParamStrategy',
+    'CredentialMixin',
 ]

--- a/lazyllm/common/auth.py
+++ b/lazyllm/common/auth.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+_AUTH_KINDS = ('static', 'dynamic', 'oauth2', 'app_credentials')
+
+
+@dataclass(frozen=True)
+class Credential:
+    kind: str = 'static'
+    secret_key: Any = None
+    access_token: str = ''
+    token_expire_at: Optional[float] = None
+    refresh_token: str = ''
+    oauth_auto: bool = False
+
+    def __post_init__(self) -> None:
+        if self.kind not in _AUTH_KINDS:
+            raise ValueError(f'Invalid Credential.kind: {self.kind!r}, must be one of {_AUTH_KINDS}')
+
+
+@runtime_checkable
+class AuthStrategy(Protocol):
+    def build_header(self, token: str) -> Dict[str, str]: ...
+    def build_params(self, token: str) -> Dict[str, str]: ...
+
+
+class BearerTokenStrategy:
+
+    def build_header(self, token: str) -> Dict[str, str]:
+        return {'Authorization': f'Bearer {token}'} if token else {}
+
+    def build_params(self, token: str) -> Dict[str, str]:
+        return {}
+
+
+class ApiKeyHeaderStrategy:
+
+    def __init__(self, header_name: str, value_template: Optional[str] = None) -> None:
+        self._header_name = header_name
+        self._value_template = value_template
+
+    def build_header(self, token: str) -> Dict[str, str]:
+        if not token:
+            return {}
+        value = self._value_template.format(token=token) if self._value_template else token
+        return {self._header_name: value}
+
+    def build_params(self, token: str) -> Dict[str, str]:
+        return {}
+
+
+class QueryParamStrategy:
+
+    def __init__(self, param_name: str) -> None:
+        self._param_name = param_name
+
+    def build_header(self, token: str) -> Dict[str, str]:
+        return {}
+
+    def build_params(self, token: str) -> Dict[str, str]:
+        return {self._param_name: token} if token else {}

--- a/lazyllm/common/auth.py
+++ b/lazyllm/common/auth.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol, runtime_checkable
+from typing import Any, Dict, Optional
+from abc import ABC, abstractmethod
 
 _AUTH_KINDS = ('static', 'dynamic', 'oauth2', 'app_credentials')
 
@@ -19,13 +20,15 @@ class Credential:
             raise ValueError(f'Invalid Credential.kind: {self.kind!r}, must be one of {_AUTH_KINDS}')
 
 
-@runtime_checkable
-class AuthStrategy(Protocol):
+class AuthStrategy(ABC):
+    @abstractmethod
     def build_header(self, token: str) -> Dict[str, str]: ...
+
+    @abstractmethod
     def build_params(self, token: str) -> Dict[str, str]: ...
 
 
-class BearerTokenStrategy:
+class BearerTokenStrategy(AuthStrategy):
 
     def build_header(self, token: str) -> Dict[str, str]:
         return {'Authorization': f'Bearer {token}'} if token else {}
@@ -34,7 +37,7 @@ class BearerTokenStrategy:
         return {}
 
 
-class ApiKeyHeaderStrategy:
+class ApiKeyHeaderStrategy(AuthStrategy):
 
     def __init__(self, header_name: str, value_template: Optional[str] = None) -> None:
         self._header_name = header_name
@@ -50,7 +53,7 @@ class ApiKeyHeaderStrategy:
         return {}
 
 
-class QueryParamStrategy:
+class QueryParamStrategy(AuthStrategy):
 
     def __init__(self, param_name: str) -> None:
         self._param_name = param_name

--- a/lazyllm/common/credential_mixin.py
+++ b/lazyllm/common/credential_mixin.py
@@ -1,0 +1,253 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import contextvars
+import os
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+from urllib.parse import parse_qs, urlparse
+
+from .auth import AuthStrategy, BearerTokenStrategy, Credential
+
+
+class CredentialMixin:
+
+    _TOKEN_REFRESH_BUFFER: float = 60.0
+
+    def __init_credential__(
+        self,
+        credential: Credential,
+        strategy: Optional[AuthStrategy] = None,
+    ) -> None:
+        self._credential: Credential = credential
+        self._auth_strategy: AuthStrategy = strategy or BearerTokenStrategy()
+        self._token_lock: threading.Lock = threading.Lock()
+        self._credential_override: contextvars.ContextVar[Optional[Credential]] = (
+            contextvars.ContextVar('lazyllm_credential_override', default=None)
+        )
+
+    @property
+    def _active_credential(self) -> Credential:
+        ov = self._credential_override.get()
+        return ov if ov is not None else self._credential
+
+    @property
+    def _dynamic_auth(self) -> bool:
+        return self._credential.kind == 'dynamic'
+
+    @property
+    def _secret_key(self) -> Any:
+        return self._credential.secret_key
+
+    @property
+    def _dynamic_token(self) -> str:
+        return self._resolve_dynamic_token()
+
+    def get_current_token(self) -> str:
+        cred = self._active_credential
+        if cred.kind == 'dynamic':
+            return self._resolve_dynamic_token() or ''
+        if cred.kind == 'static':
+            sk = cred.secret_key
+            if isinstance(sk, str):
+                return sk
+            if isinstance(sk, (list, tuple)) and sk:
+                import random
+                return random.choice(sk)
+            return ''
+        return cred.access_token or ''
+
+    def _resolve_dynamic_token(self) -> str:
+        '''Subclasses with kind="dynamic" override this to fetch the token from their config source.'''
+        return ''
+
+    def _missing_dynamic_token_error(self) -> str:
+        return f'{type(self).__name__}: dynamic credential is not configured.'
+
+    def _default_credential(self, token: Any, dynamic_auth: bool) -> Credential:
+        '''Default credential factory: only handles the universal static/dynamic kinds.
+
+        Subclasses (or intermediate base classes) override _make_credential to detect
+        kind="oauth2" or kind="app_credentials" and call super()._make_credential(...) /
+        self._default_credential(...) to fall back to this implementation.
+        '''
+        if dynamic_auth:
+            return Credential(kind='dynamic')
+        return Credential(kind='static', secret_key=token)
+
+    def _make_credential(self, token: Any, dynamic_auth: bool) -> Credential:
+        return self._default_credential(token, dynamic_auth)
+
+    def ensure_token(self) -> None:
+        cred = self._active_credential
+        if cred.kind == 'dynamic':
+            if not self.get_current_token():
+                raise ValueError(self._missing_dynamic_token_error())
+            return
+        if cred.kind in ('oauth2', 'app_credentials'):
+            if not cred.access_token or self._is_token_expired(cred):
+                self._refresh_credential()
+
+    @classmethod
+    def _is_token_expired(cls, cred: Credential) -> bool:
+        if cred.token_expire_at is None:
+            return False
+        return time.time() >= (cred.token_expire_at - cls._TOKEN_REFRESH_BUFFER)
+
+    def inject_auth_header(self, headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        self.ensure_token()
+        out = dict(headers or {})
+        out.update(self._auth_strategy.build_header(self.get_current_token()))
+        return out
+
+    def inject_auth_params(self, params: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        self.ensure_token()
+        out = dict(params or {})
+        out.update(self._auth_strategy.build_params(self.get_current_token()))
+        return out
+
+    @contextmanager
+    def override_credential(
+        self, *, secret_key: Any = None, credential: Optional[Credential] = None,
+    ) -> Iterator[None]:
+        if credential is None:
+            credential = replace(self._active_credential, secret_key=secret_key)
+        token = self._credential_override.set(credential)
+        try:
+            yield
+        finally:
+            self._credential_override.reset(token)
+
+    def _refresh_credential(self) -> None:
+        with self._token_lock:
+            cred = self._credential
+            if cred.access_token and not self._is_token_expired(cred):
+                return
+            new_token, new_expires, new_refresh = self._acquire_credential(cred)
+            self._credential = replace(
+                cred, access_token=new_token, token_expire_at=new_expires,
+                refresh_token=new_refresh or cred.refresh_token,
+            )
+            if new_refresh:
+                self._save_persisted_refresh_token(new_refresh)
+
+    def _acquire_credential(self, cred: Credential) -> Tuple[str, Optional[float], str]:
+        '''Acquire a fresh access token. Subclasses implement the kind-specific paths.'''
+        if cred.kind == 'app_credentials':
+            return self._do_acquire_without_refresh()
+        rt = cred.refresh_token
+        if rt == 'auto':
+            rt = self._load_persisted_refresh_token()
+        if rt:
+            try:
+                return self._do_refresh_token(rt)
+            except Exception as err:
+                if not cred.oauth_auto:
+                    raise
+                from lazyllm import LOG
+                LOG.warning(f'refresh_token invalid for {self._get_persist_key()}: {err}; '
+                            'falling back to OAuth flow.')
+                self._save_persisted_refresh_token('')
+        return self._do_oauth_flow()
+
+    def _do_refresh_token(self, refresh_token: str) -> Tuple[str, Optional[float], str]:
+        raise NotImplementedError(
+            f'{type(self).__name__} must implement _do_refresh_token() to support refresh-based OAuth.'
+        )
+
+    def _do_acquire_without_refresh(self) -> Tuple[str, Optional[float], str]:
+        raise NotImplementedError(
+            f'{type(self).__name__} must implement _do_acquire_without_refresh() for kind="app_credentials".'
+        )
+
+    def _do_oauth_flow(self) -> Tuple[str, Optional[float], str]:
+        raise NotImplementedError(
+            f'{type(self).__name__} must implement _do_oauth_flow() for interactive OAuth.'
+        )
+
+    @staticmethod
+    def _run_local_oauth_server(port: int, timeout: float) -> str:
+        captured: Dict[str, str] = {}
+        done = threading.Event()
+
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self):  # noqa: N802
+                qs = parse_qs(urlparse(self.path).query)
+                if 'code' in qs:
+                    captured['code'] = qs['code'][0]
+                    body = b'<html><body>Authorization successful. You can close this tab.</body></html>'
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'text/html; charset=utf-8')
+                    self.end_headers()
+                    self.wfile.write(body)
+                else:
+                    captured['error'] = qs.get('error', ['unknown'])[0]
+                    self.send_response(400)
+                    self.end_headers()
+                done.set()
+
+            def log_message(self, fmt: str, *args: Any) -> None:
+                return None
+
+        server = HTTPServer(('localhost', port), _Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            if not done.wait(timeout=timeout):
+                raise TimeoutError(f'OAuth callback timed out after {timeout}s')
+        finally:
+            server.shutdown()
+            server.server_close()
+        if 'code' not in captured:
+            raise RuntimeError(f'OAuth flow failed: {captured.get("error", "unknown")}')
+        return captured['code']
+
+    def _get_persist_key(self) -> str:
+        return f'{type(self).__name__}:{id(self)}'
+
+    @staticmethod
+    def _persist_path() -> str:
+        from lazyllm import config
+        return os.path.join(config['home'], '.lazyllm/tokens.txt')
+
+    def _load_persisted_refresh_token(self) -> str:
+        path, key = self._persist_path(), self._get_persist_key()
+        try:
+            with open(path, 'r', encoding='utf-8') as fh:
+                for line in fh:
+                    k, sep, v = line.strip().partition(': ')
+                    if sep and k.strip() == key:
+                        return v.strip()
+        except FileNotFoundError:
+            pass
+        return ''
+
+    def _save_persisted_refresh_token(self, refresh_token: str) -> None:
+        path, key = self._persist_path(), self._get_persist_key()
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        lines: List[str] = []
+        replaced = False
+        try:
+            with open(path, 'r', encoding='utf-8') as fh:
+                for line in fh:
+                    k, sep, _ = line.strip().partition(': ')
+                    if sep and k.strip() == key:
+                        if refresh_token:
+                            lines.append(f'{key}: {refresh_token}\n')
+                            replaced = True
+                    else:
+                        lines.append(line if line.endswith('\n') else line + '\n')
+        except FileNotFoundError:
+            pass
+        if not replaced and refresh_token:
+            lines.append(f'{key}: {refresh_token}\n')
+        with open(path, 'w', encoding='utf-8') as fh:
+            fh.writelines(lines)
+
+    def _bootstrap_token(self) -> None:
+        if self._credential.kind in ('oauth2', 'app_credentials'):
+            self._refresh_credential()
+
+
+__all__ = ['CredentialMixin']

--- a/lazyllm/docs/common.py
+++ b/lazyllm/docs/common.py
@@ -1639,3 +1639,296 @@ def unstable_function():
 result = unstable_function()
 print(result)
 ''')
+
+# ---------------------------------------------------------------------------
+# auth.py — Credential, AuthStrategy, BearerTokenStrategy,
+#            ApiKeyHeaderStrategy, QueryParamStrategy
+# ---------------------------------------------------------------------------
+
+add_chinese_doc('Credential', '''\
+不可变的认证凭据数据类，描述一次认证所需的全部信息。
+
+Args:
+    kind (str): 凭据类型，取值为 'static'（静态 token）、'dynamic'（运行时注入）、
+        'oauth2'（OAuth2 授权码流程）或 'app_credentials'（应用凭证，无 refresh_token）。
+    secret_key (Any): 长期凭据，语义由子类决定；静态模式下通常为 API key 字符串或列表。
+    access_token (str): 短期访问令牌，oauth2/app_credentials 模式下由框架自动填充。
+    token_expire_at (float, optional): access_token 的过期时间戳（Unix 秒）；None 表示永不过期。
+    refresh_token (str): OAuth2 刷新令牌；'auto' 表示从持久化存储中读取。
+    oauth_auto (bool): 当 refresh_token 失效时是否自动触发 OAuth 授权流程，默认 False。
+''')
+
+add_english_doc('Credential', '''\
+Immutable authentication credential dataclass describing all information needed for one auth context.
+
+Args:
+    kind (str): Credential type; one of 'static' (static token), 'dynamic' (runtime injection),
+        'oauth2' (OAuth2 authorization code flow), or 'app_credentials' (app credentials, no refresh_token).
+    secret_key (Any): Long-lived credential; semantics defined by the subclass; usually an API key string or list in static mode.
+    access_token (str): Short-lived access token; filled automatically by the framework in oauth2/app_credentials mode.
+    token_expire_at (float, optional): Expiry timestamp (Unix seconds) for access_token; None means non-expiring.
+    refresh_token (str): OAuth2 refresh token; 'auto' means load from persistent storage.
+    oauth_auto (bool): Whether to automatically trigger the OAuth flow when refresh_token is invalid; default False.
+''')
+
+add_example('Credential', '''\
+>>> from lazyllm.common import Credential
+>>> cred = Credential(kind='static', secret_key='sk-xxx')
+>>> cred.kind
+'static'
+>>> cred.secret_key
+'sk-xxx'
+''')
+
+add_chinese_doc('AuthStrategy', '''\
+认证策略协议（Protocol），定义如何将 token 注入 HTTP 请求头或查询参数。
+
+实现该协议的类需提供：
+    build_header(token) → Dict[str, str]：返回要合并到请求头的字段。
+    build_params(token) → Dict[str, str]：返回要合并到查询参数的字段。
+
+内置实现：BearerTokenStrategy、ApiKeyHeaderStrategy、QueryParamStrategy。
+''')
+
+add_english_doc('AuthStrategy', '''\
+Authentication strategy protocol defining how to inject a token into HTTP request headers or query parameters.
+
+Implementations must provide:
+    build_header(token) → Dict[str, str]: Returns fields to merge into request headers.
+    build_params(token) → Dict[str, str]: Returns fields to merge into query parameters.
+
+Built-in implementations: BearerTokenStrategy, ApiKeyHeaderStrategy, QueryParamStrategy.
+''')
+
+add_chinese_doc('BearerTokenStrategy', '''\
+将 token 以 Bearer 方式注入 Authorization 请求头的认证策略。
+
+build_header 返回 {'Authorization': 'Bearer <token>'}（token 为空时返回空 dict）。
+build_params 始终返回空 dict。
+''')
+
+add_english_doc('BearerTokenStrategy', '''\
+Authentication strategy that injects the token as a Bearer Authorization header.
+
+build_header returns {'Authorization': 'Bearer <token>'} (empty dict when token is empty).
+build_params always returns an empty dict.
+''')
+
+add_example('BearerTokenStrategy', '''\
+>>> from lazyllm.common import BearerTokenStrategy
+>>> s = BearerTokenStrategy()
+>>> s.build_header('my-token')
+{'Authorization': 'Bearer my-token'}
+>>> s.build_header('')
+{}
+''')
+
+add_chinese_doc('ApiKeyHeaderStrategy', '''\
+将 token 注入自定义请求头的认证策略。
+
+Args:
+    header_name (str): 请求头字段名，如 'X-Auth-Token'。
+    value_template (str, optional): 值模板字符串，含 {token} 占位符；未传时直接使用 token 原值。
+
+build_header 返回 {header_name: value}（token 为空时返回空 dict）。
+build_params 始终返回空 dict。
+''')
+
+add_english_doc('ApiKeyHeaderStrategy', '''\
+Authentication strategy that injects the token into a custom request header.
+
+Args:
+    header_name (str): Header field name, e.g. 'X-Auth-Token'.
+    value_template (str, optional): Value template string containing a {token} placeholder;
+        when omitted the token value is used as-is.
+
+build_header returns {header_name: value} (empty dict when token is empty).
+build_params always returns an empty dict.
+''')
+
+add_example('ApiKeyHeaderStrategy', '''\
+>>> from lazyllm.common import ApiKeyHeaderStrategy
+>>> s = ApiKeyHeaderStrategy('X-Auth-Token')
+>>> s.build_header('my-key')
+{'X-Auth-Token': 'my-key'}
+>>> s2 = ApiKeyHeaderStrategy('Authorization', 'token {token}')
+>>> s2.build_header('abc')
+{'Authorization': 'token abc'}
+''')
+
+add_chinese_doc('QueryParamStrategy', '''\
+将 token 注入 URL 查询参数的认证策略。
+
+Args:
+    param_name (str): 查询参数名，如 'api_key'。
+
+build_header 始终返回空 dict。
+build_params 返回 {param_name: token}（token 为空时返回空 dict）。
+''')
+
+add_english_doc('QueryParamStrategy', '''\
+Authentication strategy that injects the token as a URL query parameter.
+
+Args:
+    param_name (str): Query parameter name, e.g. 'api_key'.
+
+build_header always returns an empty dict.
+build_params returns {param_name: token} (empty dict when token is empty).
+''')
+
+add_example('QueryParamStrategy', '''\
+>>> from lazyllm.common import QueryParamStrategy
+>>> s = QueryParamStrategy('api_key')
+>>> s.build_params('my-key')
+{'api_key': 'my-key'}
+>>> s.build_params('')
+{}
+''')
+
+# ---------------------------------------------------------------------------
+# credential_mixin.py — CredentialMixin
+# ---------------------------------------------------------------------------
+
+add_chinese_doc('CredentialMixin', '''\
+认证凭据管理 Mixin，为任意类提供统一的 token 生命周期管理能力。
+
+混入后需在 __init__ 中调用 __init_credential__(credential, strategy) 完成初始化。
+支持四种凭据模式：static（静态 API key）、dynamic（运行时注入）、
+oauth2（OAuth2 授权码 + refresh_token）、app_credentials（应用凭证，无 refresh_token）。
+
+子类扩展约定：
+    - kind="app_credentials"：实现 _do_acquire_without_refresh()
+    - kind="oauth2"（有 refresh_token）：实现 _do_refresh_token()
+    - kind="oauth2"（需浏览器授权）：实现 _do_oauth_flow()，可调用 _run_local_oauth_server() 辅助
+    - kind="dynamic"：实现 _resolve_dynamic_token()
+''')
+
+add_english_doc('CredentialMixin', '''\
+Authentication credential management mixin that provides unified token lifecycle management for any class.
+
+After mixing in, call __init_credential__(credential, strategy) in __init__ to initialize.
+Supports four credential modes: static (static API key), dynamic (runtime injection),
+oauth2 (OAuth2 authorization code + refresh_token), and app_credentials (app credentials, no refresh_token).
+
+Subclass extension conventions:
+    - kind="app_credentials": implement _do_acquire_without_refresh()
+    - kind="oauth2" (with refresh_token): implement _do_refresh_token()
+    - kind="oauth2" (browser auth needed): implement _do_oauth_flow(); may use _run_local_oauth_server()
+    - kind="dynamic": implement _resolve_dynamic_token()
+''')
+
+add_chinese_doc('CredentialMixin.get_current_token', '''\
+返回当前有效的 token 字符串。
+
+- static 模式：返回 secret_key（列表时随机选一个）。
+- dynamic 模式：调用 _resolve_dynamic_token() 获取运行时 token。
+- oauth2 / app_credentials 模式：返回已缓存的 access_token。
+
+Returns:
+    str: 当前 token，无可用 token 时返回空字符串。
+''')
+
+add_english_doc('CredentialMixin.get_current_token', '''\
+Return the current effective token string.
+
+- static mode: returns secret_key (randomly picks one if it is a list).
+- dynamic mode: calls _resolve_dynamic_token() to get the runtime token.
+- oauth2 / app_credentials mode: returns the cached access_token.
+
+Returns:
+    str: Current token, or empty string when no token is available.
+''')
+
+add_chinese_doc('CredentialMixin.ensure_token', '''\
+确保当前 token 有效，必要时自动刷新。
+
+- dynamic 模式：检查 _resolve_dynamic_token() 是否非空，否则抛出 ValueError。
+- oauth2 / app_credentials 模式：若 access_token 缺失或即将过期，触发 _refresh_credential()。
+- static 模式：无操作。
+''')
+
+add_english_doc('CredentialMixin.ensure_token', '''\
+Ensure the current token is valid, refreshing it automatically when necessary.
+
+- dynamic mode: checks that _resolve_dynamic_token() is non-empty; raises ValueError otherwise.
+- oauth2 / app_credentials mode: triggers _refresh_credential() when access_token is missing or about to expire.
+- static mode: no-op.
+''')
+
+add_chinese_doc('CredentialMixin.inject_auth_header', '''\
+将认证信息注入请求头，返回合并后的新 dict（不修改传入的 headers）。
+
+调用前会先执行 ensure_token()；认证字段由 AuthStrategy.build_header() 生成，优先级高于传入的 headers。
+
+Args:
+    headers (Dict[str, str], optional): 已有请求头；未传时视为空 dict。
+
+Returns:
+    Dict[str, str]: 合并了认证字段的新请求头 dict。
+''')
+
+add_english_doc('CredentialMixin.inject_auth_header', '''\
+Inject authentication into request headers and return a new merged dict (the input headers are not mutated).
+
+Calls ensure_token() first; auth fields from AuthStrategy.build_header() take priority over the supplied headers.
+
+Args:
+    headers (Dict[str, str], optional): Existing headers; treated as empty dict when omitted.
+
+Returns:
+    Dict[str, str]: New headers dict with auth fields merged in.
+''')
+
+add_chinese_doc('CredentialMixin.inject_auth_params', '''\
+将认证信息注入查询参数，返回合并后的新 dict（不修改传入的 params）。
+
+调用前会先执行 ensure_token()；认证字段由 AuthStrategy.build_params() 生成，优先级高于传入的 params。
+
+Args:
+    params (Dict[str, str], optional): 已有查询参数；未传时视为空 dict。
+
+Returns:
+    Dict[str, str]: 合并了认证字段的新查询参数 dict。
+''')
+
+add_english_doc('CredentialMixin.inject_auth_params', '''\
+Inject authentication into query parameters and return a new merged dict (the input params are not mutated).
+
+Calls ensure_token() first; auth fields from AuthStrategy.build_params() take priority over the supplied params.
+
+Args:
+    params (Dict[str, str], optional): Existing query parameters; treated as empty dict when omitted.
+
+Returns:
+    Dict[str, str]: New params dict with auth fields merged in.
+''')
+
+add_chinese_doc('CredentialMixin.override_credential', '''\
+上下文管理器：在当前协程/线程范围内临时替换凭据，退出后自动恢复。
+
+可通过 secret_key 快速替换静态 key，也可传入完整的 Credential 对象。
+两个参数互斥，同时传入时 credential 优先。
+
+Args:
+    secret_key (Any, optional): 临时替换的 secret_key，其余字段保持不变。
+    credential (Credential, optional): 完整替换的凭据对象。
+
+Example:
+    with obj.override_credential(secret_key='tmp-key'):
+        result = obj.some_api_call()
+''')
+
+add_english_doc('CredentialMixin.override_credential', '''\
+Context manager: temporarily replace the credential within the current coroutine/thread scope; restores automatically on exit.
+
+Use secret_key for a quick static key swap, or pass a full Credential object for a complete replacement.
+The two parameters are mutually exclusive; credential takes priority when both are supplied.
+
+Args:
+    secret_key (Any, optional): Temporary secret_key replacement; other fields remain unchanged.
+    credential (Credential, optional): Full replacement credential object.
+
+Example:
+    with obj.override_credential(secret_key='tmp-key'):
+        result = obj.some_api_call()
+''')

--- a/lazyllm/docs/common.py
+++ b/lazyllm/docs/common.py
@@ -1700,6 +1700,46 @@ Implementations must provide:
 Built-in implementations: BearerTokenStrategy, ApiKeyHeaderStrategy, QueryParamStrategy.
 ''')
 
+add_chinese_doc('AuthStrategy.build_header', '''\
+根据给定的 token 构造要注入到 HTTP 请求头中的字段。
+
+Args:
+    token (str): 当前有效的访问令牌。
+
+Returns:
+    Dict[str, str]: 要合并到请求头的键值对；若无需注入则返回空 dict。
+''')
+
+add_english_doc('AuthStrategy.build_header', '''\
+Build the HTTP request header fields to inject for the given token.
+
+Args:
+    token (str): The current valid access token.
+
+Returns:
+    Dict[str, str]: Key-value pairs to merge into the request headers; empty dict if nothing to inject.
+''')
+
+add_chinese_doc('AuthStrategy.build_params', '''\
+根据给定的 token 构造要注入到 URL 查询参数中的字段。
+
+Args:
+    token (str): 当前有效的访问令牌。
+
+Returns:
+    Dict[str, str]: 要合并到查询参数的键值对；若无需注入则返回空 dict。
+''')
+
+add_english_doc('AuthStrategy.build_params', '''\
+Build the URL query parameter fields to inject for the given token.
+
+Args:
+    token (str): The current valid access token.
+
+Returns:
+    Dict[str, str]: Key-value pairs to merge into the query parameters; empty dict if nothing to inject.
+''')
+
 add_chinese_doc('BearerTokenStrategy', '''\
 将 token 以 Bearer 方式注入 Authorization 请求头的认证策略。
 

--- a/lazyllm/docs/tools/search.py
+++ b/lazyllm/docs/tools/search.py
@@ -9,15 +9,25 @@ add_english_doc = functools.partial(utils.add_english_doc, module=_tools_module)
 add_example = functools.partial(utils.add_example, module=_tools_module)
 
 add_chinese_doc('SearchBase', '''
-所有搜索工具的基类，定义统一接口与返回格式。
+所有搜索工具的基类，定义统一接口与返回格式。混入 CredentialMixin 提供统一的 API key 管理。
 
 子类需实现 search，将各后端 API 的原始响应规范为包含 title、url、snippet、source（及可选 extra）的字典列表。
+
+Args:
+    source_name (str): 结果中的来源标识；未传时自动从类名推断（去掉 "Search" 后缀并转小写）。
+    api_key (str, optional): API 密钥；传入后以 static 模式存入 CredentialMixin，由 inject_auth_header 自动注入请求头。
+    auth_strategy (AuthStrategy, optional): 认证策略；未传时默认使用 BearerTokenStrategy。
 ''')
 
 add_english_doc('SearchBase', '''
-Base class for all search tools with unified interface and result format.
+Base class for all search tools with unified interface and result format. Mixes in CredentialMixin for unified API key management.
 
 Subclasses must implement search and normalize raw API responses to a list of dicts with keys: title, url, snippet, source, and optionally extra.
+
+Args:
+    source_name (str): Source identifier in results; inferred from the class name (strips "Search" suffix, lowercased) when omitted.
+    api_key (str, optional): API key; stored in CredentialMixin in static mode and injected into request headers automatically via inject_auth_header.
+    auth_strategy (AuthStrategy, optional): Authentication strategy; defaults to BearerTokenStrategy when omitted.
 ''')
 
 add_example('SearchBase', '''

--- a/lazyllm/docs/tools/tool_fs.py
+++ b/lazyllm/docs/tools/tool_fs.py
@@ -18,7 +18,7 @@ _add_feishu_english = functools.partial(utils.add_english_doc, module=_feishu_mo
 
 # LazyLLMFSBase
 _add_fs_chinese('LazyLLMFSBase', '''\
-云文件系统统一基类，继承 fsspec.AbstractFileSystem，借助 registry 注册各平台实现。
+云文件系统统一基类，继承 fsspec.AbstractFileSystem，借助 registry 注册各平台实现。混入 CredentialMixin 提供统一的 token 生命周期管理。
 子类需实现：_setup_auth、ls、info、_open、_download_range、_upload_data 等；可选实现 rm_file、mkdir。
 目录监听逻辑由 CloudFsWatchdog 提供，FS 子类仅需提供必要的 webhook 能力（若有）。
 
@@ -29,9 +29,10 @@ Args:
     use_listings_cache (bool): 是否缓存目录列表，对应 fsspec.AbstractFileSystem.use_listings_cache，默认 False。
     skip_instance_cache (bool): 是否跳过实例缓存，对应 fsspec.AbstractFileSystem.skip_instance_cache，默认 False。
     loop (Any, optional): 异步事件循环对象，一般仅在异步环境下需要显式传入。
+    auth_strategy (AuthStrategy, optional): 认证策略，决定 token 如何注入请求头或查询参数；未传时默认使用 BearerTokenStrategy。
 ''')
 _add_fs_english('LazyLLMFSBase', '''\
-Unified cloud filesystem base; extends fsspec.AbstractFileSystem; implementations registered via registry.
+Unified cloud filesystem base; extends fsspec.AbstractFileSystem; implementations registered via registry. Mixes in CredentialMixin for unified token lifecycle management.
 Subclasses implement _setup_auth, ls, info, _open, _download_range, _upload_data; optionally rm_file, mkdir.
 Directory watching is handled by CloudFsWatchdog; FS subclasses only expose webhook capabilities when supported.
 
@@ -42,6 +43,7 @@ Args:
     use_listings_cache (bool): Whether to cache directory listings; forwarded to fsspec.AbstractFileSystem.use_listings_cache; default False.
     skip_instance_cache (bool): Whether to skip the filesystem instance cache; forwarded to fsspec.AbstractFileSystem.skip_instance_cache; default False.
     loop (Any, optional): Event loop object for async environments.
+    auth_strategy (AuthStrategy, optional): Authentication strategy controlling how the token is injected into request headers or query parameters; defaults to BearerTokenStrategy when omitted.
 ''')
 _add_fs_example('LazyLLMFSBase', '''\
 >>> from lazyllm.tools.fs import CloudFS

--- a/lazyllm/docs/tools/tool_fs.py
+++ b/lazyllm/docs/tools/tool_fs.py
@@ -448,13 +448,13 @@ Args:
     path (str): Path to watch.
 ''')
 
-_add_fs_chinese('LazyLLMFSBase._ensure_token', '''\
-Token 刷新钩子：子类可覆盖。基类默认实现为 no-op。
-每次 _request 发请求前会调用本方法；使用会过期的 access token 的子类应覆盖本方法，在 token 即将过期或已过期时重新获取并更新 session 认证信息。
+_add_fs_chinese('LazyLLMFSBase.ensure_token', '''\
+Token 刷新钩子：基类自动管理。
+每次 inject_auth_header / _request 发请求前会调用本方法；当 access token 即将过期或未初始化时，会通过 _do_refresh_token / _do_acquire_without_refresh / _do_oauth_flow 重新获取。
 ''')
-_add_fs_english('LazyLLMFSBase._ensure_token', '''\
-Token refresh hook; subclasses may override. Default implementation is a no-op.
-Called before each _request; subclasses that use expiring access tokens should override to refresh the token and update session auth when needed.
+_add_fs_english('LazyLLMFSBase.ensure_token', '''\
+Token refresh hook; managed by the base class.
+Called before each inject_auth_header / _request; refreshes the token via _do_refresh_token / _do_acquire_without_refresh / _do_oauth_flow when the access token is missing or about to expire.
 ''')
 
 _add_fs_chinese('LazyLLMFSBase._setup_auth', '''\

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -2,12 +2,14 @@
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
-import requests
-import time
-import threading
 import io
 
+import requests
+
 from lazyllm import thirdparty, globals
+from lazyllm.common import (
+    AuthStrategy, BearerTokenStrategy, Credential, CredentialMixin,
+)
 from lazyllm.common.registry import LazyLLMRegisterMetaABCClass
 
 AbstractFileSystem = thirdparty.fsspec.spec.AbstractFileSystem
@@ -36,7 +38,7 @@ class CloudFSBufferedFile(AbstractBufferedFile):
 _CloudFSMeta = type('_CloudFSMeta', (LazyLLMRegisterMetaABCClass, type(AbstractFileSystem)), {})
 
 
-class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
+class LazyLLMFSBase(AbstractFileSystem, CredentialMixin, metaclass=_CloudFSMeta):
 
     __public_apis__ = ['ls', 'info', 'open', 'mkdir', 'rm',
                        'exists', 'read_bytes', 'read_file', 'write_file', 'move', 'copy']
@@ -44,22 +46,18 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     def __init__(self, token: Any, base_url: Optional[str] = None, asynchronous: bool = False,
                  use_listings_cache: bool = False, skip_instance_cache: bool = False, loop: Optional[Any] = None,
-                 dynamic_auth: bool = False):
-        super().__init__(asynchronous=asynchronous, use_listings_cache=use_listings_cache,
-                         skip_instance_cache=skip_instance_cache, loop=loop)
-        self._dynamic_auth: bool = dynamic_auth
-        # Long-lived credential (string or dict), semantics decided by subclasses.
-        self._secret_key: Any = token
-        # Cached short-lived access token (static auth only); not used for dynamic auth.
-        self._access_token: str = ''
-        # Expiration timestamp for short-lived access token; None means non-expiring.
-        self._token_expire_at: Optional[float] = None
+                 dynamic_auth: bool = False, auth_strategy: Optional[AuthStrategy] = None):
+        AbstractFileSystem.__init__(
+            self, asynchronous=asynchronous, use_listings_cache=use_listings_cache,
+            skip_instance_cache=skip_instance_cache, loop=loop,
+        )
         self._base_url = (base_url or '').rstrip('/')
         self._session = requests.Session()
+        credential = self._make_credential(token, dynamic_auth)
+        self.__init_credential__(credential, strategy=auth_strategy or BearerTokenStrategy())
         self._setup_auth()
-        self._lock = threading.Lock()
-        if not self._dynamic_auth and self.__class__._acquire_access_token is not __class__._acquire_access_token:
-            self._ensure_token_initialized()
+        if credential.kind in ('app_credentials', 'oauth2'):
+            self._bootstrap_token()
 
     @staticmethod
     def __lazyllm_after_registry_hook__(cls, group_name: str, name: str, isleaf: bool):
@@ -70,6 +68,25 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     def close(self) -> None:
         self._session.close()
+
+    def _make_credential(self, token: Any, dynamic_auth: bool) -> Credential:
+        # If a subclass implements _do_acquire_without_refresh, treat it as app_credentials.
+        if not dynamic_auth and self._has_app_credentials_flow():
+            return Credential(kind='app_credentials', secret_key=token)
+        return self._default_credential(token, dynamic_auth)
+
+    @classmethod
+    def _has_app_credentials_flow(cls) -> bool:
+        return cls._do_acquire_without_refresh is not CredentialMixin._do_acquire_without_refresh
+
+    def _resolve_dynamic_token(self) -> str:
+        mapping = globals.config['dynamic_fs_auth'] or {}
+        return mapping.get(self._fs_protocol_key, '')
+
+    def _missing_dynamic_token_error(self) -> str:
+        return (f'dynamic_fs_auth["{self.protocol}"] is not set in globals.config; '
+                f'use dynamic_fs_config() or set globals.config["dynamic_fs_auth"] '
+                f'before calling FS methods')
 
     @abstractmethod
     def _setup_auth(self) -> None:
@@ -159,55 +176,15 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
     def _upload_data(self, path: str, data: bytes) -> None:
         raise NotImplementedError(f'{self.__class__.__name__}._upload_data is not implemented')
 
-    def _ensure_token_initialized(self) -> None:
-        token, expires_at = self._acquire_access_token()
-        if not token: raise ValueError('Failed to acquire access token')
-        self._apply_access_token(token)
-        self._token_expire_at = expires_at
-
-    def _ensure_token(self) -> None:
-        if self._dynamic_auth:
-            if not self._dynamic_token:
-                raise ValueError(
-                    f'dynamic_fs_auth["{self.protocol}"] is not set in globals.config; '
-                    f'use dynamic_fs_config() or set globals.config["dynamic_fs_auth"] before calling FS methods'
-                )
-            return
-        if not self._token_expire_at or time.time() < self._token_expire_at: return
-        with self._lock:
-            if time.time() < self._token_expire_at: return
-            self._ensure_token_initialized()
-
-    @property
-    def _dynamic_token(self) -> str:
-        mapping = globals.config['dynamic_fs_auth'] or {}
-        return mapping.get(self._fs_protocol_key, '')
-
-    def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
-        return '', None
-
-    def _apply_access_token(self, token: str) -> None:
-        self._access_token = token
-
-    def _get_auth_header(self) -> Optional[Dict[str, str]]:
-        if self._dynamic_auth:
-            return {'Authorization': f'Bearer {self._dynamic_token}'}
-        if self._access_token:
-            return {'Authorization': f'Bearer {self._access_token}'}
-        return None
-
     def _request(self, method: str, url: str, **kwargs) -> requests.Response:
-        self._ensure_token()
-        auth_header = self._get_auth_header()
-        if auth_header:
-            existing = kwargs.get('headers') or {}
-            # auth_header takes highest priority — caller-supplied headers cannot override credentials
-            kwargs = {**kwargs, 'headers': {**existing, **auth_header}}
-        resp = self._session.request(method, url, **kwargs)
+        existing = kwargs.get('headers') or {}
+        # auth headers take highest priority — caller-supplied headers cannot override credentials
+        merged = self.inject_auth_header(existing)
+        resp = self._session.request(method, url, **{**kwargs, 'headers': merged})
         if not resp.ok:
             try:
                 body = resp.json()
-            except Exception:
+            except Exception:  # noqa: BLE001
                 body = resp.text
             raise requests.HTTPError(
                 f'{resp.status_code} {resp.reason} for url: {resp.url} — response: {body}',
@@ -216,9 +193,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
         return resp
 
     def _json_or_empty(self, resp: requests.Response) -> Any:
-        if not resp.content:
-            return {}
-        return resp.json()
+        return resp.json() if resp.content else {}
 
     def _get(self, url: str, **kwargs) -> Any:
         return self._json_or_empty(self._request('GET', url, **kwargs))
@@ -246,8 +221,7 @@ class LazyLLMFSBase(AbstractFileSystem, metaclass=_CloudFSMeta):
 
     def _parse_path(self, path: str) -> Tuple[str, ...]:
         stripped = self._strip_protocol(path)
-        parts = [p for p in stripped.split('/') if p]
-        return tuple(parts)
+        return tuple(p for p in stripped.split('/') if p)
 
 
 globals.config.add('dynamic_fs_auth', dict, None, 'DYNAMIC_FS_AUTH',

--- a/lazyllm/tools/fs/supplier/confluence.py
+++ b/lazyllm/tools/fs/supplier/confluence.py
@@ -51,14 +51,19 @@ class ConfluenceFS(LazyLLMFSBase):
             'Accept': 'application/json',
         })
 
-    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+    def inject_auth_header(self, headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        out = dict(headers or {})
         if self._dynamic_auth:
             token = self._dynamic_token
-            return {'Authorization': f'Bearer {token}'} if token else None
+            if token:
+                out['Authorization'] = f'Bearer {token}'
+            return out
         if self._cloud and self._email:
             cred = base64.b64encode(f'{self._email}:{self._secret_key}'.encode()).decode()
-            return {'Authorization': f'Basic {cred}'}
-        return {'Authorization': f'Bearer {self._secret_key}'} if self._secret_key else None
+            out['Authorization'] = f'Basic {cred}'
+        elif self._secret_key:
+            out['Authorization'] = f'Bearer {self._secret_key}'
+        return out
 
     @property
     def _rest(self) -> str:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -1,16 +1,14 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
-import os
 import re
-import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import urlencode
 
 import requests
 
 
 from lazyllm import LOG, config
+from lazyllm.common import Credential
 from lazyllm.thirdparty import mistune
 
 from ..base import LazyLLMFSBase, CloudFSBufferedFile
@@ -18,8 +16,6 @@ from ..base import LazyLLMFSBase, CloudFSBufferedFile
 config.add('feishu_app_id', str, None, 'FEISHU_APP_ID', description='Feishu App ID for tenant_access_token.')
 config.add('feishu_app_secret', str, None, 'FEISHU_APP_SECRET', description='Feishu App Secret for tenant_access_token.')
 
-
-_TOKENS_FILE = os.path.join(config['home'], '.lazyllm/tokens.txt')
 
 _API_BASE = 'https://open.feishu.cn/open-apis'
 _TOKEN_URL = 'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal'
@@ -35,40 +31,6 @@ _DEFAULT_OAUTH_SCOPE = (
     'drive:drive drive:drive:readonly drive:drive.metadata:readonly '
     'wiki:wiki wiki:wiki:readonly wiki:node:retrieve docx:document'
 )
-
-
-def _load_persisted_token(key: str) -> str:
-    try:
-        with open(_TOKENS_FILE, 'r', encoding='utf-8') as f:
-            for line in f:
-                k, sep, v = line.strip().partition(': ')
-                if sep and k.strip() == key:
-                    return v.strip()
-    except FileNotFoundError:
-        pass
-    return ''
-
-
-def _save_persisted_token(key: str, value: str) -> None:
-    os.makedirs(os.path.dirname(_TOKENS_FILE), exist_ok=True)
-    lines: List[str] = []
-    found = False
-    try:
-        with open(_TOKENS_FILE, 'r', encoding='utf-8') as f:
-            for line in f:
-                k, sep, _ = line.strip().partition(': ')
-                if sep and k.strip() == key:
-                    if value:  # empty value → delete the entry (don't write the line)
-                        found = True
-                        lines.append(f'{key}: {value}\n')
-                else:
-                    lines.append(line if line.endswith('\n') else line + '\n')
-    except FileNotFoundError:
-        pass
-    if not found and value:
-        lines.append(f'{key}: {value}\n')
-    with open(_TOKENS_FILE, 'w', encoding='utf-8') as f:
-        f.writelines(lines)
 
 
 def _feishu_acquire_access_token(
@@ -96,65 +58,6 @@ def _feishu_acquire_access_token(
         return '', None
     expires_at = now + expire_sec - _TOKEN_REFRESH_BUFFER
     return token, expires_at
-
-
-def _feishu_oauth_get_code(app_id: str, port: int, scope: str = _DEFAULT_OAUTH_SCOPE) -> Tuple[str, str]:
-    redirect_uri = f'http://localhost:{port}/callback'
-    result: Dict[str, str] = {}
-    done = threading.Event()
-
-    class _CallbackHandler(BaseHTTPRequestHandler):
-        def do_GET(self):
-            qs = parse_qs(urlparse(self.path).query)
-            if 'code' in qs:
-                result['code'] = qs['code'][0]
-                body = b'<html><body>Authorization successful. You can close this tab.</body></html>'
-                self.send_response(200)
-                self.send_header('Content-Type', 'text/html; charset=utf-8')
-                self.end_headers()
-                self.wfile.write(body)
-            else:
-                result['error'] = qs.get('error', ['unknown'])[0]
-                self.send_response(400)
-                self.end_headers()
-                self.wfile.write(b'Authorization failed.')
-            done.set()
-
-        def log_message(self, *args): pass  # suppress server access logs
-
-    try:
-        server = HTTPServer(('localhost', port), _CallbackHandler)
-    except OSError as e:
-        raise RuntimeError(
-            f'Cannot bind to localhost:{port} for Feishu OAuth callback. '
-            f'Please free the port or pass a different oauth_port. ({e})'
-        )
-
-    threading.Thread(target=server.handle_request, daemon=True).start()
-
-    auth_url = f'{_OAUTH_AUTHORIZE_URL}?' + urlencode({
-        'client_id': app_id,
-        'redirect_uri': redirect_uri,
-        'scope': scope,
-        'response_type': 'code',
-    })
-    LOG.success(
-        f'Feishu OAuth: open the link below in a browser to authorize access.\n'
-        f'  Prerequisites:\n'
-        f'    1. Register {redirect_uri} in your Feishu app Security Settings → Redirect URL.\n'
-        f'    2. Enable user-identity drive permissions (e.g. drive:drive) in Permission Management\n'
-        f'       and enable offline_access, then publish the app.\n\n'
-        f'  {auth_url}\n'
-    )
-
-    if not done.wait(timeout=_OAUTH_TIMEOUT):
-        server.server_close()
-        raise TimeoutError(f'Feishu OAuth timed out after {_OAUTH_TIMEOUT}s waiting for browser authorization.')
-    server.server_close()
-
-    if 'error' in result:
-        raise RuntimeError(f'Feishu OAuth authorization denied: {result["error"]}')
-    return result['code'], redirect_uri
 
 
 def _feishu_exchange_code(
@@ -219,45 +122,30 @@ class FeishuFSBase(LazyLLMFSBase):
                  oauth_port: int = 9981, oauth_scope: str = _DEFAULT_OAUTH_SCOPE,
                  asynchronous: bool = False, use_listings_cache: bool = False,
                  skip_instance_cache: bool = False, loop: Optional[Any] = None, dynamic_auth: bool = False):
-        if dynamic_auth:
-            if app_id:
-                raise ValueError('app_id must be None when dynamic_auth=True')
-            if app_secret:
-                raise ValueError('app_secret must be None when dynamic_auth=True')
-            if user_refresh_token:
-                raise ValueError('user_refresh_token must be None when dynamic_auth=True')
-            self._oauth_auto = False
-            self._user_refresh_token = ''
-            self._oauth_port = oauth_port
-            self._oauth_scope = oauth_scope
-            super().__init__(
-                token={},
-                base_url=base_url or _API_BASE,
-                asynchronous=asynchronous,
-                use_listings_cache=use_listings_cache,
-                skip_instance_cache=skip_instance_cache,
-                loop=loop,
-                dynamic_auth=True,
-            )
-            self._space_id = (space_id or '').strip() if space_id is not None else ''
-            return
-        if not app_id or not app_secret:
-            app_id, app_secret = config['feishu_app_id'] or app_id, config['feishu_app_secret']
-        assert app_id and app_secret, 'feishu_app_id and feishu_app_secret are required'
-        # _secret_key stores app credentials; _user_refresh_token / _oauth_port managed separately
-        self._oauth_auto: bool = (user_refresh_token == 'auto')
-        self._user_refresh_token: str = user_refresh_token or ''
+        if dynamic_auth and (app_id or app_secret or user_refresh_token):
+            raise ValueError('app_id/app_secret/user_refresh_token must be None when dynamic_auth=True')
+        if not dynamic_auth:
+            app_id = app_id or config['feishu_app_id']
+            app_secret = app_secret or config['feishu_app_secret']
+            assert app_id and app_secret, 'feishu_app_id and feishu_app_secret are required'
         self._oauth_port: int = oauth_port
         self._oauth_scope: str = oauth_scope
+        self._init_user_refresh_token: str = '' if dynamic_auth else (user_refresh_token or '')
         super().__init__(
-            token={'app_id': app_id, 'app_secret': app_secret},
+            token={} if dynamic_auth else {'app_id': app_id, 'app_secret': app_secret},
             base_url=base_url or _API_BASE,
-            asynchronous=asynchronous,
-            use_listings_cache=use_listings_cache,
-            skip_instance_cache=skip_instance_cache,
-            loop=loop,
+            asynchronous=asynchronous, use_listings_cache=use_listings_cache,
+            skip_instance_cache=skip_instance_cache, loop=loop,
+            dynamic_auth=dynamic_auth,
         )
         self._space_id = (space_id or '').strip() if space_id is not None else ''
+
+    def _make_credential(self, token: Any, dynamic_auth: bool):
+        if not dynamic_auth and self._init_user_refresh_token:
+            rt = self._init_user_refresh_token
+            return Credential(kind='oauth2', secret_key=token, refresh_token=rt,
+                              oauth_auto=(rt == 'auto'))
+        return super()._make_credential(token, dynamic_auth)
 
     @property
     def _app_id(self) -> str: return self._secret_key.get('app_id', '')
@@ -265,46 +153,42 @@ class FeishuFSBase(LazyLLMFSBase):
     @property
     def _app_secret(self) -> str: return self._secret_key.get('app_secret', '')
 
-    def _setup_auth(self) -> None:
-        self._session.headers.update({
-            'Content-Type': 'application/json; charset=utf-8',
-        })
-
-    def _do_oauth(self, token_key: str) -> Tuple[str, Optional[float]]:
-        code, redirect_uri = _feishu_oauth_get_code(self._app_id, self._oauth_port, self._oauth_scope)
-        token, expires_at, self._user_refresh_token = _feishu_exchange_code(
-            self._session, self._app_id, self._app_secret, code, redirect_uri)
-        _save_persisted_token(token_key, self._user_refresh_token)
-        return token, expires_at
-
-    def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
-        token_key = f'feishu:{self._app_id}'
-        if self._user_refresh_token == 'auto':
-            persisted = _load_persisted_token(token_key)
-            if persisted:
-                self._user_refresh_token = persisted
-            else:
-                return self._do_oauth(token_key)
-        if self._user_refresh_token:
-            try:
-                token, expires_at, self._user_refresh_token = _feishu_refresh_user_token(
-                    self._session, self._app_id, self._app_secret, self._user_refresh_token)
-                _save_persisted_token(token_key, self._user_refresh_token)
-                return token, expires_at
-            except Exception:
-                if not self._oauth_auto:
-                    raise
-                LOG.warning(f'Feishu refresh_token for {self._app_id} is invalid, re-authenticating via OAuth.')
-                self._user_refresh_token = ''
-                _save_persisted_token(token_key, '')
-                return self._do_oauth(token_key)
-        return _feishu_acquire_access_token(self._session, self._app_id, self._app_secret)
-
-    def _apply_access_token(self, token: str) -> None:
-        self._access_token = token
+    @property
+    def _user_refresh_token(self) -> str:
+        return self._credential.refresh_token
 
     def get_user_refresh_token(self) -> str:
         return self._user_refresh_token
+
+    def _setup_auth(self) -> None:
+        self._session.headers.update({'Content-Type': 'application/json; charset=utf-8'})
+
+    def _get_persist_key(self) -> str:
+        return f'feishu:{self._app_id}'
+
+    def _do_refresh_token(self, refresh_token: str) -> Tuple[str, Optional[float], str]:
+        return _feishu_refresh_user_token(self._session, self._app_id, self._app_secret, refresh_token)
+
+    def _do_acquire_without_refresh(self) -> Tuple[str, Optional[float], str]:
+        token, expires_at = _feishu_acquire_access_token(self._session, self._app_id, self._app_secret)
+        return token, expires_at, ''
+
+    def _do_oauth_flow(self) -> Tuple[str, Optional[float], str]:
+        redirect_uri = f'http://localhost:{self._oauth_port}/callback'
+        authorize_url = f'{_OAUTH_AUTHORIZE_URL}?' + urlencode({
+            'client_id': self._app_id, 'redirect_uri': redirect_uri,
+            'scope': self._oauth_scope, 'response_type': 'code',
+        })
+        LOG.success(
+            f'Feishu OAuth: open the link below in a browser to authorize access.\n'
+            f'  Prerequisites:\n'
+            f'    1. Register {redirect_uri} in your Feishu app Security Settings -> Redirect URL.\n'
+            f'    2. Enable user-identity drive permissions (e.g. drive:drive) in Permission Management\n'
+            f'       and enable offline_access, then publish the app.\n\n'
+            f'  {authorize_url}\n'
+        )
+        code = self._run_local_oauth_server(self._oauth_port, _OAUTH_TIMEOUT)
+        return _feishu_exchange_code(self._session, self._app_id, self._app_secret, code, redirect_uri)
 
     def _drive_root_folder_token(self) -> str:
         if not getattr(self, '_cached_drive_root_token', ''):

--- a/lazyllm/tools/fs/supplier/googledrive.py
+++ b/lazyllm/tools/fs/supplier/googledrive.py
@@ -67,17 +67,18 @@ class GoogleDriveFS(LazyLLMFSBase):
         return None
 
     def _setup_auth(self) -> None:
-        # Short-lived access tokens are injected into headers by _ensure_token.
+        # Short-lived access tokens are injected into headers by inject_auth_header().
         return None
 
-    def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
+    def _do_acquire_without_refresh(self) -> Tuple[str, Optional[float], str]:
         if not self._service_account_info:
-            return '', None
+            raise ValueError(f'{type(self).__name__} failed to acquire access token: '
+                             'service_account_info is not configured.')
         token = self._fetch_sa_token()
         if not token:
-            return '', None
+            raise ValueError(f'{type(self).__name__} failed to acquire access token from service account.')
         expires_at = time.time() + 3600 - _SA_TOKEN_BUFFER
-        return token, expires_at
+        return token, expires_at, ''
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/notion.py
+++ b/lazyllm/tools/fs/supplier/notion.py
@@ -32,8 +32,6 @@ class NotionFS(LazyLLMFSBase):
             'Notion-Version': _NOTION_VERSION,
             'Content-Type': 'application/json',
         })
-        if not self._dynamic_auth:
-            self._apply_access_token(self._secret_key)
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/onedrive.py
+++ b/lazyllm/tools/fs/supplier/onedrive.py
@@ -76,16 +76,14 @@ class OneDriveFS(LazyLLMFSBase):
             'Content-Type': 'application/json',
         })
 
-    def _acquire_access_token(self) -> Tuple[str, Optional[float]]:
+    def _do_acquire_without_refresh(self) -> Tuple[str, Optional[float], str]:
         if not self._client_id or not self._client_secret:
-            return '', None
+            raise ValueError(f'{type(self).__name__} failed to acquire access token: '
+                             'client_id/client_secret are not configured.')
         token, expires_at = self._acquire_app_token_with_expiry(
             self._client_id, self._client_secret, self._tenant_id,
         )
-        return token, expires_at
-
-    def _apply_access_token(self, token: str) -> None:
-        self._access_token = token
+        return token, expires_at, ''
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         url = self._make_children_url(path)

--- a/lazyllm/tools/fs/supplier/ones.py
+++ b/lazyllm/tools/fs/supplier/ones.py
@@ -56,23 +56,25 @@ class OnesFS(LazyLLMFSBase):
     def _setup_auth(self) -> None:
         self._session.headers.update({'Content-Type': 'application/json'})
 
-    def _get_auth_header(self) -> Optional[Dict[str, str]]:
+    def inject_auth_header(self, headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+        out = dict(headers or {})
         if self._dynamic_auth:
             raw = self._dynamic_token
             if not raw:
-                return None
+                return out
             if ':' in raw:
                 uid, tok = raw.split(':', 1)
             else:
                 uid, tok = self._user_id, raw
-            h = {'Ones-Auth-Token': tok}
-            if uid:
-                h['Ones-User-Id'] = uid
-            return h
-        h = {'Ones-Auth-Token': self._secret_key}
-        if self._user_id:
-            h['Ones-User-Id'] = self._user_id
-        return h if self._secret_key else None
+        else:
+            tok = self._secret_key or ''
+            uid = self._user_id
+            if not tok:
+                return out
+        out['Ones-Auth-Token'] = tok
+        if uid:
+            out['Ones-User-Id'] = uid
+        return out
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/fs/supplier/s3.py
+++ b/lazyllm/tools/fs/supplier/s3.py
@@ -28,7 +28,7 @@ class S3FS(LazyLLMFSBase):
                  **storage_options):
         if dynamic_auth:
             self._access_key = ''
-            self._secret_key = ''
+            self._aws_secret = ''
             self._endpoint_url = endpoint_url or None
             self._region_name = region_name or None
             self._s3_client = None
@@ -40,7 +40,7 @@ class S3FS(LazyLLMFSBase):
         endpoint_url = endpoint_url or config['s3_endpoint_url'] or ''
         region_name = region_name or config['s3_region_name'] or os.environ.get('AWS_DEFAULT_REGION') or ''
         self._access_key = access_key
-        self._secret_key = secret_key
+        self._aws_secret = secret_key
         self._endpoint_url = endpoint_url or None
         self._region_name = region_name or None
         self._s3_client = None
@@ -52,8 +52,8 @@ class S3FS(LazyLLMFSBase):
         kwargs: Dict[str, Any] = {}
         if self._access_key:
             kwargs['aws_access_key_id'] = self._access_key
-        if self._secret_key:
-            kwargs['aws_secret_access_key'] = self._secret_key
+        if self._aws_secret:
+            kwargs['aws_secret_access_key'] = self._aws_secret
         if self._endpoint_url:
             kwargs['endpoint_url'] = self._endpoint_url
         if self._region_name:

--- a/lazyllm/tools/fs/supplier/yuque.py
+++ b/lazyllm/tools/fs/supplier/yuque.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import lazyllm
 from lazyllm import config
+from lazyllm.common import ApiKeyHeaderStrategy
 
 from ..base import LazyLLMFSBase, CloudFSBufferedFile
 
@@ -23,17 +24,16 @@ class YuqueFS(LazyLLMFSBase):
             token = ''
         else:
             token = token or config['yuque_token'] or os.environ.get('YUQUE_TOKEN') or ''
-        super().__init__(token=token, base_url=base_url or _API_BASE, dynamic_auth=dynamic_auth, **storage_options)
+        super().__init__(
+            token=token, base_url=base_url or _API_BASE, dynamic_auth=dynamic_auth,
+            auth_strategy=ApiKeyHeaderStrategy('X-Auth-Token'), **storage_options,
+        )
 
     def _setup_auth(self) -> None:
         self._session.headers.update({
             'Content-Type': 'application/json',
             'User-Agent': 'lazyllm-fs (https://github.com/LazyAGI/lazyllm)',
         })
-
-    def _get_auth_header(self) -> Optional[Dict[str, str]]:
-        token = self._dynamic_token if self._dynamic_auth else self._secret_key
-        return {'X-Auth-Token': token} if token else None
 
     def ls(self, path: str, detail: bool = True, **kwargs) -> List:
         parts = self._parse_path(path)

--- a/lazyllm/tools/tools/search/base.py
+++ b/lazyllm/tools/tools/search/base.py
@@ -1,7 +1,10 @@
 import re
 from html import unescape
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
+from lazyllm.common import (
+    AuthStrategy, BearerTokenStrategy, Credential, CredentialMixin,
+)
 from lazyllm.module import ModuleBase
 from lazyllm.module.module import ModuleExecutionError
 from lazyllm.thirdparty import httpx
@@ -35,12 +38,20 @@ def _make_result(title: str, url: str, snippet: str = '', source: str = '', **ex
 
 
 # TODO: add tests after key is ready
-class SearchBase(ModuleBase):
+class SearchBase(ModuleBase, CredentialMixin):
     __public_apis__ = ['search', 'get_content', 'get_contents']
 
-    def __init__(self, source_name: str = '', **kwargs):
-        super().__init__(**kwargs)
+    def __init__(
+        self,
+        source_name: str = '',
+        api_key: Optional[str] = None,
+        auth_strategy: Optional[AuthStrategy] = None,
+        **kwargs,
+    ):
+        ModuleBase.__init__(self, **kwargs)
         self._source_name = source_name or self.__class__.__name__.replace('Search', '').lower()
+        credential = Credential(kind='static', secret_key=api_key or '')
+        self.__init_credential__(credential, strategy=auth_strategy or BearerTokenStrategy())
 
     @property
     def source_name(self) -> str:

--- a/lazyllm/tools/tools/search/bing_search.py
+++ b/lazyllm/tools/tools/search/bing_search.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from lazyllm.common import ApiKeyHeaderStrategy
 from lazyllm.thirdparty import httpx
 
 from .base import SearchBase, _make_result
@@ -9,13 +10,15 @@ class BingSearch(SearchBase):
 
     def __init__(self, subscription_key: str, endpoint: Optional[str] = None,
                  timeout: int = 10, source_name: str = 'bing'):
-        super().__init__(source_name=source_name)
-        self._key = subscription_key
+        super().__init__(
+            source_name=source_name, api_key=subscription_key,
+            auth_strategy=ApiKeyHeaderStrategy('Ocp-Apim-Subscription-Key'),
+        )
         self._url = endpoint or 'https://api.bing.microsoft.com/v7.0/search'
         self._timeout = timeout
 
     def search(self, query: str, count: int = 10) -> List[dict]:
-        headers = {'Ocp-Apim-Subscription-Key': self._key}
+        headers = self.inject_auth_header()
         params = {'q': query, 'count': min(count, 50)}
         resp = httpx.get(
             self._url,

--- a/lazyllm/tools/tools/search/bocha_search.py
+++ b/lazyllm/tools/tools/search/bocha_search.py
@@ -9,8 +9,7 @@ class BochaSearch(SearchBase):
 
     def __init__(self, api_key: str, base_url: str = 'https://api.bochaai.com',
                  timeout: int = 15, source_name: str = 'bocha'):
-        super().__init__(source_name=source_name)
-        self._api_key = api_key
+        super().__init__(source_name=source_name, api_key=api_key)
         self._base_url = base_url.rstrip('/')
         self._timeout = timeout
 
@@ -18,7 +17,7 @@ class BochaSearch(SearchBase):
                freshness: Optional[str] = None,
                summary: bool = False) -> List[dict]:
         url = f'{self._base_url}/v1/web-search'
-        headers = {'Authorization': f'Bearer {self._api_key}', 'Content-Type': 'application/json'}
+        headers = self.inject_auth_header({'Content-Type': 'application/json'})
         body = {'query': query, 'count': min(count, 20), 'summary': summary}
         if freshness:
             body['freshness'] = freshness

--- a/lazyllm/tools/tools/search/google_books_search.py
+++ b/lazyllm/tools/tools/search/google_books_search.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 
+from lazyllm.common import QueryParamStrategy
 from lazyllm.thirdparty import httpx
 
 from .base import SearchBase, _make_result
@@ -9,15 +10,15 @@ class GoogleBooksSearch(SearchBase):
 
     def __init__(self, api_key: Optional[str] = None,
                  timeout: int = 10, source_name: str = 'google_books'):
-        super().__init__(source_name=source_name)
-        self._api_key = api_key
+        super().__init__(
+            source_name=source_name, api_key=api_key,
+            auth_strategy=QueryParamStrategy('key'),
+        )
         self._timeout = timeout
         self._url = 'https://www.googleapis.com/books/v1/volumes'
 
     def search(self, query: str, max_results: int = 10) -> List[dict]:
-        params = {'q': query, 'maxResults': min(max_results, 40)}
-        if self._api_key:
-            params['key'] = self._api_key
+        params = self.inject_auth_params({'q': query, 'maxResults': min(max_results, 40)})
         resp = httpx.get(self._url, params=params, timeout=self._timeout)
         resp.raise_for_status()
         data = resp.json()

--- a/lazyllm/tools/tools/search/google_search.py
+++ b/lazyllm/tools/tools/search/google_search.py
@@ -1,5 +1,6 @@
 from typing import Optional, Dict, Any, List
 
+from lazyllm.common import QueryParamStrategy
 from lazyllm.tools.tools import HttpTool
 
 from .base import SearchBase, _make_result
@@ -10,7 +11,10 @@ class GoogleSearch(SearchBase):
     def __init__(self, custom_search_api_key: str, search_engine_id: str,
                  timeout: int = 10, proxies: Optional[Dict[str, str]] = None,
                  source_name: str = 'google'):
-        super().__init__(source_name=source_name)
+        super().__init__(
+            source_name=source_name, api_key=custom_search_api_key,
+            auth_strategy=QueryParamStrategy('key'),
+        )
         params = {
             'key': custom_search_api_key,
             'cx': '{{search_engine_id}}',

--- a/lazyllm/tools/tools/search/semantic_scholar_search.py
+++ b/lazyllm/tools/tools/search/semantic_scholar_search.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Optional
 
+from lazyllm.common import ApiKeyHeaderStrategy
 from lazyllm.thirdparty import httpx
 
 from .base import SearchBase, _make_result
@@ -9,8 +10,10 @@ class SemanticScholarSearch(SearchBase):
 
     def __init__(self, api_key: Optional[str] = None,
                  timeout: int = 15, source_name: str = 'semantic_scholar'):
-        super().__init__(source_name=source_name)
-        self._api_key = api_key
+        super().__init__(
+            source_name=source_name, api_key=api_key,
+            auth_strategy=ApiKeyHeaderStrategy('x-api-key'),
+        )
         self._timeout = timeout
         self._base = 'https://api.semanticscholar.org/graph/v1'
 
@@ -23,9 +26,7 @@ class SemanticScholarSearch(SearchBase):
                 return snippet
             return super().get_content(item)
         url = f'{self._base}/paper/{paper_id}'
-        headers = {}
-        if self._api_key:
-            headers['x-api-key'] = self._api_key
+        headers = self.inject_auth_header()
         try:
             resp = httpx.get(
                 url,
@@ -47,9 +48,7 @@ class SemanticScholarSearch(SearchBase):
             'limit': min(limit, 100),
             'fields': fields or 'title,url,abstract,authors,year,citationCount',
         }
-        headers = {}
-        if self._api_key:
-            headers['x-api-key'] = self._api_key
+        headers = self.inject_auth_header()
         resp = httpx.get(url, params=params, headers=headers or None, timeout=self._timeout)
         resp.raise_for_status()
         data = resp.json()

--- a/lazyllm/tools/tools/search/stackoverflow_search.py
+++ b/lazyllm/tools/tools/search/stackoverflow_search.py
@@ -1,6 +1,7 @@
 import re
 from typing import Any, Dict, List, Optional
 
+from lazyllm.common import QueryParamStrategy
 from lazyllm.thirdparty import httpx
 
 from .base import SearchBase, _html_to_text, _make_result
@@ -10,9 +11,11 @@ class StackOverflowSearch(SearchBase):
 
     def __init__(self, site: str = 'stackoverflow', key: Optional[str] = None,
                  timeout: int = 10, source_name: str = 'stackoverflow'):
-        super().__init__(source_name=source_name)
+        super().__init__(
+            source_name=source_name, api_key=key,
+            auth_strategy=QueryParamStrategy('key'),
+        )
         self._site = site
-        self._key = key
         self._timeout = timeout
 
     def get_content(self, item: Dict[str, Any]) -> str:
@@ -22,9 +25,7 @@ class StackOverflowSearch(SearchBase):
             return super().get_content(item)
         qid = m.group(1)
         api_url = f'https://api.stackexchange.com/2.3/questions/{qid}'
-        params = {'site': self._site, 'filter': 'withbody'}
-        if self._key:
-            params['key'] = self._key
+        params = self.inject_auth_params({'site': self._site, 'filter': 'withbody'})
         try:
             resp = httpx.get(api_url, params=params, timeout=self._timeout)
             resp.raise_for_status()
@@ -56,15 +57,13 @@ class StackOverflowSearch(SearchBase):
     def search(self, query: str, count: int = 10,
                sort: str = 'relevance') -> List[dict]:
         url = 'https://api.stackexchange.com/2.3/search/advanced'
-        params = {
+        params = self.inject_auth_params({
             'order': 'desc',
             'sort': sort,
             'q': query,
             'site': self._site,
             'pagesize': min(count, 100),
-        }
-        if self._key:
-            params['key'] = self._key
+        })
         resp = httpx.get(url, params=params, timeout=self._timeout)
         resp.raise_for_status()
         data = resp.json()

--- a/lazyllm/tools/tools/search/tencent_search.py
+++ b/lazyllm/tools/tools/search/tencent_search.py
@@ -6,6 +6,7 @@ from .base import SearchBase, _make_result
 class TencentSearch(SearchBase):
 
     def __init__(self, secret_id: str, secret_key: str, source_name: str = 'tencent'):
+        # Tencent SDK signs requests internally; no SearchBase strategy needed.
         super().__init__(source_name=source_name)
         from tencentcloud.common.common_client import CommonClient
         from tencentcloud.common import credential


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 引入 `CredentialMixin` + `Credential` + `AuthStrategy` 抽象，统一 `LazyLLMFSBase`、`SearchBase`（以及未来的 `LazyLLMOnlineBase`）所需的认证存储、token 刷新与 header/参数注入逻辑。
- 将原本散落在 `fs/base.py` 与 `fs/supplier/feishu.py` 中的 token 缓存、双重检查锁、OAuth2 三路 fallback、refresh_token 持久化等代码下沉到通用 mixin。
- `Search` 工具开始统一接入新基类，删除各自手写 header 的重复样板；`Feishu` / `GoogleDrive` / `OneDrive` / `Notion` / `Confluence` / `ONES` / `Yuque` 等 FS 子类按四种 `kind`（`static` / `dynamic` / `app_credentials` / `oauth2`）重新归位，子类只实现 hook，不再覆盖核心流程。

---

# 🎯 问题背景 / Problem Context

当前认证逻辑分散在三层、各自实现一套，缺乏共享：

- `LazyLLMFSBase`：同时承担 credential 管理、token 获取/刷新、header 注入、HTTP 请求，职责过重。
- `LazyLLMOnlineBase`：独立实现一套 api-key 管理，与 FS 的 token 体系完全平行，无法复用。
- `Search` 工具（`bocha_search` / `bing_search` / `google_*` 等）：各自在 `__init__` 里存 `self._api_key`，在 `search()` 里手动构造 header，没有任何抽象。

同时 `feishu.py` 里 `_user_refresh_token`、`_access_token` 直接写实例变量，并发刷新时存在写入竞态；`Credential` 的 4 种语义（`api_key` 静态、`dynamic` 多租户、`app_credentials` 短期 token、`oauth2` 完整 OAuth2）没有清晰边界，每个子类自己拼一遍。

本 PR 收敛抽象边界：**只依赖 `Credential` 对象的逻辑全部沉到 `CredentialMixin`；依赖业务接口的探测放在中间 base；具体 OAuth/SA/MSAL 业务调用留在叶子子类。**

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `make lint-only-diff` 通过；`LAZYLLM_INIT_DOC=True python -c 'import lazyllm'` 通过。
2. 既有 `tests/basic_tests/` 中针对 FS / Search 的用例全部跑通，重点关注 Feishu OAuth2 三路 fallback、`dynamic_fs_config()` 上下文管理器、`override_credential()` 行为。
3. 手工验证：`FeishuFS(user_refresh_token='auto')` 触发本地 OAuth server → 回调写入 `~/.lazyllm/tokens.txt` → 进程重启后仍可继续 refresh；`GoogleDriveFS` / `OneDriveFS` 用 SA / client_credentials 走 `app_credentials` 路径正常获取 token。

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
import lazyllm
from lazyllm.tools.fs import FS, FeishuFS, dynamic_fs_config
from lazyllm.tools.tools.search import BochaSearch

# Feishu OAuth2: refresh_token='auto' 时由基类托管整个生命周期（持久化 + 刷新 + fallback）
fs = FeishuFS(app_id='xxx', app_secret='xxx', user_refresh_token='auto')
content = fs.cat('feishu:/docs/my-doc')

# 多租户：后端注入 access_token，FS 走 dynamic 模式
with dynamic_fs_config({'feishu': 'user_token_for_this_request'}):
    content = FS.cat('feishu:/docs/my-doc')

# Search：默认 BearerTokenStrategy，与 FS 共享同一套抽象
bocha = BochaSearch(api_key='bk-xxx')
results = bocha('LazyLLM')

# 临时覆盖 credential（测试/调试场景）
with bocha.override_credential(secret_key='bk-other'):
    results = bocha('LazyLLM')
```

---

# 🔄 重构对比 / Refactor Comparison

## Before

```python
class LazyLLMFSBase(AbstractFileSystem):
    def __init__(self, token, dynamic_auth=False, ...):
        self._secret_key = token
        self._access_token = ''
        self._token_expire_at = None
        self._lock = threading.Lock()
        self._dynamic_auth = dynamic_auth
        ...

    def _ensure_token(self):
        with self._lock:
            if not self._access_token or time.time() >= self._token_expire_at:
                token, exp = self._acquire_access_token()
                self._apply_access_token(token, exp)

    def _get_auth_header(self):
        return {'Authorization': f'Bearer {self._access_token}'}


class FeishuFSBase(LazyLLMFSBase):
    def __init__(self, ..., user_refresh_token=None):
        self._user_refresh_token = user_refresh_token or ''
        super().__init__(...)

    def _acquire_access_token(self):
        # 自己实现 refresh_token / OAuth flow / app_credentials 三路 fallback
        # 自己读写 ~/.lazyllm/tokens.txt
        # 自己起本地 HTTP server 等 OAuth callback
        ...
```

## After

```python
class LazyLLMFSBase(AbstractFileSystem, CredentialMixin, metaclass=_CloudFSMeta):
    def __init__(self, token, dynamic_auth=False, auth_strategy=None, ...):
        cred = self._make_credential(token, dynamic_auth)
        self.__init_credential__(cred, strategy=auth_strategy or BearerTokenStrategy())
        self._setup_auth()
        if cred.kind in ('app_credentials', 'oauth2'):
            self._bootstrap_token()

    def _make_credential(self, token, dynamic_auth):
        # FS 层只追加 app_credentials 探测；static/dynamic 由 mixin 兜底
        if not dynamic_auth and self._has_app_credentials_flow():
            return Credential(kind='app_credentials', secret_key=token)
        return self._default_credential(token, dynamic_auth)

    def _request(self, method, url, **kwargs):
        merged = self.inject_auth_header(kwargs.get('headers') or {})
        return self._session.request(method, url, **{**kwargs, 'headers': merged})


class FeishuFSBase(LazyLLMFSBase):
    def _make_credential(self, token, dynamic_auth):
        if not dynamic_auth and self._init_user_refresh_token:
            rt = self._init_user_refresh_token
            return Credential(kind='oauth2', secret_key=token, refresh_token=rt,
                              oauth_auto=(rt == 'auto'))
        return super()._make_credential(token, dynamic_auth)

    # 三个原子 hook，业务调用各自独立
    def _do_refresh_token(self, refresh_token): ...
    def _do_acquire_without_refresh(self): ...
    def _do_oauth_flow(self): ...

    # 持久化 key 由基类调用
    def _get_persist_key(self): return f'feishu:{self._app_id}'
```

# ⚠️ 注意事项 / Additional Notes

* `LazyLLMOnlineBase` 的接入留作 Phase 4，本次不做（影响面最大，需要保留多 key 随机选取语义）。
* `Credential` 是 frozen dataclass，token 刷新通过 `dataclasses.replace()` 原子替换整个对象，避免 `_user_refresh_token` / `_access_token` 双字段更新的非原子性。
* `~/.lazyllm/tokens.txt` 持久化逻辑由基类托管，子类只覆盖 `_get_persist_key()`；如需改成 Redis/DB，重写 `_load_persisted_refresh_token` / `_save_persisted_refresh_token` 即可。
* `dynamic_fs_config()` 外部接口未变；`override_credential()` 是新增的同实例临时切换 key 用法（非多租户方案）。

---


# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [x] Cursor
- [ ] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
@认证基类重构设计_f8b67dae.plan.md (1-590) 请基于此方案进行重构，请注意，重构的时候，要严格遵循 @.cursor/rules/coding-standards.mdc
```

先和 AI 一起把方案文档（`认证基类重构设计`，含 9 个章节、类图、四种 kind 边界、Phase 1~4 拆解）讨论清楚，再让 AI 严格按照 plan + coding standards 落地，避免一上来就写代码导致抽象边界漂移。

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

## **问题点 / Issues：**

- 第一版重构后四个核心文件（`auth.py` / `credential_mixin.py` / `fs/base.py` / `feishu.py`）**新增 ~520 行、删除 ~176 行**，与"逻辑只是挪位置、行数应基本持平"的预期严重不符。
- 抽象层（mixin）和 FS-base 之间存在**双倍代价**：mixin 已经提供了新接口，FS-base 又封装一层老接口（`_acquire_access_token` / `_apply_access_token` / `_ensure_token`）shim 指向它。
- `_dynamic_auth` / `_secret_key` / `_dynamic_token` 等只依赖 `_credential` 的 property 全部写在 `LazyLLMFSBase` 上，导致 `SearchBase` 接入时拿不到这些通用能力。
- 存在多份冗余安全网：未被使用的 `BasicAuthStrategy`、`Credential.extra/dynamic_config_key`、`_feishu_oauth_get_code` 死代码等。

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
我们聚焦于 auth.py，fs/base.py，feishu.py 和 credential_mixin.py，我认为目前飞书已经实现了几乎所有的认证逻辑，那么在重构后，理论上代码量应该和之前不会相差特别大，大部分逻辑只是挪了位置；
可是目前重构下来，这四个文件共计新增了约520行代码，而减少的只有176行，我想了解一下：
1. 为什么多这么多
2. 有哪些可以简化的么
3. 是否存在有该删除但没删除的逻辑
```

### **原因 / Reason：**

第一版 AI 倾向于"加抽象 + 留兼容"两手都抓，结果把每个旧接口都做了 shim、每个可能有用的 Strategy 都先写出来。需要先让它**自己盘点**新增量的来源（抽象层本身 / 兼容层 / 冗余安全网），再针对性地裁剪，而不是直接让它"删一删"——否则容易把真正需要的兼容层也误删。

### 第二次修正 / Second Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
请简化，过时的代码全部删掉
```

### **原因 / Reason：**

确认 AI 对新增量的归因正确（兼容层 ~45 行、未使用 Strategy ~30 行、Credential 冗余字段、`_feishu_oauth_get_code` 死函数等）后，给一个明确"删"的指令，让它一次性清理。结果是四文件总计 −186 行，相比 main 净增基础设施 281 行而 FS 层净减 116 行，符合"逻辑挪位置 + 抽象增量合理"的预期。

### 第三次修正 / Third Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
我有个问题，既然 LazyLLMFSBase 继承自 CredentialMixin，为什么权限相关的接口不能直接提供在 CredentialMixin，fsbase 要重写一份，比如

    @property
    def _dynamic_auth(self) -> bool:
        return self._credential.kind == 'dynamic'

    @property
    def _secret_key(self) -> Any:
        return self._credential.secret_key

等，你认为写在哪合适呢
```

### **原因 / Reason：**

AI 在第一轮把"FS 历史属性"原样放在了 `LazyLLMFSBase`，没意识到 `SearchBase` 也继承同一个 mixin、同样需要这些能力。给出**判断标准**："只依赖 `_credential` 对象的，全部归 mixin；依赖 FS 特有概念（`globals.config['dynamic_fs_auth']` / `_fs_protocol_key` / `_acquire_access_token` 老接口）的留 FS 层。"AI 据此把 `_dynamic_auth` / `_secret_key` / `_dynamic_token` / `get_current_token` / `ensure_token` 全部上移，FS 层只保留 `_resolve_dynamic_token` 和 `_missing_dynamic_token_error` 两个 hook 的具体实现。

### 第四次修正 / Fourth Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
_acquire_access_token 也判断一下呢，进一步的，_make_credential 和 _do_acquire_without_refresh 也重新判断一下
```

### **原因 / Reason：**

第三轮上移后还遗留三个 FS-base 上的接口没有按"归属标准"再走一遍：
- `_acquire_access_token`：纯属 legacy hook，是 `_do_acquire_without_refresh` 的"少返回 refresh_token"版，没存在价值 → **删除**。
- `_do_acquire_without_refresh`：mixin 已有 `raise NotImplementedError` 默认，FS-base 桥接到 `_acquire_access_token` 是冗余 → **删除桥接**。
- `_make_credential`：三种通用 kind 决策（static/dynamic）应该 mixin 兜底；FS-base 只追加 `app_credentials` 探测；`feishu` 自己再追加 `oauth2` 探测 → **分三层**：`CredentialMixin._default_credential` → `LazyLLMFSBase._make_credential`（探测 `app_credentials`）→ `FeishuFSBase._make_credential`（探测 `oauth2`，并 `super()._make_credential()` 链式回退）。

最终 GoogleDrive / OneDrive 直接实现 `_do_acquire_without_refresh`，不再过 `_acquire_access_token` 中转层，FS-base 上的 legacy hook 彻底清理。

### 最终策略总结 / Final Strategy Summary

* **先方案后代码**：复杂重构必须先把抽象边界（哪些是基类、哪些是策略、哪些是 hook）写成 plan 文档，让 AI 严格按 plan 落地，而不是一上来 "请帮我重构 X"。
* **行数是最早的信号**：如果"逻辑挪位置"的重构出现明显行数膨胀，先让 AI 自己**归因**（抽象层本身 / 兼容层 / 冗余安全网），再分阶段删除，避免一次性大砍砍掉真正必要的兼容。
* **抽象归属用一句话判断**：*"只依赖 X 对象的逻辑放在拥有 X 的层；依赖业务接口/外部配置的留具体 base；依赖叶子业务字段的留叶子。"* 本 PR 中 X 就是 `Credential`。这条标准帮我们一次性把 6 个 property + 3 个核心方法的归属理清。
* **链式 super 优于平铺探测**：多层 base 的 `_make_credential` 用 `super()` 链式 fallback，每一层只判断自己关心的 kind，比每层都平铺判断 N 种 kind 清晰得多。
* **legacy hook 最容易留**：AI 默认倾向"加新接口的同时不删旧接口"，需要显式追问每个老 hook 的存在价值（"它现在还有谁在调？谁实现它？为什么不直接实现新接口？"），才能把 shim 真正清掉。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`90%`
* 人工修改占比 / Human modifications：`10%`

**主要人工修改点 / Key Human Modifications：**

* [x] 逻辑修正 / Logic fixes（指出 `_acquire_access_token` / `_do_acquire_without_refresh` 是冗余 legacy）
* [ ] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [ ] 代码风格 / Code style
* [x] 架构调整 / Architecture adjustments（property 归属上移、`_make_credential` 三层分层）

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```text
@认证基类重构设计_f8b67dae.plan.md (1-590) 请基于此方案进行重构
```

### ❌ 问题表现 / Issue Description

* AI 倾向"加抽象 + 留兼容"两手都抓：mixin 给一套新接口，FS-base 再给一套老接口的 shim 指向它，相当于双倍代价。
* 把"FS 历史属性"原样放在 `LazyLLMFSBase` 上，没考虑到同一个 mixin 还会被 `SearchBase` 继承，导致 Search 拿不到 `_dynamic_auth` / `_secret_key` 等通用能力。
* 默认保留所有"可能有用"的 Strategy（`BasicAuthStrategy` 等）和 dataclass 字段（`Credential.extra` / `dynamic_config_key`），即使没人用。

### ✅ 改进后 Prompt / Improved Prompt

```text
@认证基类重构设计_f8b67dae.plan.md (1-590) 请基于此方案进行重构，注意：
1. 严格遵循 @.cursor/rules/coding-standards.mdc
2. 只保留 plan 中明确列出的接口和 Strategy；不要"为以后预留"的安全网
3. 抽象归属判断标准：只依赖 _credential 对象的逻辑放 mixin；依赖 FS 特有概念的放 FS-base；依赖叶子业务字段的放叶子
4. legacy hook（如 _acquire_access_token）必须直接删除而不是做 shim，让所有子类直接实现 mixin 定义的新 hook
```

# 🧩 可复用经验 / Reusable Patterns

* **Prompt 模板**：复杂重构 = "*Plan 文档 + 严格抽象归属判断标准 + 禁止预留安全网 + 强制删除 legacy hook*"。
* **常见坑**：
  - AI 默认"加新不删旧"，shim 层会让重构看似完成、实则双倍代价；
  - "只依赖 X 对象的 property"很容易被错误地放在 X 的某个使用方而非 X 自己；
  - 多层 base 决策容易写成平铺判断，应优先考虑 `super()` 链式 fallback。
* **推荐做法**：
  - 重构后第一时间统计四象限（新增基础设施 / 兼容层 / 冗余安全网 / 净逻辑迁移）的行数占比，作为是否真正"瘦身"的指标；
  - 每个老 hook 都用三连问："它现在还有谁在调？谁实现它？为什么不直接实现新接口？"——能答出第三问之外的理由才保留；
  - 抽象边界给一条**单句判断标准**（本 PR：依赖 `_credential` 的归 mixin），让后续接入新模块时不需要再讨论一次归属。
