### PR TITLE
add qwen and siliconflow multimodal embeddings

### DIFF
--- a/lazyllm/components/utils/downloader/model_directory.py
+++ b/lazyllm/components/utils/downloader/model_directory.py
@@ -19,7 +19,7 @@ special_models = {
     'ocr': {},
     'embed': {'embeddinggemma-300m', 'all-roberta-large-v1'},
     'rerank': {'gte-multilingual-reranker-base', 'gte-rerank-v2'},
-    'cross_modal_embed': {'vlm2vec-full', 'siglip-base-patch16-224'},
+    'cross_modal_embed': {'vlm2vec-full', 'siglip-base-patch16-224', 'qwen3-vl-embedding-8b'},
 }
 
 def special_model_rule(model_name: str) -> Optional[str]:

--- a/lazyllm/docs/module.py
+++ b/lazyllm/docs/module.py
@@ -2638,6 +2638,47 @@ Args:
     api_key (str, optional): API key. Defaults to 'qwen_api_key' from configuration
 """)
 
+add_chinese_doc('llms.onlinemodule.supplier.qwen.QwenMultimodalEmbed', """\
+通义千问在线多模态嵌入模块。
+
+该类继承自 OnlineEmbeddingModuleBase，通过 DashScope MultiModalEmbedding 接口将文本、图像或图文组合转换为统一向量表示。单次多模态请求返回一条向量，输出格式与 QwenEmbed 处理单条文本时保持一致。
+
+Args:
+    embed_url (str, optional): DashScope API URL。默认使用 DashScope 官方 API 地址。
+    embed_model_name (str, optional): 多模态嵌入模型名称，默认从配置项 'qwen_multimodal_embed_model_name' 读取，未配置时使用 'qwen2.5-vl-embedding'。
+    api_key (str, optional): API 密钥。默认从配置项 'qwen_api_key' 中读取。
+    batch_size (int, optional): 批处理大小，默认为 1。
+    return_trace (bool, optional): 是否返回追踪信息，默认为 False。
+    skip_auth (bool, optional): 是否跳过鉴权，默认为 False。
+""")
+
+add_english_doc('llms.onlinemodule.supplier.qwen.QwenMultimodalEmbed', """\
+Qwen online multimodal embedding module.
+
+This class inherits from OnlineEmbeddingModuleBase and calls the DashScope MultiModalEmbedding API to convert text, image, or text-image inputs into a unified vector representation. A single multimodal request returns one vector, matching the output format of QwenEmbed for a single text input.
+
+Args:
+    embed_url (str, optional): DashScope API URL. Defaults to the official DashScope API address.
+    embed_model_name (str, optional): Multimodal embedding model name. Defaults to 'qwen_multimodal_embed_model_name' from config, or 'qwen2.5-vl-embedding' if unset.
+    api_key (str, optional): API key. Defaults to 'qwen_api_key' from configuration.
+    batch_size (int, optional): Batch size, defaults to 1.
+    return_trace (bool, optional): Whether to return trace information, defaults to False.
+    skip_auth (bool, optional): Whether to skip authentication, defaults to False.
+""")
+
+add_example('llms.onlinemodule.supplier.qwen.QwenMultimodalEmbed', """\
+>>> import lazyllm
+>>> embed = lazyllm.OnlineModule(
+...     model='qwen2.5-vl-embedding',
+...     source='qwen',
+...     type='cross_modal_embed',
+... )
+>>> vector = embed([
+...     {'text': '这是一只猫'},
+...     {'image': '/path/to/cat.jpg'},
+... ])
+""")
+
 add_chinese_doc('llms.onlinemodule.supplier.qwen.QwenChat', """\
 通义千问模型模块，继承自OnlineChatModuleBase和FileHandlerBase。
 
@@ -2988,6 +3029,44 @@ Args:
     api_key (str, optional): API key, defaults to lazyllm.config['siliconflow_api_key']
     batch_size (int, optional): Batch size for processing, defaults to 16
     **kw: Additional embedding module parameters
+""")
+
+add_chinese_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowMultimodalEmbed', """\
+SiliconFlow 多模态向量嵌入模块，继承自 OnlineEmbeddingModuleBase。
+
+提供基于 SiliconFlow 平台的多模态嵌入功能，使用 "Qwen/Qwen3-VL-Embedding-8B" 将文本、图像或图文组合转换为统一向量表示。单条输入返回一条向量；本地图片路径会自动转换为 base64 data URI。
+
+Args:
+    embed_url (str, optional): 嵌入 API 的 URL，默认为 "https://api.siliconflow.cn/v1/embeddings"。
+    embed_model_name (str, optional): 使用的多模态嵌入模型名称，默认为 "Qwen/Qwen3-VL-Embedding-8B"。
+    api_key (str, optional): API 密钥，默认从配置项 lazyllm.config['siliconflow_api_key'] 中读取。
+    batch_size (int, optional): 批处理大小，默认为 1。
+    **kw: 其他嵌入模块参数。
+""")
+
+add_english_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowMultimodalEmbed', """\
+SiliconFlow multimodal embedding module, inherits from OnlineEmbeddingModuleBase.
+
+Provides multimodal embedding functionality via the SiliconFlow platform, using "Qwen/Qwen3-VL-Embedding-8B" to convert text, image, or text-image inputs into a unified vector representation. A single input returns one vector; local image paths are converted to base64 data URIs automatically.
+
+Args:
+    embed_url (str, optional): Embedding API URL, defaults to "https://api.siliconflow.cn/v1/embeddings".
+    embed_model_name (str, optional): Name of the multimodal embedding model to use, defaults to "Qwen/Qwen3-VL-Embedding-8B".
+    api_key (str, optional): API key, defaults to lazyllm.config['siliconflow_api_key'].
+    batch_size (int, optional): Batch size, defaults to 1.
+    **kw: Additional embedding module parameters.
+""")
+
+add_example('llms.onlinemodule.supplier.siliconflow.SiliconFlowMultimodalEmbed', """\
+>>> import lazyllm
+>>> embed = lazyllm.OnlineModule(
+...     model='Qwen/Qwen3-VL-Embedding-8B',
+...     source='siliconflow',
+...     type='cross_modal_embed',
+... )
+>>> vector = embed([
+...     {'image': '/path/to/cat.jpg'},
+... ])
 """)
 
 add_chinese_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowRerank', """\

--- a/lazyllm/module/llms/onlinemodule/embedding.py
+++ b/lazyllm/module/llms/onlinemodule/embedding.py
@@ -6,8 +6,23 @@ from lazyllm.common.bind import _MetaBind
 from .base import OnlineEmbeddingModuleBase
 from .base.utils import select_source_with_default_key, resolve_online_params
 from .supplier.doubao import DoubaoEmbed, DoubaoMultimodalEmbed
+from .supplier.qwen import QwenMultimodalEmbed
+from .supplier.siliconflow import SiliconFlowMultimodalEmbed
 from .map_model_type import get_model_type
 from .dynamic_router import _DynamicSourceRouterMixin, dynamic_model_config_context
+
+
+def _is_qwen_multimodal_embed_model(model_name: Optional[str]) -> bool:
+    if not model_name:
+        return False
+    model_name = model_name.lower()
+    return (model_name.endswith('vl-embedding') or
+            'embedding-vision' in model_name or
+            model_name.startswith('multimodal-embedding'))
+
+
+def _is_siliconflow_multimodal_embed_model(model_name: Optional[str]) -> bool:
+    return bool(model_name and model_name.lower() == 'qwen/qwen3-vl-embedding-8b')
 
 
 def dynamic_embed_config(
@@ -36,6 +51,8 @@ class OnlineEmbeddingModule(_DynamicSourceRouterMixin, metaclass=__EmbedModuleMe
     @staticmethod
     def _resolve_type_name(type_name: Optional[str], embed_model_name: Optional[str]) -> str:
         if type_name is not None:
+            if type_name == LLMType.CROSS_MODAL_EMBED:
+                return 'embed'
             return type_name
         resolved = get_model_type(embed_model_name) if embed_model_name else 'embed'
         return resolved if resolved in ('embed', 'rerank') else 'embed'
@@ -45,6 +62,10 @@ class OnlineEmbeddingModule(_DynamicSourceRouterMixin, metaclass=__EmbedModuleMe
         if type_name == 'embed':
             if source == 'doubao' and embed_model_name and embed_model_name.startswith('doubao-embedding-vision'):
                 return DoubaoMultimodalEmbed(**params)
+            if source == 'qwen' and _is_qwen_multimodal_embed_model(embed_model_name):
+                return QwenMultimodalEmbed(**params)
+            if source == 'siliconflow' and _is_siliconflow_multimodal_embed_model(embed_model_name):
+                return SiliconFlowMultimodalEmbed(**params)
             if source == 'doubao':
                 return DoubaoEmbed(**params)
             return getattr(lazyllm.online.embed, source)(**params)

--- a/lazyllm/module/llms/onlinemodule/embedding.py
+++ b/lazyllm/module/llms/onlinemodule/embedding.py
@@ -16,9 +16,10 @@ def _is_qwen_multimodal_embed_model(model_name: Optional[str]) -> bool:
     if not model_name:
         return False
     model_name = model_name.lower()
-    return (model_name.endswith('vl-embedding') or
-            'embedding-vision' in model_name or
-            model_name.startswith('multimodal-embedding'))
+    return (model_name.endswith('vl-embedding')
+            or 'embedding-vision' in model_name
+            or model_name.startswith('multimodal-embedding')
+        )
 
 
 def _is_siliconflow_multimodal_embed_model(model_name: Optional[str]) -> bool:

--- a/lazyllm/module/llms/onlinemodule/map_model_type.py
+++ b/lazyllm/module/llms/onlinemodule/map_model_type.py
@@ -444,17 +444,18 @@ MODEL_MAPPING = {
     'deepseek-v4-pro': 'llm',
 
     # ===== SiliconFlow =====
+    'qwen/qwen3-vl-embedding-8b': 'cross_modal_embed',
     'qwen/qwen-image-edit': 'image_editing',
     'qwen/qwen-image-edit-2509': 'image_editing',
 }
 _TOKEN_MAP = {
+    'cross_modal_embed': ('cross_modal', 'multimodal-embedding', 'embedding-vision', 'vl-embedding'),
     'embed': ('embedding', 'embed'),
     'stt': ('whisper', 'paraformer', 'asr', 'stt', 'transcribe'),
     'tts': ('tts', 'cosyvoice', 'nova-tts'),
     'vlm': ('qwen-vl', 'vl', 'vision', 'caption', 'omni', 'vlm', 'seed'),
     'ocr': ('ocr',),
     'rerank': ('rerank',),
-    'cross_modal_embed': ('cross_modal', 'multimodal-embedding', 'embedding-vision'),
     'sd': ('dall', 'wan', 'sora', 'image', 'video', 't2i', 't2v'),
     'image_editing': ('image-edit', 'seededit', 'i2i', 'seedream-3', 'seedream-4'),
 }

--- a/lazyllm/module/llms/onlinemodule/supplier/qwen.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/qwen.py
@@ -355,6 +355,9 @@ class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
                  **kw):
         _ensure_dashscope_urls_initialized()
         kw.pop('type', None)
+        if batch_size != 1:
+            LOG.warning('QwenMultimodalEmbed does not support batch_size > 1; resetting batch_size to 1.')
+            batch_size = 1
         if embed_url and embed_url != _DASHSCOPE_DEFAULT_HTTP_URL:
             LOG.warning('QwenMultimodalEmbed ignores `embed_url`; use `set_dashscope_urls` instead.')
         embed_url = embed_url or _DASHSCOPE_DEFAULT_HTTP_URL
@@ -376,10 +379,7 @@ class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
             if len(input) == 0:
                 raise ValueError('Input list cannot be empty')
             if any(isinstance(item, list) for item in input):
-                LOG.warning('QwenMultimodalEmbed expects a 1D input list; using the first item.')
-                input = input[0]
-                if not isinstance(input, list) or len(input) == 0:
-                    raise ValueError('Input list cannot be empty')
+                raise ValueError('QwenMultimodalEmbed expects a 1D input list of dictionaries')
             if not all(isinstance(item, dict) for item in input):
                 raise ValueError('Input list must contain dictionaries')
             return input

--- a/lazyllm/module/llms/onlinemodule/supplier/qwen.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/qwen.py
@@ -375,6 +375,11 @@ class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
         if isinstance(input, list):
             if len(input) == 0:
                 raise ValueError('Input list cannot be empty')
+            if any(isinstance(item, list) for item in input):
+                LOG.warning('QwenMultimodalEmbed expects a 1D input list; using the first item.')
+                input = input[0]
+                if not isinstance(input, list) or len(input) == 0:
+                    raise ValueError('Input list cannot be empty')
             if not all(isinstance(item, dict) for item in input):
                 raise ValueError('Input list must contain dictionaries')
             return input

--- a/lazyllm/module/llms/onlinemodule/supplier/qwen.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/qwen.py
@@ -7,9 +7,11 @@ from urllib.parse import urljoin
 import lazyllm
 from lazyllm.components.utils.downloader.model_downloader import LLMType
 from ..base import (
-    OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineRerankModuleBase,
-    LazyLLMOnlineSTTModuleBase, LazyLLMOnlineText2ImageModuleBase, LazyLLMOnlineTTSModuleBase
+    OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineMultimodalEmbedModuleBase,
+    LazyLLMOnlineRerankModuleBase, LazyLLMOnlineSTTModuleBase, LazyLLMOnlineText2ImageModuleBase,
+    LazyLLMOnlineTTSModuleBase
 )
+from ..base.utils import resolve_online_params
 from ..fileHandler import FileHandlerBase
 from http import HTTPStatus
 from lazyllm.thirdparty import dashscope
@@ -339,6 +341,74 @@ class QwenEmbed(LazyLLMOnlineEmbedModuleBase):
             return embeddings[0].get('embedding', [])
         else:
             return [res.get('embedding', []) for res in embeddings]
+
+
+class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
+
+    def __init__(self,
+                 embed_url: Optional[str] = None,
+                 embed_model_name: Optional[str] = None,
+                 api_key: str = None,
+                 batch_size: int = 1,
+                 return_trace: bool = False,
+                 skip_auth: bool = False,
+                 **kw):
+        _ensure_dashscope_urls_initialized()
+        kw.pop('type', None)
+        if embed_url and embed_url != _DASHSCOPE_DEFAULT_HTTP_URL:
+            LOG.warning('QwenMultimodalEmbed ignores `embed_url`; use `set_dashscope_urls` instead.')
+        embed_url = embed_url or _DASHSCOPE_DEFAULT_HTTP_URL
+        embed_model_name = (embed_model_name or lazyllm.config['qwen_multimodal_embed_model_name']
+                            or 'qwen2.5-vl-embedding')
+        super().__init__(embed_url, api_key or self._default_api_key(), embed_model_name,
+                         skip_auth=skip_auth, return_trace=return_trace, batch_size=batch_size, **kw)
+
+    @staticmethod
+    def _get_response_value(response, key: str, default=None):
+        if isinstance(response, dict):
+            return response.get(key, default)
+        return getattr(response, key, default)
+
+    def _encapsulated_data(self, input: Union[List, str], **kwargs):
+        if isinstance(input, str):
+            return [{'text': input}]
+        if isinstance(input, list):
+            if len(input) == 0:
+                raise ValueError('Input list cannot be empty')
+            if not all(isinstance(item, dict) for item in input):
+                raise ValueError('Input list must contain dictionaries')
+            return input
+        raise ValueError('Input must be either a string or a list of dictionaries')
+
+    def forward(self, input: Union[List, str], url: str = None, model: str = None, **kwargs) -> List[float]:
+        model, _, url, kwargs = resolve_online_params(
+            model, None, url, kwargs,
+            model_aliases=('model_name', 'embed_model_name', 'embed_name'),
+            url_aliases=('base_url', 'embed_url'))
+        if url and url != self._embed_url:
+            LOG.warning('QwenMultimodalEmbed ignores runtime `url`; use `set_dashscope_urls` instead.')
+        call_params = {
+            'model': model or self._embed_model_name,
+            'input': self._encapsulated_data(input),
+            **kwargs
+        }
+        if self._api_key:
+            call_params['api_key'] = self._api_key
+        response = dashscope.MultiModalEmbedding.call(**call_params)
+        if self._get_response_value(response, 'status_code') != HTTPStatus.OK:
+            message = self._get_response_value(response, 'message', 'Unknown error')
+            raise RuntimeError(f'Qwen multimodal embedding failed: {message}')
+        return self._parse_response(response, input=input)
+
+    def _parse_response(self, response: Dict, input: Union[List, str]) -> List[float]:
+        output = self._get_response_value(response, 'output', {})
+        embeddings = self._get_response_value(output, 'embeddings', [])
+        if not embeddings:
+            raise ValueError('No embeddings found in response')
+        embedding = self._get_response_value(embeddings[0], 'embedding', [])
+        if not embedding:
+            raise ValueError('No embedding found in response')
+        return embedding
 
 
 class QwenRerank(LazyLLMOnlineRerankModuleBase):

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -55,11 +55,10 @@ class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
     MODEL_NAME = 'Qwen/Qwen3-VL-Embedding-8B'
 
     def __init__(self, embed_url: Optional[str] = None, embed_model_name: Optional[str] = None,
-                 api_key: str = None, batch_size: int = 1, dimensions: Optional[int] = None, **kw):
+                 api_key: str = None, batch_size: int = 1, **kw):
         kw.pop('type', None)
         embed_url = embed_url or 'https://api.siliconflow.cn/v1/embeddings'
         embed_model_name = embed_model_name or SiliconFlowMultimodalEmbed.MODEL_NAME
-        self._dimensions = dimensions
         super().__init__(embed_url, api_key or self._default_api_key(),
                          embed_model_name, batch_size=batch_size, **kw)
 
@@ -97,8 +96,6 @@ class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
             'input': input,
             'model': self._embed_model_name
         }
-        if self._dimensions is not None:
-            json_data['dimensions'] = self._dimensions
         if len(kwargs) > 0:
             json_data.update(kwargs)
         return json_data

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -57,6 +57,9 @@ class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
     def __init__(self, embed_url: Optional[str] = None, embed_model_name: Optional[str] = None,
                  api_key: str = None, batch_size: int = 1, **kw):
         kw.pop('type', None)
+        if batch_size != 1:
+            LOG.warning('SiliconFlowMultimodalEmbed does not support batch_size > 1; resetting batch_size to 1.')
+            batch_size = 1
         embed_url = embed_url or 'https://api.siliconflow.cn/v1/embeddings'
         embed_model_name = embed_model_name or SiliconFlowMultimodalEmbed.MODEL_NAME
         super().__init__(embed_url, api_key or self._default_api_key(),
@@ -87,10 +90,7 @@ class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
             if len(input) == 0:
                 raise ValueError('Input list cannot be empty')
             if any(isinstance(item, list) for item in input):
-                LOG.warning('SiliconFlowMultimodalEmbed expects a 1D input list; using the first item.')
-                input = input[0]
-                if not isinstance(input, list) or len(input) == 0:
-                    raise ValueError('Input list cannot be empty')
+                raise ValueError('SiliconFlowMultimodalEmbed expects a 1D input list')
             if not all(isinstance(item, (str, dict)) for item in input):
                 raise ValueError('Input list must contain strings or dictionaries')
         else:

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -1,13 +1,14 @@
+import os
 import requests
 from typing import Tuple, List, Dict, Union, Optional
 from urllib.parse import urljoin
 from lazyllm.components.utils.downloader.model_downloader import LLMType
 from ..base import (
-    OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineRerankModuleBase,
-    LazyLLMOnlineText2ImageModuleBase, LazyLLMOnlineTTSModuleBase
+    OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineMultimodalEmbedModuleBase,
+    LazyLLMOnlineRerankModuleBase, LazyLLMOnlineText2ImageModuleBase, LazyLLMOnlineTTSModuleBase
 )
 from lazyllm.components.formatter import encode_query_with_filepaths
-from lazyllm.components.utils.file_operate import bytes_to_file
+from lazyllm.components.utils.file_operate import bytes_to_file, _image_to_base64
 from ..fileHandler import FileHandlerBase
 from lazyllm import LOG
 
@@ -48,6 +49,68 @@ class SiliconFlowEmbed(LazyLLMOnlineEmbedModuleBase):
         embed_model_name = embed_model_name or 'BAAI/bge-large-zh-v1.5'
         super().__init__(embed_url, api_key or self._default_api_key(),
                          embed_model_name, batch_size=batch_size, **kw)
+
+
+class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
+    MODEL_NAME = 'Qwen/Qwen3-VL-Embedding-8B'
+
+    def __init__(self, embed_url: Optional[str] = None, embed_model_name: Optional[str] = None,
+                 api_key: str = None, batch_size: int = 1, dimensions: Optional[int] = None, **kw):
+        kw.pop('type', None)
+        embed_url = embed_url or 'https://api.siliconflow.cn/v1/embeddings'
+        embed_model_name = embed_model_name or SiliconFlowMultimodalEmbed.MODEL_NAME
+        self._dimensions = dimensions
+        super().__init__(embed_url, api_key or self._default_api_key(),
+                         embed_model_name, batch_size=batch_size, **kw)
+
+    @staticmethod
+    def _format_image(image: str) -> str:
+        if image.startswith(('http://', 'https://', 'data:')):
+            return image
+        if not os.path.exists(image):
+            return image
+        image_base64, mime = _image_to_base64(image)
+        if not image_base64 or not mime:
+            raise ValueError(f'Unsupported image file: {image}')
+        return f'data:{mime};base64,{image_base64}'
+
+    @classmethod
+    def _format_input_item(cls, item: Union[str, Dict]) -> Union[str, Dict]:
+        if isinstance(item, dict) and 'image' in item:
+            item = item.copy()
+            item['image'] = cls._format_image(item['image'])
+        return item
+
+    def _encapsulated_data(self, input: Union[List, str], **kwargs) -> Dict:
+        if isinstance(input, str):
+            input = [input]
+        elif isinstance(input, list):
+            if len(input) == 0:
+                raise ValueError('Input list cannot be empty')
+            if not all(isinstance(item, (str, dict)) for item in input):
+                raise ValueError('Input list must contain strings or dictionaries')
+        else:
+            raise ValueError('Input must be either a string or a list')
+        input = [self._format_input_item(item) for item in input]
+
+        json_data = {
+            'input': input,
+            'model': self._embed_model_name
+        }
+        if self._dimensions is not None:
+            json_data['dimensions'] = self._dimensions
+        if len(kwargs) > 0:
+            json_data.update(kwargs)
+        return json_data
+
+    def _parse_response(self, response: Dict, input: Union[List, str]) -> Union[List[List[float]], List[float]]:
+        data = response.get('data', [])
+        if not data:
+            raise ValueError('No data found in response')
+        embeddings = [res.get('embedding', []) for res in data]
+        if len(embeddings) == 1:
+            return embeddings[0]
+        return embeddings
 
 
 class SiliconFlowRerank(LazyLLMOnlineRerankModuleBase):

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -86,6 +86,11 @@ class SiliconFlowMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
         elif isinstance(input, list):
             if len(input) == 0:
                 raise ValueError('Input list cannot be empty')
+            if any(isinstance(item, list) for item in input):
+                LOG.warning('SiliconFlowMultimodalEmbed expects a 1D input list; using the first item.')
+                input = input[0]
+                if not isinstance(input, list) or len(input) == 0:
+                    raise ValueError('Input list cannot be empty')
             if not all(isinstance(item, (str, dict)) for item in input):
                 raise ValueError('Input list must contain strings or dictionaries')
         else:


### PR DESCRIPTION
报错原因：未支持qwen的multimodalembed
<img width="1091" height="802" alt="image" src="https://github.com/user-attachments/assets/0b71ddba-7030-40c9-a38d-9fdc4b25bdb6" />

解决方式：
增加QwenMultiModalEmbeded 和 SiliconflowMultiModalEmbeded

测试：
Qwen /////////使用qwen需要一个 `dashscope` 的依赖
<img width="1073" height="682" alt="image" src="https://github.com/user-attachments/assets/29ce0d25-d65c-4858-9c93-814edd090562" />

Siliconflow
<img width="990" height="648" alt="image" src="https://github.com/user-attachments/assets/40facc54-89c2-4820-9c41-eb9e3393e8b6" />
=============能力比较差，cos(猫与猫) < cos(猫与今天天气很不错)



Worklog:
https://ones.ainewera.com/wiki/#/team/JNwe8qUX/space/CJVRUCtB/page/3saUibTE