### PR TITLE
support url read for feishu

### DIFF
--- a/lazyllm/docs/tools/tool_fs.py
+++ b/lazyllm/docs/tools/tool_fs.py
@@ -815,6 +815,8 @@ _add_fs_chinese('FeishuFS', '''\
     app_id (str, optional): 企业自建应用的 App ID，用于换取 tenant_access_token 或刷新 user_access_token。
     app_secret (str, optional): 企业自建应用的 App Secret。
     space_id (str, optional): 若传入则会返回 FeishuWikiFS 实例，将指定知识库作为 FS。
+        传入真实 space_id（如 'wikcnKQ1k3pcuo5uSK4t8VN6kVf'）或传入 'dynamic'（运行时从
+        globals.config['feishu_wiki_space_id'] 或链接 get_node 响应中动态解析）。
     云盘上传：put_file 时若远程路径以 .md 结尾或传入 content_type='markdown'，会在目标目录创建 docx 并按 Markdown 解析写入（标题、列表、代码块等）；否则按二进制上传原文件。
     user_refresh_token (str, optional): OAuth2 refresh_token，用于以用户身份访问「我的空间」个人文件。
         - 传入真实 refresh_token：直接用于换取 user_access_token，每次刷新后内存中的 token 同步滚动。
@@ -873,6 +875,8 @@ Parameters:
     app_id (str, optional): App ID of the enterprise custom app, used to obtain tenant_access_token or refresh user_access_token.
     app_secret (str, optional): App Secret of the enterprise custom app.
     space_id (str, optional): When provided, returns a FeishuWikiFS instance targeting the given wiki space.
+        Pass a real space_id (e.g. 'wikcnKQ1k3pcuo5uSK4t8VN6kVf') or 'dynamic' to resolve the space
+        at runtime from globals.config['feishu_wiki_space_id'] or from the get_node response.
     Drive upload: when the remote path ends with .md or put_file(..., content_type='markdown'), a docx is created in the target folder and content is parsed as Markdown; otherwise the file is uploaded as binary.
     user_refresh_token (str, optional): OAuth2 refresh_token for accessing the user's personal drive ("My Space").
         - Pass a real refresh_token: used directly to obtain user_access_token; rolls forward in memory after each use.
@@ -933,7 +937,8 @@ How to configure:
        the token for persistence; pass it directly on subsequent runs to skip the OAuth step.
 ''')
 _add_fs_example('FeishuFS', '''\
->>> from lazyllm.tools.fs import FeishuFS
+>>> from lazyllm.tools.fs import FeishuFS, FS
+>>> import lazyllm
 >>> # tenant_access_token: access files shared with the app
 >>> fs = FeishuFS(app_id='cli_xxx', app_secret='xxx')
 >>> fs.ls('/')
@@ -948,37 +953,102 @@ _add_fs_example('FeishuFS', '''\
 >>> # use FeishuWikiFS implicitly by passing space_id (wiki space id)
 >>> wiki_fs = FeishuFS(app_id='cli_xxx', app_secret='xxx', space_id='wikcnKQ1k3pcuo5uSK4t8VN6kVf')
 >>> wiki_fs.ls('/')
+>>> # link-based read: pass space_id='dynamic', no space_id required for reading
+>>> wiki_dynamic = FeishuFS(app_id='cli_xxx', app_secret='xxx', space_id='dynamic')
+>>> content = wiki_dynamic.fetch_url('https://xxx.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb')
+>>> # FS convenience: bare feishu URL is auto-detected and routed to wiki
+>>> lazyllm.globals.config['feishu_wiki_space_id'] = 'wikcnKQ1k3pcuo5uSK4t8VN6kVf'  # for ls
+>>> text = FS.read_bytes('https://xxx.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb').decode()
+>>> text = FS.read_bytes('feishu:/~node/MCjOwGxwSimztPkO5X6cv8uxnwb').decode()
+>>> text = FS.read_bytes('feishu@dynamic:/~node/MCjOwGxwSimztPkO5X6cv8uxnwb').decode()
 ''')
 
 # FeishuWikiFS
 _add_fs_chinese('FeishuWikiFS', '''\
-飞书知识库文件系统：使用飞书开放平台 Wiki API，将指定知识库（space）映射为文件系统。目录对应 Wiki 目录/节点，文件对应文档或附件。支持 ls、info、open（读/写）、mkdir、rm_file、put_file；并支持文档块级文本编辑：get_document_id、get_doc_blocks、update_doc_block_text。
+飞书知识库文件系统：使用飞书开放平台 Wiki API，将指定知识库（space）映射为文件系统。目录对应 Wiki 目录/节点，文件对应文档或附件。支持 ls、info、open（读/写）、mkdir、rm_file、put_file、fetch_url；并支持文档块级文本编辑：get_document_id、get_doc_blocks、update_doc_block_text。
 
 使用方式:
     构造参数:
         base_url (str, optional): 飞书开放平台根地址，默认使用官方地址即可。
         app_id (str, optional): 企业自建应用的 App ID。
         app_secret (str, optional): 企业自建应用的 App Secret。
-        space_id (str): 知识空间 ID，例如 'wikcnKQ1k3pcuo5uSK4t8VN6kVf'。
+        space_id (str): 知识空间 ID（如 'wikcnKQ1k3pcuo5uSK4t8VN6kVf'），或传入 'dynamic' 以懒解析。
 
     1. 与 FeishuFS 共享同一套鉴权方式：推荐 app_id + app_secret，由 FS 自动获取 tenant_access_token。
-    2. 必须传入 space_id（知识空间 ID），例如 'wikcnKQ1k3pcuo5uSK4t8VN6kVf'。
+    2. space_id 解析优先级（每次需要时按序查找）：
+       a. 构造时传入的真实 space_id；
+       b. globals.config['feishu_wiki_space_id']（运行时设置）；
+       c. 调用 get_node 接口时从响应回填（仅读文档时可省略 space_id）。
+       ls/mkdir/copy/move 等树形操作必须能解析到有效 space_id，否则抛出 ValueError。
     3. 根路径 '/' 对应知识库根节点；路径为 Wiki 节点路径；open 会根据节点类型拉取文档纯文本或附件二进制；put_file 会新建 docx 并写入内容。当远程路径以 .md 结尾或 put_file(..., content_type='markdown') 时，会按 Markdown 解析并保持标题、列表、代码块、引用等格式；否则按纯文本追加段落。
+
+链接直读路径（只读，无需 space_id）:
+    支持以下路径前缀，直接通过飞书 token 或链接拉取内容，不需要标题路径或 space_id：
+    - ~node/<node_token>       wiki 节点 token，如 feishu:/~node/MCjOwG...
+    - ~link/<urlencoded_url>   飞书浏览器链接（URL 编码），如 feishu:/~link/https%3A%2F%2F...
+    - ~docx/<document_id>      docx 文档 id
+    - ~doc/<doc_token>         旧版 doc token
+    也可以直接传入裸 URL（feishu:/ 协议会自动识别 feishu.cn / larksuite.com 链接）。
+    写模式（open write / put_file）不支持 ~ 路径，会抛出 NotImplementedError。
 
 保持原格式（表格、标题等）:
     - 通过 open/raw_content 下载到的是纯文本，put_file 会新建文档并只追加段落，因此「下载-修改-上传」会丢失表格等格式。
     - 若要保留原格式，请使用块级编辑：先 get_doc_blocks(path) 获取文档块列表（含 block_id、block_type、plain_text），再对需要修改的文本块调用 update_doc_block_text(path, block_id, new_text)。仅修改目标文本块，表格等其它块不会被改动。
 ''')
 _add_fs_english('FeishuWikiFS', '''\
-Feishu Wiki FS: Feishu Open Platform Wiki API; maps a wiki space into a filesystem. Directories are wiki folders/nodes; files are documents or attachments. Supports ls, info, open (r/w), mkdir, rm_file, put_file, and block-level text edit: get_document_id, get_doc_blocks, update_doc_block_text.
+Feishu Wiki FS: Feishu Open Platform Wiki API; maps a wiki space into a filesystem. Directories are wiki folders/nodes; files are documents or attachments. Supports ls, info, open (r/w), mkdir, rm_file, put_file, fetch_url, and block-level text edit: get_document_id, get_doc_blocks, update_doc_block_text.
 
 Usage:
-    1. Shares the same auth model as FeishuFS; space_id (wiki space ID) is required.
-    2. '/' is the wiki root; paths are wiki node paths; open returns document plain text or file binary; put_file creates a new docx. When the remote path ends with .md or put_file(..., content_type='markdown'), content is parsed as Markdown and rendered as headings, lists, code blocks, quotes, etc.; otherwise appended as plain text paragraphs.
+    1. Shares the same auth model as FeishuFS; space_id is a wiki space ID or 'dynamic' for lazy resolution.
+    2. space_id resolution order (checked on each operation):
+       a. Real space_id passed to the constructor;
+       b. globals.config['feishu_wiki_space_id'] (set at runtime);
+       c. Backfilled from the get_node response (no space_id required for link-based reads).
+       Tree operations (ls/mkdir/copy/move) require a resolvable space_id; otherwise ValueError is raised.
+    3. '/' is the wiki root; paths are wiki node paths; open returns document plain text or file binary; put_file creates a new docx. When the remote path ends with .md or put_file(..., content_type='markdown'), content is parsed as Markdown and rendered as headings, lists, code blocks, quotes, etc.; otherwise appended as plain text paragraphs.
+
+Link-based read paths (read-only, no space_id required):
+    The following path prefixes bypass title-based resolution and fetch content directly by token:
+    - ~node/<node_token>       wiki node token, e.g. feishu:/~node/MCjOwG...
+    - ~link/<urlencoded_url>   URL-encoded Feishu browser link, e.g. feishu:/~link/https%3A%2F%2F...
+    - ~docx/<document_id>      docx document id
+    - ~doc/<doc_token>         legacy doc token
+    Bare Feishu URLs (feishu.cn / larksuite.com) are also accepted and routed automatically.
+    Write mode (open write / put_file) on ~ paths raises NotImplementedError.
 
 Preserving format (tables, headings, etc.):
     - open/raw_content returns plain text only; put_file creates a new doc and appends paragraphs, so download-modify-upload loses tables and other structure.
     - To preserve format, use block-level edit: get_doc_blocks(path) to list blocks (block_id, block_type, plain_text), then update_doc_block_text(path, block_id, new_text) for the blocks you need to change; other blocks (e.g. tables) are left unchanged.
+''')
+_add_fs_chinese('FeishuWikiFS.fetch_url', '''\
+通过飞书浏览器链接直接拉取文档内容（只读），无需 space_id 也无需标题路径。
+
+支持的链接格式：
+    - https://<host>/wiki/<node_token>   知识库节点链接
+    - https://<host>/docx/<document_id>  新版文档直链
+    - https://<host>/docs/<doc_token>    旧版文档直链
+host 支持 *.feishu.cn 和 *.larksuite.com，query 参数会被忽略。
+
+Args:
+    url (str): 飞书浏览器链接。
+
+Returns:
+    bytes: 文档纯文本内容（UTF-8 编码）；附件类型返回二进制。
+''')
+_add_fs_english('FeishuWikiFS.fetch_url', '''\
+Fetch document content directly from a Feishu browser URL (read-only), without requiring space_id or a title path.
+
+Supported URL formats:
+    - https://<host>/wiki/<node_token>   wiki node link
+    - https://<host>/docx/<document_id>  new-style docx direct link
+    - https://<host>/docs/<doc_token>    legacy doc direct link
+host supports *.feishu.cn and *.larksuite.com; query parameters are ignored.
+
+Args:
+    url (str): Feishu browser URL.
+
+Returns:
+    bytes: Document plain text content (UTF-8 encoded); binary for file attachments.
 ''')
 _add_fs_chinese('FeishuWikiFS.get_document_id', '''\
 返回 Wiki 文档节点对应的飞书 docx document_id（即 obj_token）。path 必须指向 doc 或 docx 类型节点，否则抛出 ValueError。

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -3,9 +3,12 @@ import re
 import threading
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
+from urllib.parse import quote
 from lazyllm import globals
 
 _PROTOCOL_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+\-.]*)(@[^:/]+)?:/(.*)$')
+_FEISHU_BARE_URL_RE = re.compile(r'^https?://[^/]*(?:feishu\.cn|larksuite\.com)/', re.IGNORECASE)
+_FEISHU_WIKI_PATH_PREFIXES = ('~link/', '~node/', '~docx/', '~doc/')
 
 
 def _lookup_fs_cls(protocol: str):
@@ -21,6 +24,15 @@ def _lookup_fs_cls(protocol: str):
     return cls
 
 
+def _feishu_needs_wiki(space_id: Optional[str], real_path: str) -> bool:
+    if space_id:
+        return True
+    norm = real_path.lstrip('/')
+    if any(norm.startswith(p) for p in _FEISHU_WIKI_PATH_PREFIXES):
+        return True
+    return bool((globals.config.get('feishu_wiki_space_id') or '').strip())
+
+
 class _FSRouter:
 
     def __init__(self) -> None:
@@ -28,16 +40,26 @@ class _FSRouter:
         self._lock = threading.Lock()
 
     def _parse(self, path: str):
+        if _FEISHU_BARE_URL_RE.match(path):
+            return 'feishu', 'dynamic', '/~link/' + quote(path, safe='')
         m = _PROTOCOL_RE.match(path)
         if not m:
             return 'file', None, path
         protocol = m.group(1).lower()
         at_id = m.group(2)
         rest = '/' + m.group(3)
-        return protocol, (at_id[1:] if at_id else None), rest
+        space_id = at_id[1:] if at_id else None
+        if protocol == 'feishu' and space_id is None:
+            norm = rest.lstrip('/')
+            if any(norm.startswith(p) for p in _FEISHU_WIKI_PATH_PREFIXES):
+                space_id = 'dynamic'
+        return protocol, space_id, rest
 
-    def _get_or_create_fs(self, protocol: str, space_id: Optional[str]) -> Any:
-        key = (protocol, space_id)
+    def _get_or_create_fs(self, protocol: str, space_id: Optional[str], real_path: str = '') -> Any:
+        effective_space = space_id
+        if protocol == 'feishu' and effective_space is None and _feishu_needs_wiki(None, real_path):
+            effective_space = 'dynamic'
+        key = (protocol, effective_space)
         if key not in self._instances:
             with self._lock:
                 if key not in self._instances:
@@ -45,8 +67,8 @@ class _FSRouter:
                     import inspect
                     init_params = inspect.signature(cls.__init__).parameters
                     kwargs: Dict[str, Any] = {'dynamic_auth': True}
-                    if space_id and 'space_id' in init_params:
-                        kwargs['space_id'] = space_id
+                    if effective_space and 'space_id' in init_params:
+                        kwargs['space_id'] = effective_space
                     self._instances[key] = cls(**kwargs)
         return self._instances[key]
 
@@ -56,7 +78,7 @@ class _FSRouter:
             import fsspec.implementations.local as _local_fs
             fs = _local_fs.LocalFileSystem()
             return getattr(fs, method)(real_path, *args, **kwargs)
-        fs = self._get_or_create_fs(protocol, space_id)
+        fs = self._get_or_create_fs(protocol, space_id, real_path)
         return getattr(fs, method)(real_path, *args, **kwargs)
 
     def open(self, path: str, mode: str = 'rb', **kwargs) -> Any:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -2,12 +2,12 @@
 import re
 import time
 from typing import Any, Dict, List, Optional, Tuple
-from urllib.parse import urlencode
+from urllib.parse import urlencode, unquote
 
 import requests
 
 
-from lazyllm import LOG, config
+from lazyllm import LOG, config, globals as lazyllm_globals
 from lazyllm.common import Credential
 from lazyllm.thirdparty import mistune
 
@@ -15,6 +15,13 @@ from ..base import LazyLLMFSBase, CloudFSBufferedFile
 
 config.add('feishu_app_id', str, None, 'FEISHU_APP_ID', description='Feishu App ID for tenant_access_token.')
 config.add('feishu_app_secret', str, None, 'FEISHU_APP_SECRET', description='Feishu App Secret for tenant_access_token.')
+lazyllm_globals.config.add(
+    'feishu_wiki_space_id', str, None, 'FEISHU_WIKI_SPACE_ID',
+    description='Default Feishu wiki space_id for tree ops (ls/mkdir) when not set in URI.',
+)
+
+_SPACE_ID_DYNAMIC = 'dynamic'
+_FEISHU_URL_RE = re.compile(r'/(wiki|docx|docs)/([A-Za-z0-9_-]+)', re.IGNORECASE)
 
 
 _API_BASE = 'https://open.feishu.cn/open-apis'
@@ -31,6 +38,22 @@ _DEFAULT_OAUTH_SCOPE = (
     'drive:drive drive:drive:readonly drive:drive.metadata:readonly '
     'wiki:wiki wiki:wiki:readonly wiki:node:retrieve docx:document'
 )
+
+
+def _parse_feishu_browser_url(url: str) -> Optional[Dict[str, str]]:
+    clean = url.split('?')[0].split('#')[0].rstrip('/')
+    m = _FEISHU_URL_RE.search(clean)
+    if not m:
+        return None
+    type_part = m.group(1).lower()
+    token = m.group(2)
+    if type_part == 'wiki':
+        return {'kind': 'wiki_node', 'token': token}
+    if type_part == 'docx':
+        return {'kind': 'docx', 'token': token}
+    if type_part == 'docs':
+        return {'kind': 'doc', 'token': token}
+    return None
 
 
 def _feishu_acquire_access_token(
@@ -528,8 +551,10 @@ class FeishuFS(FeishuFSBase):
                 asynchronous: bool = False, use_listings_cache: bool = False,
                 skip_instance_cache: bool = False, loop: Optional[Any] = None,
                 dynamic_auth: bool = False) -> LazyLLMFSBase:
-        if space_id is not None and str(space_id).strip():
-            return FeishuWikiFS(base_url=base_url, app_id=app_id, app_secret=app_secret, space_id=space_id,
+        sid = (space_id or '').strip() if space_id is not None else ''
+        if sid:
+            wiki_sid = '' if sid == _SPACE_ID_DYNAMIC else sid
+            return FeishuWikiFS(base_url=base_url, app_id=app_id, app_secret=app_secret, space_id=wiki_sid,
                                 user_refresh_token=user_refresh_token, oauth_port=oauth_port,
                                 oauth_scope=oauth_scope, asynchronous=asynchronous,
                                 use_listings_cache=use_listings_cache,
@@ -724,7 +749,7 @@ class FeishuWikiFS(FeishuFSBase):
     _fs_protocol_key = 'feishu'
 
     def _create_docx_node(self, title: str, parent_token: str = '') -> str:
-        url = f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes'
+        url = f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes'
         payload: Dict[str, Any] = {'obj_type': 'docx', 'node_type': 'origin', 'title': title}
         if parent_token:
             payload['parent_node_token'] = parent_token
@@ -745,12 +770,20 @@ class FeishuWikiFS(FeishuFSBase):
             } for chunk in chunks[i:i + 50]]
             self._post(url, json={'index': 0, 'children': children})
 
+    def _effective_space_id(self) -> str:
+        if self._space_id:
+            return self._space_id
+        return (lazyllm_globals.config['feishu_wiki_space_id'] or '').strip()
+
     def _require_space_id(self) -> None:
-        if not self._space_id:
-            raise ValueError('space_id is required for FeishuWikiFS')
+        if not self._effective_space_id():
+            raise ValueError(
+                "space_id is required for FeishuWikiFS: pass space_id='wikcn...' to the constructor, "
+                "set globals.config['feishu_wiki_space_id'], or use feishu@<space_id>:/ URI"
+            )
 
     def _list_nodes_raw(self, parent_token: str = '') -> List[Dict[str, Any]]:
-        url = f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes'
+        url = f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes'
         params: Dict[str, Any] = {'page_size': 50}
         if parent_token:
             params['parent_node_token'] = parent_token
@@ -766,6 +799,7 @@ class FeishuWikiFS(FeishuFSBase):
         return results
 
     def _resolve_path_to_token(self, path: str) -> str:
+        self._require_space_id()
         parts = [p for p in path.strip('/').split('/') if p]
         if not parts:
             return ''
@@ -806,7 +840,7 @@ class FeishuWikiFS(FeishuFSBase):
             payload['target_parent_token'] = parent_token
         if title:
             payload['title'] = title
-        self._post(f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes/{src_token}/copy', json=payload)
+        self._post(f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes/{src_token}/copy', json=payload)
 
     def move(self, path1: str, path2: str, recursive: bool = False, **kwargs) -> None:
         src_token = self._resolve_path_to_token(path1)
@@ -818,13 +852,57 @@ class FeishuWikiFS(FeishuFSBase):
         payload: Dict[str, Any] = {}
         if parent_token:
             payload['target_parent_token'] = parent_token
-        self._post(f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes/{src_token}/move', json=payload)
+        self._post(f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes/{src_token}/move', json=payload)
+
+    def _resolve_link_content(self, parsed: Dict[str, str]) -> bytes:
+        kind = parsed['kind']
+        token = parsed['token']
+        if kind == 'wiki_node':
+            node = self._get_node(token)
+            obj_type = node.get('obj_type')
+            obj_token = node.get('obj_token') or ''
+            if not obj_type or not obj_token:
+                return b''
+            if obj_type in {'doc', 'docx'}:
+                return self._download_doc_raw(obj_token, obj_type=obj_type)
+            if obj_type == 'file':
+                return self._download_file_raw(obj_token)
+            raise NotImplementedError(
+                f'Feishu wiki node obj_type {obj_type!r} is not yet supported for link-based fetch'
+            )
+        if kind == 'docx':
+            return self._download_doc_raw(token, obj_type='docx')
+        if kind == 'doc':
+            return self._download_doc_raw(token, obj_type='doc')
+        raise NotImplementedError(f'Unsupported link kind: {kind!r}')
+
+    def fetch_url(self, url: str) -> bytes:
+        parsed = _parse_feishu_browser_url(url)
+        if not parsed:
+            raise ValueError(f'Cannot parse Feishu browser URL: {url!r}')
+        return self._resolve_link_content(parsed)
 
     def _fetch_wiki_content(self, path: str) -> bytes:
-        token = self._resolve_path_to_token(path)
-        if not token:
+        norm = path.lstrip('/')
+        if norm.startswith('~link/'):
+            url = unquote(norm[len('~link/'):])
+            parsed = _parse_feishu_browser_url(url)
+            if not parsed:
+                raise ValueError(f'Cannot parse Feishu browser URL from path: {path!r}')
+            return self._resolve_link_content(parsed)
+        if norm.startswith('~node/'):
+            token = norm[len('~node/'):].split('/')[0]
+            return self._resolve_link_content({'kind': 'wiki_node', 'token': token})
+        if norm.startswith('~docx/'):
+            token = norm[len('~docx/'):].split('/')[0]
+            return self._download_doc_raw(token, obj_type='docx')
+        if norm.startswith('~doc/'):
+            token = norm[len('~doc/'):].split('/')[0]
+            return self._download_doc_raw(token, obj_type='doc')
+        node_token = self._resolve_path_to_token(path)
+        if not node_token:
             return b''
-        node = self._get_node(token)
+        node = self._get_node(node_token)
         obj_type = node.get('obj_type')
         obj_token = node.get('obj_token') or ''
         if not obj_type or not obj_token:
@@ -848,6 +926,9 @@ class FeishuWikiFS(FeishuFSBase):
         if 'r' in mode:
             return FeishuWikiFile(self, path, mode=mode, block_size=block_size or self.blocksize,
                                   autocommit=autocommit, cache_options=cache_options)
+        norm = path.lstrip('/')
+        if norm.startswith(('~link/', '~node/', '~docx/', '~doc/')):
+            raise NotImplementedError('FeishuWikiFS: write mode is not supported for link/node paths')
         return CloudFSBufferedFile(self, path, mode=mode, block_size=block_size or self.blocksize,
                                    autocommit=autocommit, cache_options=cache_options)
 
@@ -857,7 +938,7 @@ class FeishuWikiFS(FeishuFSBase):
             return
         title = parts[-1]
         parent_token = self._resolve_path_to_token('/' + '/'.join(parts[:-1])) if len(parts) > 1 else ''
-        url = f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes'
+        url = f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes'
         payload: Dict[str, Any] = {'title': title, 'obj_type': 'docx', 'node_type': 'origin'}
         if parent_token:
             payload['parent_node_token'] = parent_token
@@ -867,7 +948,7 @@ class FeishuWikiFS(FeishuFSBase):
         token = self._resolve_path_to_token(path)
         if not token:
             raise FileNotFoundError(path)
-        self._delete(f'{self._base_url}/wiki/v2/spaces/{self._space_id}/nodes/{token}')
+        self._delete(f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes/{token}')
 
     def rmdir(self, path: str) -> None:
         self.rm_file(path)
@@ -920,6 +1001,10 @@ class FeishuWikiFS(FeishuFSBase):
     def _get_node(self, token: str) -> Dict[str, Any]:
         data = self._get(f'{self._base_url}/wiki/v2/spaces/get_node', params={'token': token})
         node = data.get('data', {}).get('node') or data.get('data', {})
+        if node and not self._space_id:
+            sid = (node.get('space_id') or '').strip()
+            if sid:
+                self._space_id = sid
         return node or {}
 
     def get_document_id(self, path: str) -> str:


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

为飞书 FS 增加通过**浏览器链接**与 **node_token** 的**只读**内容拉取能力，并支持 **`space_id` 懒解析**（`space_id='dynamic'`、`globals.config['feishu_wiki_space_id']`、`get_node` 响应回填）。`FS` 路由器可识别裸 `https://*.feishu.cn/`、`*.larksuite.com/` 链接并归一化为 `feishu@dynamic:/~link/...`。

# 🎯 问题背景 / Problem Context
原先飞书 Wiki 只能通过知识库标题路径访问，且必须有明确的 `space_id`；用户从飞书复制的 wiki/docx/docs 链接无法在 FS 层直接使用。需要在保持云盘 `feishu:/...` 与标题路径 `feishu@wikcn...:/...` 行为不变的前提下，补充链接与懒解析能力。

# 🔍 相关 Issue / Related Issue
（无关联 Issue；需求来自内部讨论与 wiki 链接使用场景。）

# ✅ 变更类型 / Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [ ] Performance optimization

# 🧪 如何测试 / How Has This Been Tested?
单元测试

# ⚡ 更新后的用法示例 / Usage After Update
```
import lazyllm
from lazyllm.tools.fs import FS, FeishuFS
lazyllm.globals.config['feishu_wiki_space_id'] = 'wikcnYourSpace'
text = FS.read_bytes('https://tenant.feishu.cn/wiki/YourNodeToken').decode('utf-8')
wiki = FeishuFS(user_refresh_token='...', space_id='dynamic')
text = wiki.fetch_url('https://tenant.feishu.cn/wiki/YourNodeToken').decode('utf-8')
```

# 🔄 重构对比 / Refactor Comparison
Before
Wiki 仅支持标题路径；无可靠的链接直连；space_id 缺失时难以只做「按链接读内容」。

After
支持 ~link/、~node/、~docx/、~doc/ 与裸 HTTPS；feishu@dynamic 与 config / get_node 协同；~ 路径写操作首版拒绝（只读）。与 [PR #1138 页面](https://github.com/LazyAGI/LazyLLM/pull/1138) 中 bot 指出的共享实例 _space_id 回填线程风险，在「注意事项」中保留说明。

# ⚠️ 注意事项 / Additional Notes
_FSRouter 缓存的 Wiki 实例在 get_node 时可能回填 self._space_id，多线程、多空间并发时存在竞态与「粘住首个 space」的风险（见 review）。
get_document_id / get_doc_blocks / update_doc_block_text 仍未对接虚拟路径，按计划留待后续 PR。
sheet/bitable 等类型首版可能 NotImplementedError。
FS（dynamic_auth）与 FeishuFS(user_refresh_token=...) 鉴权路径不同，需按文档选择入口。

# 🧠 AI 参与情况 / AI Involvement

使用工具 / Tools Used： Cursor

说明： 需求分析、方案多轮迭代（space_id='dynamic' 替代 wiki_mode、globals.config.add、裸 URL 与 ~link/~node 协议）及明确首版不做链接路径上的块级/部分编辑均由人机协作定稿；实现与测试在 Cursor 中完成。

## 🤖 AI 生成过程 / AI Generation Process
### 初始 Prompt（概括）
评估飞书 FS 是否支持文档链接拉取；给出含自动 space_id、构造分流、globals.config 与 URI 的改造计划；确认裸 URL + ~link、首版类型范围；按反馈改为 space_id='dynamic' 与 globals.config，并删除计划中「链接打通块级编辑」部分。

### AI 初始输出质量

部分正确

### 人工干预要点
收窄范围：只读链接拉取，不包含 get_doc_blocks/update_doc_block_text 与虚拟路径打通。
命名与配置：wiki_mode → dynamic 语义；配置注册走 globals.config。

## AI vs Human 贡献（估算）
AI 生成代码：约 60–75%
人工修改：约 25–40%（协议定稿、范围裁剪、lint/测试与 review 响应）

## 🧩 可复用经验 / Reusable Patterns
先固定 URI 与「树操作 vs 直读」对 space_id 的要求，再动 Router 与缓存 key。
文档需区分 FS 的 dynamic token 与用户 OAuth 构造 FeishuFS 两条路径，避免误用。