### PR TITLE
embed lazy init

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -4011,6 +4011,41 @@ Args:
     description (Optional[str]): Description of the algorithm, defaults to None.
 """)
 
+add_chinese_doc('rag.parsing_service.server.DocumentProcessor.register_new_node_group', """
+向已注册的算法动态追加一个新的节点组（node group）。
+
+该方法会将节点组信息持久化到数据库，并将其 ID 追加到指定算法的 ``node_group_ids`` 列表中，
+使 Worker 在下次轮询时能够发现并加载该节点组。通常由 ``Document`` 模块在运行时动态绑定新的
+切分/转换策略时调用，一般无需手动调用。
+
+Args:
+    name (str): 节点组名称，作为唯一标识符。
+    config (Dict): 节点组配置，包含 ``transform``/``args``、``parent``、``ref``、``group_type`` 等字段。
+    algo_name (str): 目标算法的唯一标识，节点组 ID 将被追加到该算法的 ``node_group_ids`` 中。
+
+Returns:
+    str: 新创建或已存在的节点组 ID。
+""")
+
+add_english_doc('rag.parsing_service.server.DocumentProcessor.register_new_node_group', """
+Dynamically append a new node group to an already-registered algorithm.
+
+The node group is persisted to the database and its ID is appended to the target algorithm's
+``node_group_ids`` list so that workers can discover and load it on the next poll cycle.
+This is typically called by the ``Document`` module when a new chunking or transformation
+strategy is bound at runtime, and generally does not need to be called manually.
+
+Args:
+    name (str): Node group name used as a unique identifier.
+    config (Dict): Node group configuration containing fields such as ``transform``/``args``,
+        ``parent``, ``ref``, and ``group_type``.
+    algo_name (str): Unique identifier of the target algorithm whose ``node_group_ids``
+        list will receive the new node group ID.
+
+Returns:
+    str: The ID of the newly created or already-existing node group.
+""")
+
 add_chinese_doc('rag.parsing_service.server.DocumentProcessor.drop_algorithm', """
 从文档处理服务中移除指定算法， 该方法会自动从数据库中删除算法信息，后续无法使用该算法处理文档。
 
@@ -7364,6 +7399,41 @@ Args:
     filters (Optional[Dict[str, Union[str, int, List, Set]]]): Metadata filter conditions.
     embed_key (Optional[str]): Embedding key.
     **kwargs: Additional parameters.
+''')
+
+add_chinese_doc('rag.LazyLLMStoreBase.try_read_dims_from_schema', '''\
+尝试从已有的后端 schema 中读取 embedding 维度和数据类型信息。
+
+在调用 ``connect()`` 之前，通过检查后端已存在的 collection schema 来推断
+``embed_dims`` 和 ``embed_datatypes``，从而避免在初始化阶段调用 embedding 函数。
+基类默认返回空字典（不支持自省），子类在向量后端支持 schema 描述时可覆盖此方法。
+
+Args:
+    collections (List[str]): 需要检查的 collection 名称列表。
+
+Returns:
+    Tuple[Dict[str, int], Dict[str, DataType]]:
+        - 第一个元素为 embed key 到维度的映射（稀疏向量无维度，不包含在内）。
+        - 第二个元素为 embed key 到 ``DataType`` 的映射。
+''')
+
+add_english_doc('rag.LazyLLMStoreBase.try_read_dims_from_schema', '''\
+Try to read embedding dimensions and data types from an existing backend schema.
+
+Before ``connect()`` is called, this method inspects the backend's existing collection
+schemas to infer ``embed_dims`` and ``embed_datatypes``, avoiding the need to invoke
+embedding functions during initialisation. The base-class implementation returns empty
+dicts (no introspection supported); subclasses override this when the vector backend
+can describe collections before ``connect()``.
+
+Args:
+    collections (List[str]): List of collection names to inspect.
+
+Returns:
+    Tuple[Dict[str, int], Dict[str, DataType]]:
+        - First element: mapping from embed key to dimension
+          (sparse vectors have no fixed dimension and are omitted).
+        - Second element: mapping from embed key to ``DataType``.
 ''')
 
 add_chinese_doc('rag.doc_impl.DocImpl', '''\

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -1,14 +1,13 @@
 import os
 import hashlib
-import json
 import re
 from enum import Enum
 from pydantic import BaseModel
 from typing import Callable, Dict, List, Optional, Set, Union, Tuple, Any, Type
 from lazyllm import LOG, once_wrapper, config
 from lazyllm.module import LLMBase
-from .transform import (NodeTransform, SentenceSplitter,
-                        TransformArgs, TransformArgs as TArgs, _transmap, _normalize_for_sig)
+from .transform import (NodeTransform, SentenceSplitter, TransformArgs, TransformArgs as TArgs,
+                        _transmap, _normalize_for_sig, _calculate_signature)
 from .index_base import IndexBase
 from .store import (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP, LazyLLMStoreBase)
 from .store.store_base import DEFAULT_KB_ID
@@ -59,10 +58,9 @@ def _compute_node_group_signature(name: str, transform, parent_sig: str, ref_sig
         transform_sig = transform.signature()
     else:
         transform_sig = _elem_sig(transform)
-    payload = json.dumps(_normalize_for_sig(
+    return _calculate_signature(_normalize_for_sig(
         {'name': name, 'parent_sig': parent_sig, 'ref_sig': ref_sig, 'transform_sig': transform_sig,
          'group_type': group_type.name if isinstance(group_type, NodeGroupType) else str(group_type)}))
-    return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 class StorePlaceholder:
     pass

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -8,7 +8,7 @@ from typing import Callable, Dict, List, Optional, Set, Union, Tuple, Any, Type
 from lazyllm import LOG, once_wrapper, config
 from lazyllm.module import LLMBase
 from .transform import (NodeTransform, SentenceSplitter,
-                        TransformArgs, TransformArgs as TArgs, _transmap)
+                        TransformArgs, TransformArgs as TArgs, _transmap, _normalize_for_sig)
 from .index_base import IndexBase
 from .store import (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP, LazyLLMStoreBase)
 from .store.store_base import DEFAULT_KB_ID
@@ -59,13 +59,9 @@ def _compute_node_group_signature(name: str, transform, parent_sig: str, ref_sig
         transform_sig = transform.signature()
     else:
         transform_sig = _elem_sig(transform)
-    payload = json.dumps({
-        'name': name,
-        'parent_sig': parent_sig,
-        'ref_sig': ref_sig,
-        'transform_sig': transform_sig,
-        'group_type': group_type.name if isinstance(group_type, NodeGroupType) else str(group_type),
-    }, sort_keys=True)
+    payload = json.dumps(_normalize_for_sig(
+        {'name': name, 'parent_sig': parent_sig, 'ref_sig': ref_sig, 'transform_sig': transform_sig,
+         'group_type': group_type.name if isinstance(group_type, NodeGroupType) else str(group_type)}))
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 class StorePlaceholder:
@@ -341,7 +337,7 @@ class DocImpl:
                     transform=transform, parent=parent, trans_node=trans_node,
                     num_workers=num_workers, display_name=display_name,
                     group_type=group_type, ref=ref, **kwargs,
-                ))
+                ), algo_name=self._algo_name)
                 # Also update local node_groups so in-process callers see the new group.
                 DocImpl._create_node_group_impl(self, 'node_groups', name=name, transform=transform, parent=parent,
                                                 trans_node=trans_node, num_workers=num_workers,

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -214,8 +214,10 @@ class DocImpl:
                 raise TypeError(
                     f'processor must be a DocumentProcessor instance, got {type(self._processor).__name__!r}'
                 )
+            policy = config['algo_register_policy'].strip().lower()
             self._processor.register_algorithm(self._algo_name, self._store, self._reader, self.node_groups,
-                                               self._schema_extractor, self._display_name, self._description)
+                                               self._schema_extractor, self._display_name, self._description,
+                                               policy=policy)
         else:
             self._processor = _Processor(self._store, self._build_schema_extractors_dict())
 

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -15,9 +15,8 @@ from .store.store_base import DEFAULT_KB_ID
 from .store.document_store import _DocumentStore
 from .doc_node import DocNode
 from .data_loaders import DirectoryReader
-from .utils import RAG_DEFAULT_GROUP_NAME, gen_docid, is_sparse, _get_default_db_config
+from .utils import RAG_DEFAULT_GROUP_NAME, gen_docid, _get_default_db_config
 from .global_metadata import GlobalMetadataDesc, RAG_DOC_ID, RAG_KB_ID
-from .data_type import DataType
 from .parsing_service import _Processor, DocumentProcessor
 from .embed_wrapper import _EmbedWrapper
 from .doc_to_db import SchemaExtractor
@@ -186,19 +185,11 @@ class DocImpl:
         if store is None and self._processor is not None:
             store = getattr(self._processor, '_store_conf', None)
         self._store = store or {'type': 'map'}
-        embed_dims, embed_datatypes = {}, {}
-        for k, e in self.embed.items():
-            embedding = e('a')
-            if is_sparse(embedding):
-                embed_datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
-            else:
-                embed_dims[k] = len(embedding)
-                embed_datatypes[k] = DataType.FLOAT_VECTOR
-
+        # embed dims/datatypes are resolved in _DocumentStore._lazy_init()
         self._store.pop('metadata_store', None)
         self._store = _DocumentStore(store=self._store,
                                      group_embed_keys=self._activated_embeddings, embed=self.embed,
-                                     embed_dims=embed_dims, embed_datatypes=embed_datatypes,
+                                     embed_dims={}, embed_datatypes={},
                                      global_metadata_desc=self._global_metadata_desc)
         self._store.activate_group(self._activated_groups)
 

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -422,52 +422,63 @@ class DocumentProcessor(ModuleBase):
                 LOG.error(f'[DocumentProcessor] Failed to register algorithm: {e}, {traceback.format_exc()}')
                 raise
 
+        def _upsert_single_node_group(self, sess, ng_name: str, sig: str, cfg: Dict, policy: str) -> str:
+            '''Upsert one node group row; return its id. Raises on signature conflict unless policy==force.'''
+            NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
+            existing = sess.query(NodeGroupInfo).filter(NodeGroupInfo.name == ng_name).first()
+            if existing:
+                if existing.signature != sig:
+                    if policy == 'force':
+                        LOG.warning(
+                            f'[DocumentProcessor] force policy: overwriting node group {ng_name!r} '
+                            f'(old_sig={existing.signature}, new_sig={sig})'
+                        )
+                        existing.signature = sig
+                        existing.info_pickle = dump_obj(cfg)
+                        existing.updated_at = datetime.now()
+                    else:
+                        raise ValueError(
+                            f'Node group {ng_name!r} already registered with different signature '
+                            f'(existing={existing.signature}, new={sig}). '
+                            'Use a different name or version.'
+                        )
+                else:
+                    LOG.info(f'[DocumentProcessor] Node group {ng_name!r} already exists, reusing id={existing.id}')
+                return existing.id
+            ng_id = str(uuid4())
+            sess.add(NodeGroupInfo(
+                id=ng_id, name=ng_name, signature=sig,
+                info_pickle=dump_obj(cfg), created_at=datetime.now(), updated_at=datetime.now(),
+            ))
+            LOG.info(f'[DocumentProcessor] Node group {ng_name!r} registered with id={ng_id}')
+            return ng_id
+
         def _upsert_node_groups(self, node_groups: Dict[str, Dict], session=None) -> List[str]:
             from ..doc_impl import _compute_node_group_signature, NodeGroupType
-            NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
+            from .impl import _NodeGroupDependencyGraph
+            from ..store import LAZY_ROOT_NAME
             policy = lazyllm.config['algo_register_policy'].strip().lower()
             reader_sig = self._reader.signature() if self._reader is not None else ''
-            # Build signatures in topological order (parent before child)
+            # Build signatures in true topological order (parent before child)
             name_to_id: Dict[str, str] = {}
             name_to_sig: Dict[str, str] = {}
-            ordered_names = list(node_groups.keys())
+            ordered_names = _NodeGroupDependencyGraph(
+                node_groups, list(node_groups.keys())
+            ).topological_order
 
             def _upsert_in_session(sess):
                 for ng_name in ordered_names:
                     cfg = node_groups[ng_name]
                     parent = cfg.get('parent', 'root')
                     ref = cfg.get('ref')
-                    parent_sig = name_to_sig.get(parent, reader_sig)
+                    parent_sig = '' if not parent or parent == LAZY_ROOT_NAME \
+                        else name_to_sig.get(parent, reader_sig)
                     ref_sig = name_to_sig.get(ref, '') if ref else ''
                     transform = cfg.get('transform') or cfg.get('args')
                     group_type = cfg.get('group_type', NodeGroupType.CHUNK)
                     sig = _compute_node_group_signature(ng_name, transform, parent_sig, ref_sig, group_type)
                     name_to_sig[ng_name] = sig
-                    existing = sess.query(NodeGroupInfo).filter(NodeGroupInfo.name == ng_name).first()
-                    if existing:
-                        if existing.signature != sig:
-                            if policy == 'force':
-                                LOG.warning(
-                                    f'[DocumentProcessor] force policy: overwriting node group {ng_name!r} '
-                                    f'(old_sig={existing.signature}, new_sig={sig})'
-                                )
-                                existing.signature = sig
-                                existing.info_pickle = dump_obj(cfg)
-                                existing.updated_at = datetime.now()
-                            else:
-                                raise ValueError(
-                                    f'Node group {ng_name!r} already registered with different signature '
-                                    f'(existing={existing.signature}, new={sig}). '
-                                    'Use a different name or version.'
-                                )
-                        name_to_id[ng_name] = existing.id
-                    else:
-                        ng_id = str(uuid4())  # random id for new node group
-                        sess.add(NodeGroupInfo(
-                            id=ng_id, name=ng_name, signature=sig,
-                            info_pickle=dump_obj(cfg), created_at=datetime.now(), updated_at=datetime.now(),
-                        ))
-                        name_to_id[ng_name] = ng_id
+                    name_to_id[ng_name] = self._upsert_single_node_group(sess, ng_name, sig, cfg, policy)
 
             if session is not None:
                 _upsert_in_session(session)
@@ -476,32 +487,29 @@ class DocumentProcessor(ModuleBase):
                     _upsert_in_session(sess)
             return [name_to_id[n] for n in ordered_names]
 
-        def register_new_node_group(self, name: str, config: Dict, session=None) -> str:
+        def register_new_node_group(self, name: str, config: Dict, algo_name: Optional[str] = None,
+                                    session=None) -> str:
             self._lazy_init()
             LOG.info(f'[DocumentProcessor] Register new node group: name={name}')
             try:
                 from ..doc_impl import _compute_node_group_signature, NodeGroupType
-                NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
+                policy = lazyllm.config['algo_register_policy'].strip().lower()
                 transform = config.get('transform') or config.get('args')
                 group_type = config.get('group_type', NodeGroupType.CHUNK)
                 sig = _compute_node_group_signature(name, transform, '', '', group_type)
 
                 def _do_register(sess):
-                    existing = sess.query(NodeGroupInfo).filter(NodeGroupInfo.name == name).first()
-                    if existing:
-                        if existing.signature != sig:
-                            raise ValueError(
-                                f'Node group {name!r} already registered with different signature '
-                                f'(existing={existing.signature}, new={sig}).'
-                            )
-                        LOG.info(f'[DocumentProcessor] Node group {name!r} already exists, reusing id={existing.id}')
-                        return existing.id
-                    ng_id = str(uuid4())  # random id for new node group
-                    sess.add(NodeGroupInfo(
-                        id=ng_id, name=name, signature=sig,
-                        info_pickle=dump_obj(config), created_at=datetime.now(), updated_at=datetime.now(),
-                    ))
-                    LOG.info(f'[DocumentProcessor] Node group {name!r} registered with id={ng_id}')
+                    ng_id = self._upsert_single_node_group(sess, name, sig, config, policy)
+                    # Append the id to the caller's algorithm node_group_ids so workers can discover it.
+                    if algo_name:
+                        AlgoInfo = self._db_manager.get_table_orm_class('lazyllm_algorithm')
+                        algo = sess.query(AlgoInfo).filter(AlgoInfo.id == algo_name).first()
+                        if algo:
+                            ids = json.loads(algo.node_group_ids or '[]')
+                            if ng_id not in ids:
+                                ids.append(ng_id)
+                                algo.node_group_ids = json.dumps(ids)
+                                algo.updated_at = datetime.now()
                     return ng_id
 
                 if session is not None:
@@ -1176,6 +1184,9 @@ class DocumentProcessor(ModuleBase):
         assert isinstance(reader, DirectoryReader), 'Only DirectoryReader can be registered to processor'
         self._dispatch('register_algorithm', name, store, reader, node_groups, schema_extractor,
                        display_name, description, **kwargs)
+
+    def register_new_node_group(self, name: str, config: Dict, algo_name: Optional[str] = None) -> str:
+        return self._dispatch('register_new_node_group', name, config, algo_name)
 
     def drop_algorithm(self, name: str) -> None:
         return self._dispatch('drop_algorithm', name)

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -348,10 +348,9 @@ class DocumentProcessor(ModuleBase):
                         )
             self._schema_extractors[ext_name] = schema_extractor
 
-        def _validate_reader(self, reader):
+        def _validate_reader(self, reader, policy: str = 'none'):
             if reader is None:
                 return
-            policy = lazyllm.config['algo_register_policy'].strip().lower()
             incoming_sig = reader.signature()
 
             if self._reader is None:
@@ -365,6 +364,7 @@ class DocumentProcessor(ModuleBase):
                 )
                 self._reader = reader
             elif policy == 'update':
+                # mirror inner changes, cannot change reader signature
                 if self._reader.signature() != incoming_sig:
                     raise ValueError(
                         f'[DocumentProcessor] update policy: reader signature mismatch '
@@ -381,17 +381,18 @@ class DocumentProcessor(ModuleBase):
 
         def register_algorithm(self, name: str, store: _DocumentStore, reader: DirectoryReader,
                                node_groups: Dict[str, Dict], schema_extractor: Optional[SchemaExtractor] = None,
-                               display_name: Optional[str] = None, description: Optional[str] = None):
+                               display_name: Optional[str] = None, description: Optional[str] = None,
+                               policy: str = 'none'):
             # NOTE: name is the algorithm id, display_name is the algorithm display name
             self._lazy_init()
             LOG.info(f'[DocumentProcessor] Register algorithm: name={name}, display_name={display_name}')
             self._register_schema_extractor(name, schema_extractor)
-            self._validate_reader(reader)
+            self._validate_reader(reader, policy)
             try:
                 # Upsert node groups and algorithm in a single transaction to ensure atomicity.
                 info_pickle = dump_obj({'reader': reader, 'store': store})
                 with self._db_manager.get_session() as session:
-                    node_group_ids = self._upsert_node_groups(node_groups, session=session)
+                    node_group_ids = self._upsert_node_groups(node_groups, policy=policy, session=session)
                     ng_ids_json = json.dumps(node_group_ids)
                     AlgoInfo = self._db_manager.get_table_orm_class('lazyllm_algorithm')
                     existing = session.query(AlgoInfo).filter(AlgoInfo.id == name).first()
@@ -444,13 +445,13 @@ class DocumentProcessor(ModuleBase):
             LOG.info(f'[DocumentProcessor] Node group {ng_name!r} registered with id={ng_id}')
             return ng_id
 
-        def _upsert_node_groups(self, node_groups: Dict[str, Dict], session=None) -> List[str]:
+        def _upsert_node_groups(self, node_groups: Dict[str, Dict], policy: str = 'none', session=None) -> List[str]:
             # TODO(wangzhohng): resolve circular import and moving these imports to the top of the file
             from ..doc_impl import _compute_node_group_signature, NodeGroupType
             from .impl import _NodeGroupDependencyGraph
-            from ..store import LAZY_ROOT_NAME
+            from ..store import LAZY_ROOT_NAME, LAZY_IMAGE_GROUP
 
-            policy = lazyllm.config['algo_register_policy'].strip().lower()
+            _BUILTIN_GROUPS = {LAZY_ROOT_NAME, LAZY_IMAGE_GROUP}
             reader_sig = self._reader.signature() if self._reader is not None else ''
             # Build signatures in true topological order (parent before child)
             name_to_id: Dict[str, str] = {}
@@ -468,7 +469,10 @@ class DocumentProcessor(ModuleBase):
                     group_type = cfg.get('group_type', NodeGroupType.CHUNK)
                     sig = _compute_node_group_signature(ng_name, transform, parent_sig, ref_sig, group_type)
                     name_to_sig[ng_name] = sig
-                    name_to_id[ng_name] = self._upsert_single_node_group(sess, ng_name, sig, cfg, policy)
+                    # Built-in groups (lazyllm_root, image) may have signature drift across versions;
+                    # always upsert them without signature validation.
+                    effective_policy = 'force' if ng_name in _BUILTIN_GROUPS else policy
+                    name_to_id[ng_name] = self._upsert_single_node_group(sess, ng_name, sig, cfg, effective_policy)
 
             if session is not None:
                 _upsert_in_session(session)

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -33,6 +33,7 @@ from ..utils import BaseResponse, ensure_call_endpoint, _get_default_db_config, 
 from ..doc_to_db import SchemaExtractor
 from ...sql import SqlManager
 
+
 lazyllm.config.add(
     'algo_register_policy', str, '', 'ALGO_REGISTER_POLICY',
     description=(
@@ -429,50 +430,39 @@ class DocumentProcessor(ModuleBase):
             if existing:
                 if existing.signature != sig:
                     if policy == 'force':
-                        LOG.warning(
-                            f'[DocumentProcessor] force policy: overwriting node group {ng_name!r} '
-                            f'(old_sig={existing.signature}, new_sig={sig})'
-                        )
-                        existing.signature = sig
-                        existing.info_pickle = dump_obj(cfg)
+                        LOG.warning(f'[DocumentProcessor] force policy: overwriting node group {ng_name!r} '
+                                    f'(old_sig={existing.signature}, new_sig={sig})')
+                        existing.signature, existing.info_pickle = sig, dump_obj(cfg)
                         existing.updated_at = datetime.now()
                     else:
-                        raise ValueError(
-                            f'Node group {ng_name!r} already registered with different signature '
-                            f'(existing={existing.signature}, new={sig}). '
-                            'Use a different name or version.'
-                        )
-                else:
-                    LOG.info(f'[DocumentProcessor] Node group {ng_name!r} already exists, reusing id={existing.id}')
+                        raise ValueError(f'Node group {ng_name!r} already registered with different signature '
+                                         f'(existing={existing.signature}, new={sig}). Use a different name or version.')
                 return existing.id
             ng_id = str(uuid4())
-            sess.add(NodeGroupInfo(
-                id=ng_id, name=ng_name, signature=sig,
-                info_pickle=dump_obj(cfg), created_at=datetime.now(), updated_at=datetime.now(),
-            ))
+            sess.add(NodeGroupInfo(id=ng_id, name=ng_name, signature=sig, info_pickle=dump_obj(cfg),
+                                   created_at=datetime.now(), updated_at=datetime.now()))
             LOG.info(f'[DocumentProcessor] Node group {ng_name!r} registered with id={ng_id}')
             return ng_id
 
         def _upsert_node_groups(self, node_groups: Dict[str, Dict], session=None) -> List[str]:
+            # TODO(wangzhohng): resolve circular import and moving these imports to the top of the file
             from ..doc_impl import _compute_node_group_signature, NodeGroupType
             from .impl import _NodeGroupDependencyGraph
             from ..store import LAZY_ROOT_NAME
+
             policy = lazyllm.config['algo_register_policy'].strip().lower()
             reader_sig = self._reader.signature() if self._reader is not None else ''
             # Build signatures in true topological order (parent before child)
             name_to_id: Dict[str, str] = {}
             name_to_sig: Dict[str, str] = {}
-            ordered_names = _NodeGroupDependencyGraph(
-                node_groups, list(node_groups.keys())
-            ).topological_order
+            ordered_names = _NodeGroupDependencyGraph(node_groups, list(node_groups.keys())).topological_order
 
             def _upsert_in_session(sess):
                 for ng_name in ordered_names:
                     cfg = node_groups[ng_name]
                     parent = cfg.get('parent', 'root')
                     ref = cfg.get('ref')
-                    parent_sig = '' if not parent or parent == LAZY_ROOT_NAME \
-                        else name_to_sig.get(parent, reader_sig)
+                    parent_sig = '' if not parent or parent == LAZY_ROOT_NAME else name_to_sig.get(parent, reader_sig)
                     ref_sig = name_to_sig.get(ref, '') if ref else ''
                     transform = cfg.get('transform') or cfg.get('args')
                     group_type = cfg.get('group_type', NodeGroupType.CHUNK)
@@ -487,8 +477,7 @@ class DocumentProcessor(ModuleBase):
                     _upsert_in_session(sess)
             return [name_to_id[n] for n in ordered_names]
 
-        def register_new_node_group(self, name: str, config: Dict, algo_name: Optional[str] = None,
-                                    session=None) -> str:
+        def register_new_node_group(self, name: str, config: Dict, algo_name: str, session=None) -> str:
             self._lazy_init()
             LOG.info(f'[DocumentProcessor] Register new node group: name={name}')
             try:
@@ -501,15 +490,14 @@ class DocumentProcessor(ModuleBase):
                 def _do_register(sess):
                     ng_id = self._upsert_single_node_group(sess, name, sig, config, policy)
                     # Append the id to the caller's algorithm node_group_ids so workers can discover it.
-                    if algo_name:
-                        AlgoInfo = self._db_manager.get_table_orm_class('lazyllm_algorithm')
-                        algo = sess.query(AlgoInfo).filter(AlgoInfo.id == algo_name).first()
-                        if algo:
-                            ids = json.loads(algo.node_group_ids or '[]')
-                            if ng_id not in ids:
-                                ids.append(ng_id)
-                                algo.node_group_ids = json.dumps(ids)
-                                algo.updated_at = datetime.now()
+                    AlgoInfo = self._db_manager.get_table_orm_class('lazyllm_algorithm')
+                    algo = sess.query(AlgoInfo).filter(AlgoInfo.id == algo_name).first()
+                    if not algo: raise ValueError(f'Algorithm {algo_name} not found')
+                    ids = json.loads(algo.node_group_ids or '[]')
+                    if ng_id not in ids:
+                        ids.append(ng_id)
+                        algo.node_group_ids = json.dumps(ids)
+                        algo.updated_at = datetime.now()
                     return ng_id
 
                 if session is not None:
@@ -1185,7 +1173,7 @@ class DocumentProcessor(ModuleBase):
         self._dispatch('register_algorithm', name, store, reader, node_groups, schema_extractor,
                        display_name, description, **kwargs)
 
-    def register_new_node_group(self, name: str, config: Dict, algo_name: Optional[str] = None) -> str:
+    def register_new_node_group(self, name: str, config: Dict, algo_name: str) -> str:
         return self._dispatch('register_new_node_group', name, config, algo_name)
 
     def drop_algorithm(self, name: str) -> None:

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -141,15 +141,16 @@ class _DocumentStore(object):
         dims, datatypes = self._impl.try_read_dims_from_schema(collections)
         if dims or datatypes:
             LOG.info('[_DocumentStore] Inferred embed dims from existing store schema')
-            return dims, datatypes
-        dims, datatypes = {}, {}
-        for k, e in (self._embed or {}).items():
-            embedding = e('a')
-            if is_sparse(embedding):
-                datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
-            else:
-                dims[k] = len(embedding)
-                datatypes[k] = DataType.FLOAT_VECTOR
+        missing_keys = [k for k in (self._embed or {}) if k not in datatypes]
+        if missing_keys:
+            LOG.info(f'[_DocumentStore] Resolving embed dims by calling embed functions for keys: {missing_keys}')
+            for k in missing_keys:
+                embedding = self._embed[k]('a')
+                if is_sparse(embedding):
+                    datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
+                else:
+                    dims[k] = len(embedding)
+                    datatypes[k] = DataType.FLOAT_VECTOR
         return dims, datatypes
 
     @once_wrapper(reset_on_pickle=True)

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -12,7 +12,7 @@ from .store_base import (LazyLLMStoreBase, StoreCapability, SegmentType, Segment
                          BUILDIN_GLOBAL_META_DESC, DEFAULT_KB_ID)
 from .hybrid import HybridStore, MapStore
 from ..default_index import DefaultIndex
-from ..utils import parallel_do_embedding
+from ..utils import parallel_do_embedding, is_sparse
 
 from ..doc_node import DocNode, QADocNode, ImageDocNode, JsonDocNode, RichDocNode
 from ..index_base import IndexBase
@@ -124,8 +124,39 @@ class _DocumentStore(object):
         # should not reach here
         raise RuntimeError('Unexpected store creation state')
 
+    def _embed_specs_need_resolution(self) -> bool:
+        if not self._embed:
+            return False
+        dims = self._embed_dims or {}
+        dtypes = self._embed_datatypes or {}
+        for k in self._embed:
+            if k not in dtypes:
+                return True
+            if dtypes[k] != DataType.SPARSE_FLOAT_VECTOR and k not in dims:
+                return True
+        return False
+
+    def _resolve_embed_dims(self):
+        collections = [self._gen_collection_name(group) for group in self.activated_groups()]
+        dims, datatypes = self._impl.try_read_dims_from_schema(collections)
+        if dims or datatypes:
+            LOG.info('[_DocumentStore] Inferred embed dims from existing store schema')
+            return dims, datatypes
+        dims, datatypes = {}, {}
+        for k, e in (self._embed or {}).items():
+            embedding = e('a')
+            if is_sparse(embedding):
+                datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
+            else:
+                dims[k] = len(embedding)
+                datatypes[k] = DataType.FLOAT_VECTOR
+        return dims, datatypes
+
     @once_wrapper(reset_on_pickle=True)
     def _lazy_init(self):
+        if self._embed_specs_need_resolution():
+            self._embed_dims, self._embed_datatypes = self._resolve_embed_dims()
+
         if self._impl.capability == StoreCapability.VECTOR or self._impl.capability == StoreCapability.ALL:
             self._impl.connect(
                 embed_dims=self._embed_dims, embed_datatypes=self._embed_datatypes,

--- a/lazyllm/tools/rag/store/hybrid/hybrid_store.py
+++ b/lazyllm/tools/rag/store/hybrid/hybrid_store.py
@@ -25,6 +25,10 @@ class HybridStore(LazyLLMStoreBase):
         self.vector_store.connect(*args, **kwargs)
 
     @override
+    def try_read_dims_from_schema(self, collections: List[str]):
+        return self.vector_store.try_read_dims_from_schema(collections)
+
+    @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:
         segments = [{k: v for k, v in segment.items() if k != 'embedding'} for segment in data]
         return self.segment_store.upsert(collection_name=collection_name, data=segments) and \

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -2,7 +2,7 @@ import re
 
 from abc import ABC, abstractmethod
 from enum import IntFlag, auto
-from typing import Optional, List, Union, Set, Dict, Any
+from typing import Optional, List, Union, Set, Dict, Any, Tuple
 from lazyllm.common import LazyLLMRegisterMetaABCClass
 from pydantic import BaseModel, Field
 
@@ -102,3 +102,11 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
                filters: Optional[Dict[str, Union[str, int, List, Set]]] = None,
                embed_key: Optional[str] = None, **kwargs) -> List[dict]:
         raise NotImplementedError
+
+    def try_read_dims_from_schema(self, collections: List[str]) -> Tuple[Dict[str, int], Dict[str, DataType]]:
+        '''Try to read embed_dims and embed_datatypes from existing backend schema.
+
+        Default: no introspection supported. Subclasses override when the vector backend
+        can describe collections before connect().
+        '''
+        return {}, {}

--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -7,7 +7,7 @@ from queue import Queue, Empty, Full
 from packaging import version
 from urllib import parse
 from pathlib import Path
-from typing import Dict, List, Union, Optional, Set
+from typing import Dict, List, Tuple, Union, Optional, Set
 
 from lazyllm import LOG
 from lazyllm.thirdparty import pymilvus
@@ -89,6 +89,41 @@ class MilvusStore(LazyLLMStoreBase):
         p = Path(self._uri)
         p = p if p.suffix else (p / 'milvus.db')
         return str(p.resolve(strict=False))
+
+    @override
+    def try_read_dims_from_schema(self, collections: List[str]) -> Tuple[Dict[str, int], Dict[str, DataType]]:
+        embed_dims, embed_datatypes = {}, {}
+        if not self._uri:
+            return embed_dims, embed_datatypes
+        try:
+            tmp = pymilvus.MilvusClient(uri=self._uri, **self._client_kwargs)
+            if self._is_remote and self._db_name:
+                tmp.using_database(self._db_name)
+            try:
+                sparse_dt = pymilvus.DataType.SPARSE_FLOAT_VECTOR
+                sparse_ids = {sparse_dt, getattr(sparse_dt, 'value', None)}
+                for collection_name in collections:
+                    if not tmp.has_collection(collection_name):
+                        continue
+                    desc = tmp.describe_collection(collection_name=collection_name)
+                    for field in desc.get('fields', []):
+                        name = field.get('name', '') or ''
+                        if not name.startswith(EMBED_PREFIX):
+                            continue
+                        key = name[len(EMBED_PREFIX):]
+                        raw_dtype = field.get('type', field.get('dtype'))
+                        params = field.get('params') or {}
+                        dim = params.get('dim')
+                        if raw_dtype in sparse_ids:
+                            embed_datatypes[key] = DataType.SPARSE_FLOAT_VECTOR
+                        elif dim is not None:
+                            embed_dims[key] = int(dim)
+                            embed_datatypes[key] = DataType.FLOAT_VECTOR
+            finally:
+                tmp.close()
+        except Exception as e:
+            LOG.warning(f'[Milvus] Could not read embed dims from schema: {e}')
+        return embed_dims, embed_datatypes
 
     @override
     def connect(self, embed_dims: Optional[Dict[str, int]] = None,

--- a/lazyllm/tools/rag/transform/__init__.py
+++ b/lazyllm/tools/rag/transform/__init__.py
@@ -1,6 +1,6 @@
 from .base import MetadataMode, NodeTransform
-from .factory import (make_transform, AdaptiveTransform, FuncNodeTransform,
-                      LLMParser, TransformArgs, build_nodes_from_splits, _transmap, _normalize_for_sig)
+from .factory import (make_transform, AdaptiveTransform, FuncNodeTransform, LLMParser, TransformArgs,
+                      build_nodes_from_splits, _transmap, _normalize_for_sig, _calculate_signature)
 from .sentence import SentenceSplitter
 from .character import CharacterSplitter
 from .recursive import RecursiveSplitter
@@ -21,5 +21,5 @@ __all__ = [
     'RecursiveSplitter', 'build_nodes_from_splits', 'MarkdownSplitter', 'CodeSplitter',
     'JSONSplitter', 'YAMLSplitter', 'HTMLSplitter', 'XMLSplitter', 'GeneralCodeSplitter', 'JSONLSplitter',
     'RichTransform', 'LayoutNodeParser', 'TreeBuilderParser', 'TreeFixerParser', 'GroupNodeParser',
-    'RuleSet', 'Rule', 'ContentFiltParser', '_transmap', '_normalize_for_sig'
+    'RuleSet', 'Rule', 'ContentFiltParser', '_transmap', '_normalize_for_sig', '_calculate_signature'
 ]

--- a/lazyllm/tools/rag/transform/__init__.py
+++ b/lazyllm/tools/rag/transform/__init__.py
@@ -1,6 +1,6 @@
 from .base import MetadataMode, NodeTransform
 from .factory import (make_transform, AdaptiveTransform, FuncNodeTransform,
-                      LLMParser, TransformArgs, build_nodes_from_splits, _transmap)
+                      LLMParser, TransformArgs, build_nodes_from_splits, _transmap, _normalize_for_sig)
 from .sentence import SentenceSplitter
 from .character import CharacterSplitter
 from .recursive import RecursiveSplitter
@@ -21,5 +21,5 @@ __all__ = [
     'RecursiveSplitter', 'build_nodes_from_splits', 'MarkdownSplitter', 'CodeSplitter',
     'JSONSplitter', 'YAMLSplitter', 'HTMLSplitter', 'XMLSplitter', 'GeneralCodeSplitter', 'JSONLSplitter',
     'RichTransform', 'LayoutNodeParser', 'TreeBuilderParser', 'TreeFixerParser', 'GroupNodeParser',
-    'RuleSet', 'Rule', 'ContentFiltParser', '_transmap',
+    'RuleSet', 'Rule', 'ContentFiltParser', '_transmap', '_normalize_for_sig'
 ]

--- a/lazyllm/tools/rag/transform/factory.py
+++ b/lazyllm/tools/rag/transform/factory.py
@@ -18,6 +18,17 @@ from ..prompts import LLMTransformParserPrompts
 from .base import NodeTransform
 from .sentence import SentenceSplitter
 
+def _normalize_for_sig(v):
+    if isinstance(v, float): return int(round(v)) if abs(v - round(v)) < 1e-8 else f'{v:.8f}'
+    if isinstance(v, dict): return {k: _normalize_for_sig(val) for k, val in sorted(v.items())}
+    if isinstance(v, (list, tuple)): return [_normalize_for_sig(i) for i in v]
+    return v
+
+
+def _calculate_signature(v):
+    return hashlib.sha256(json.dumps(_normalize_for_sig(v)).encode()).hexdigest()[:16]
+
+
 def _callable_sig(f: Optional[Callable], name_override: Optional[str] = None) -> str:
     if f is None:
         return '__default__'
@@ -73,12 +84,9 @@ class TransformArgs():
                 sig_dict = {'type': type(f).__name__, 'params': f.sig_fields()}
                 if self.pattern is not None:
                     sig_dict['pattern'] = _callable_sig(self.pattern) if callable(self.pattern) else self.pattern
-                return hashlib.sha256(json.dumps(sig_dict, sort_keys=True).encode()).hexdigest()[:16]
-            return hashlib.sha256(json.dumps({
-                'type': '__callable__',
-                'func': _callable_sig(f, self.name),
-                'trans_node': self.trans_node,
-            }, sort_keys=True).encode()).hexdigest()[:16]
+                return _calculate_signature(sig_dict)
+            return _calculate_signature({'type': '__callable__', 'func': _callable_sig(f, self.name),
+                                         'trans_node': self.trans_node})
 
         instance = cls(**kw) if cls is not None else None
         if instance is not None:
@@ -87,7 +95,7 @@ class TransformArgs():
             sig_dict = {'type': type_name}
         if self.pattern is not None:
             sig_dict['pattern'] = _callable_sig(self.pattern) if callable(self.pattern) else self.pattern
-        return hashlib.sha256(json.dumps(sig_dict, sort_keys=True).encode()).hexdigest()[:16]
+        return _calculate_signature(sig_dict)
 
 
 def build_nodes_from_splits(


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

将 embedding 维度和数据类型的解析从 `DocImpl._lazy_init` 提前到 `_DocumentStore._lazy_init`，实现懒加载（lazy init）。同时修复了 `register_algorithm` 的 `policy` 传递链路问题，以及内置 node group 跨版本签名漂移导致注册失败的问题。

---

# 🎯 问题背景 / Problem Context

**问题 1：Embedding 维度在启动时被急切求值（eager evaluation）**

原来 `DocImpl._lazy_init` 在创建 `_DocumentStore` 之前，会对每个 embed key 调用一次 `embedding('a')` 来探测维度和数据类型。这导致：
- 每次服务启动都必须调用一次 embedding 函数，即使 Milvus 中已有对应 collection schema；
- 对于需要远程调用的 embedding（如 API 类），增加了不必要的冷启动延迟和失败风险。

**问题 2：`LAZYLLM_ALGO_REGISTER_POLICY` 环境变量在 parse-server 侧读取，导致 force 策略失效**

`register_algorithm` 的 `policy` 原本在 `lazyllm-parse-server` 容器内通过 `lazyllm.config['algo_register_policy']` 读取。但用户实际上是在 `lazyllm-algo` 容器里配置该变量，parse-server 容器里没有这个环境变量，导致 `force` 策略始终不生效，algo 容器因注册冲突而崩溃退出。

**问题 3：内置 node group（`lazyllm_root`、`image`）跨版本签名漂移**

`lazyllm_root` 的签名计算依赖 `group_type` 字段。旧版本注册时该字段可能缺失（走默认值 `CHUNK`），新版本明确传入 `ORIGINAL`，导致签名不一致，在非 force 策略下直接抛出 `ValueError` 阻断注册。

---

# 🔍 相关 Issue / Related Issue

无

---

# ✅ 变更类型 / Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation
- [x] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. 启动服务时使用 pdfreader，然后切换为 mineru（`LAZYMIND_OCR_SERVER_TYPE=mineru LAZYMIND_OCR_SERVICE_VARIANT=online LAZYLLM_ALGO_REGISTER_POLICY=force`），验证 algo 容器能正常注册并启动；
2. 验证 Milvus 中已有 collection 时，`_DocumentStore` 能从 schema 读取 embed 维度，不再调用 embedding 函数；
3. 验证 Milvus 中无 collection 时，fallback 到调用 embedding 函数探测维度，行为与原来一致。

---

# ⚡ 更新后的用法示例 / Usage After Update

切换 OCR reader 时，只需在 `lazyllm-algo` 容器侧设置：

```bash
make up-build SERVICES=lazyllm-algo,lazyllm-parse-worker \
  LAZYMIND_OCR_SERVER_TYPE=mineru \
  LAZYMIND_OCR_SERVICE_VARIANT=online \
  LAZYLLM_ALGO_REGISTER_POLICY=force
```

parse-server 无需配置 `LAZYLLM_ALGO_REGISTER_POLICY`，policy 由 algo 侧读取后通过 RPC 参数传入。

---

# 🔄 重构对比 / Refactor Comparison

## Before

```python
# doc_impl.py — 启动时急切求值 embed 维度
for k, e in self.embed.items():
    embedding = e('a')
    if is_sparse(embedding):
        embed_datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
    else:
        embed_dims[k] = len(embedding)
        embed_datatypes[k] = DataType.FLOAT_VECTOR
self._store = _DocumentStore(..., embed_dims=embed_dims, embed_datatypes=embed_datatypes)

# server.py — policy 在 parse-server 侧读取
def _validate_reader(self, reader):
    policy = lazyllm.config['algo_register_policy'].strip().lower()
    ...

def _upsert_node_groups(self, node_groups, session=None):
    policy = lazyllm.config['algo_register_policy'].strip().lower()
    ...
```

## After

```python
# doc_impl.py — 传空值，延迟到 _DocumentStore._lazy_init() 解析
self._store = _DocumentStore(..., embed_dims={}, embed_datatypes={})

# _DocumentStore._lazy_init() — 优先从 Milvus schema 读取，fallback 到调用 embed 函数
def _lazy_init(self):
    if self._embed_specs_need_resolution():
        self._embed_dims, self._embed_datatypes = self._resolve_embed_dims()
    ...

# server.py — policy 由调用方传入，不再读环境变量
def _validate_reader(self, reader, policy: str = 'none'): ...
def _upsert_node_groups(self, node_groups, policy: str = 'none', session=None): ...

# doc_impl.py — algo 侧读取 policy 并传入
policy = config['algo_register_policy'].strip().lower()
self._processor.register_algorithm(..., policy=policy)
```

---

# ⚠️ 注意事项 / Additional Notes

- `_upsert_node_groups` 中对 `lazyllm_root` 和 `image` 两个内置 group 始终使用 `force` 策略，避免跨版本升级时因签名漂移阻断注册。
- `MilvusStore.try_read_dims_from_schema` 对 `SPARSE_FLOAT_VECTOR` 的判断使用了 `getattr` 兼容旧版 pymilvus（pre-2.4.0）。
- `_compute_node_group_signature` 改用 `_normalize_for_sig` + `_calculate_signature` 统一签名计算逻辑，与其他模块保持一致。

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：** Cursor (Claude Sonnet 4.6)

---

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```
embed lazy init：将 embedding 维度解析从启动时急切求值改为懒加载，优先从 Milvus schema 读取，fallback 到调用 embed 函数
```

## AI 初始输出质量 / Initial Output Quality

- [ ] 一次正确 / Correct on first try
- [x] 部分正确 / Partially correct
- [ ] 基本不可用 / Mostly unusable

---

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**问题：切换 OCR reader（pdfreader → mineru）后服务不生效**

**操作：** 排查发现 Makefile 变量名前缀错误（`LAZYRAG_` → `LAZYMIND_`），修正命令后仍不生效。

**原因：** `lazyllm-algo` 容器因注册冲突崩溃退出，根本原因是 `LAZYLLM_ALGO_REGISTER_POLICY=force` 配置在 algo 容器，但 policy 实际在 parse-server 容器内读取，导致 force 策略完全失效。

---

### 第二次修正 / Second Correction

**问题：即使加了 `LAZYLLM_ALGO_REGISTER_POLICY=force`，algo 容器仍然崩溃**

**操作：** 通过 `docker logs` 确认错误为 `Node group 'lazyllm_root' already registered with different signature`，进一步分析发现两个独立问题：
1. policy 读取位置错误（parse-server 侧 vs algo 侧）；
2. `lazyllm_root` 签名因 `group_type` 字段新旧版本不一致而漂移。

**修正方案：**
- 将 policy 从 `doc_impl.py` 读取后作为参数传入 `register_algorithm`，parse-server 侧各方法改为接收参数而非读环境变量；
- 对 `lazyllm_root`、`image` 等内置 group 在 `_upsert_node_groups` 中始终使用 `force` 策略，跳过签名校验。

---

### 第三次修正 / Third Correction

**问题：`_upsert_node_groups` 中 `lazyllm_root` 的 `parent_sig` 计算逻辑与 `doc_impl.py` 不一致**

**操作：** 对比 `doc_impl.py:267` 和 `server.py:465` 的 `parent_sig` 计算逻辑，发现 server.py 旧版本中 `parent_sig` 直接 fallback 到 `reader_sig`，而 doc_impl.py 中对 `parent == LAZY_ROOT_NAME` 的情况返回 `''`，导致签名计算结果不同。

**修正方案：** 统一为 `parent_sig = '' if not parent or parent == LAZY_ROOT_NAME else ...`，与 doc_impl.py 保持一致。

---

### 最终策略总结 / Final Strategy Summary

核心问题是「policy 的读取位置」和「内置 group 签名稳定性」两个独立 bug 叠加，导致切换 reader 时 algo 容器必然崩溃。AI 在初始实现中未考虑分布式部署下环境变量的作用域问题，需要人工通过日志分析定位根因后指导修正方向。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

- AI 生成代码占比 / AI-generated code：`75%`
- 人工修改占比 / Human modifications：`25%`

**主要人工修改点 / Key Human Modifications：**

- 逻辑修正 / Logic fixes：policy 传递链路的根因分析与修正方向
- 边界处理 / Edge case handling：内置 node group 签名漂移的识别与处理策略
- 架构调整 / Architecture adjustments：明确 policy 应在 algo 侧读取而非 parse-server 侧，符合「调用方决定策略」的设计原则

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```
我不是配置了 LAZYLLM_ALGO_REGISTER_POLICY=force，为什么没有生效
```

### ❌ 问题表现 / Issue Description

AI 最初分析认为是环境变量未传入容器，建议检查 docker-compose.yml 的 environment 配置。实际根因是 policy 在错误的容器（parse-server）侧读取，而非配置问题。

### ✅ 改进后 Prompt / Improved Prompt

```
1. 可以帮我改成，lazyllm-algo 读到变量之后，在 register_algo 的时候，把 policy 带过去，然后 lazyllm-parse-server 不再读环境变量，而是读注册时候的值
2. 对于默认的 node-group，不校验签名，比如 LAZY_ROOT_NAME，LAZY_IMAGE_GROUP
```

---

# 🧩 可复用经验 / Reusable Patterns

- **Prompt 模板：** 在分布式 RPC 场景下，配置项应由调用方读取并作为参数传入，而非在被调用方读取环境变量——这是一个通用的「配置作用域」设计原则，可作为 Prompt 约束加入。
- **常见坑：** AI 在分析「环境变量不生效」类问题时，倾向于检查变量是否传入容器，而忽略「变量在哪个容器里被读取」这一更根本的问题。
- **推荐做法：** 遇到分布式服务间的策略/配置传递问题，先用 `docker logs` + `docker exec env` 确认实际读取位置，再让 AI 给出修正方案。