### PR TITLE
support url ls for feishu

### DIFF
--- a/lazyllm/docs/tools/tool_fs.py
+++ b/lazyllm/docs/tools/tool_fs.py
@@ -1021,7 +1021,7 @@ Preserving format (tables, headings, etc.):
     - To preserve format, use block-level edit: get_doc_blocks(path) to list blocks (block_id, block_type, plain_text), then update_doc_block_text(path, block_id, new_text) for the blocks you need to change; other blocks (e.g. tables) are left unchanged.
 ''')
 _add_fs_chinese('FeishuWikiFS.fetch_url', '''\
-通过飞书浏览器链接直接拉取文档内容（只读），无需 space_id 也无需标题路径。
+通过飞书浏览器链接直接拉取文档内容（只读），无需 space_id 也无需标题路径。已废弃，推荐使用 read_bytes(url) 或 open(url)。
 
 支持的链接格式：
     - https://<host>/wiki/<node_token>   知识库节点链接
@@ -1036,7 +1036,7 @@ Returns:
     bytes: 文档纯文本内容（UTF-8 编码）；附件类型返回二进制。
 ''')
 _add_fs_english('FeishuWikiFS.fetch_url', '''\
-Fetch document content directly from a Feishu browser URL (read-only), without requiring space_id or a title path.
+Fetch document content directly from a Feishu browser URL (read-only), without requiring space_id or a title path. Deprecated; prefer read_bytes(url) or open(url).
 
 Supported URL formats:
     - https://<host>/wiki/<node_token>   wiki node link
@@ -1049,6 +1049,72 @@ Args:
 
 Returns:
     bytes: Document plain text content (UTF-8 encoded); binary for file attachments.
+''')
+_add_fs_chinese('FeishuWikiFS.read_bytes', '''\
+读取路径对应文档的完整内容（字节）。支持裸飞书 URL、~link/~node/~docx/~doc 路径及标题路径。
+
+Args:
+    path (str): 文档路径或飞书 URL。
+    include_references (bool): 为 True 时在正文末尾追加引用附录（lazyllm-feishu-references 格式），默认 False。
+
+Returns:
+    bytes: 文档内容（UTF-8 编码）；include_references=True 时末尾含引用附录。
+''')
+_add_fs_english('FeishuWikiFS.read_bytes', '''\
+Read the full content of the document at path as bytes. Supports bare Feishu URLs, ~link/~node/~docx/~doc paths, and title paths.
+
+Args:
+    path (str): Document path or Feishu URL.
+    include_references (bool): When True, appends a reference appendix (lazyllm-feishu-references format) after the body; default False.
+
+Returns:
+    bytes: Document content (UTF-8 encoded); with reference appendix when include_references=True.
+''')
+_add_fs_chinese('FeishuWikiFS.ls', '''\
+列出路径下的子节点。支持裸飞书 wiki URL、~link/<encoded_url>、~node/<token> 路径及标题路径。
+
+- 传入 wiki URL 或 ~node 路径时，列举该节点的直接子节点（不拉取子文档正文）。
+- 节点无子页（has_child=false）时返回空列表，不报错。
+- 传入 docx/docs 直链（非 wiki 节点）时抛出 ValueError。
+
+Args:
+    path (str): 目录路径、wiki URL 或 ~node/~link 路径。
+    detail (bool): True 时返回 dict 列表（含 creator/owner/node_token 等）；False 时返回名称列表。
+
+Returns:
+    list: detail=True 时为 dict 列表；detail=False 时为 name 列表。
+''')
+_add_fs_english('FeishuWikiFS.ls', '''\
+List child nodes at path. Supports bare Feishu wiki URLs, ~link/<encoded_url>, ~node/<token> paths, and title paths.
+
+- For wiki URLs or ~node paths, lists direct child nodes (does not fetch document content).
+- Returns empty list when the node has no children (has_child=false); does not raise.
+- Raises ValueError for docx/docs direct links (non-wiki nodes).
+
+Args:
+    path (str): Directory path, wiki URL, or ~node/~link path.
+    detail (bool): If True return list of dicts (with creator/owner/node_token etc.); if False return list of names.
+
+Returns:
+    list: List of dicts if detail=True else list of names.
+''')
+_add_fs_chinese('FeishuWikiFS.info', '''\
+获取路径对应节点的元信息。支持裸飞书 wiki URL、~link/~node 路径及标题路径。
+
+Args:
+    path (str): 节点路径、wiki URL 或 ~node/~link 路径。
+
+Returns:
+    dict: 含 name、size、type、mtime、title、obj_type、node_token、creator、owner 等字段。
+''')
+_add_fs_english('FeishuWikiFS.info', '''\
+Get metadata for the node at path. Supports bare Feishu wiki URLs, ~link/~node paths, and title paths.
+
+Args:
+    path (str): Node path, wiki URL, or ~node/~link path.
+
+Returns:
+    dict: Contains name, size, type, mtime, title, obj_type, node_token, creator, owner, etc.
 ''')
 _add_fs_chinese('FeishuWikiFS.get_document_id', '''\
 返回 Wiki 文档节点对应的飞书 docx document_id（即 obj_token）。path 必须指向 doc 或 docx 类型节点，否则抛出 ValueError。

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -99,8 +99,8 @@ class _FSRouter:
     def exists(self, path: str, **kwargs) -> bool:
         return self._dispatch('exists', path, **kwargs)
 
-    def read_bytes(self, path: str) -> bytes:
-        return self._dispatch('read_bytes', path)
+    def read_bytes(self, path: str, **kwargs) -> bytes:
+        return self._dispatch('read_bytes', path, **kwargs)
 
     def read_file(self, path: str) -> str:
         return self._dispatch('read_file', path)

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -22,6 +22,10 @@ lazyllm_globals.config.add(
 
 _SPACE_ID_DYNAMIC = 'dynamic'
 _FEISHU_URL_RE = re.compile(r'/(wiki|docx|docs)/([A-Za-z0-9_-]+)', re.IGNORECASE)
+_FEISHU_BARE_HOST_RE = re.compile(r'^https?://[^/]*(?:feishu\.cn|larksuite\.com)/', re.IGNORECASE)
+_FEISHU_WIKI_TILDE_PREFIXES = ('~link/', '~node/', '~docx/', '~doc/')
+_FEISHU_REF_FOOTER_START = '\n--- lazyllm-feishu-references ---\n'
+_FEISHU_REF_FOOTER_END = '--- end lazyllm-feishu-references ---\n'
 
 
 _API_BASE = 'https://open.feishu.cn/open-apis'
@@ -54,6 +58,70 @@ def _parse_feishu_browser_url(url: str) -> Optional[Dict[str, str]]:
     if type_part == 'docs':
         return {'kind': 'doc', 'token': token}
     return None
+
+
+def _is_wiki_locator_path(path: str) -> bool:
+    norm = path.lstrip('/')
+    if any(norm.startswith(p) for p in _FEISHU_WIKI_TILDE_PREFIXES):
+        return True
+    return bool(_FEISHU_BARE_HOST_RE.match(path))
+
+
+def _iter_docx_elements(blocks: List[Dict[str, Any]]):
+    for block in blocks:
+        bt = block.get('block_type')
+        if bt in (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15):
+            key = {2: 'text', 3: 'heading1', 4: 'heading2', 5: 'heading3', 6: 'heading4',
+                   7: 'heading5', 8: 'heading6', 9: 'heading7', 10: 'heading8', 11: 'heading9',
+                   12: 'bullet', 13: 'ordered', 14: 'code', 15: 'quote'}.get(bt, 'text')
+            for el in (block.get(key) or {}).get('elements') or []:
+                yield el
+        elif bt == 48:
+            yield {'link_preview': block.get('link_preview') or {}}
+
+
+def _ref_from_element(el: Dict[str, Any]) -> Optional[str]:
+    if 'mention_doc' in el:
+        md = el['mention_doc']
+        url = md.get('url') or ''
+        if url:
+            return url
+        token = md.get('token') or ''
+        obj_type = md.get('obj_type') or ''
+        if token and obj_type:
+            path_seg = 'wiki' if obj_type == 'wiki_node' else ('docx' if obj_type == 'docx' else 'docs')
+            return f'https://open.feishu.cn/{path_seg}/{token}'
+    if 'text_run' in el:
+        link = (el['text_run'].get('text_element_style') or {}).get('link') or {}
+        url = link.get('url') or ''
+        if url and _FEISHU_BARE_HOST_RE.match(url):
+            return url
+    if 'link_preview' in el:
+        url = el['link_preview'].get('url') or ''
+        if url and _FEISHU_BARE_HOST_RE.match(url):
+            return url
+    return None
+
+
+def _dedupe_refs(refs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    seen: set = set()
+    out: List[Dict[str, Any]] = []
+    for r in refs:
+        key = r.get('url', '')
+        if key and key not in seen:
+            seen.add(key)
+            out.append(r)
+    return out
+
+
+def _format_references_footer(refs: List[Dict[str, Any]]) -> str:
+    if not refs:
+        return ''
+    lines = [_FEISHU_REF_FOOTER_START]
+    for i, r in enumerate(refs, 1):
+        lines.append(f'[{i}] {r.get("ref_type", "hyperlink")} | {r.get("url", "")}\n')
+    lines.append(_FEISHU_REF_FOOTER_END)
+    return ''.join(lines)
 
 
 def _feishu_acquire_access_token(
@@ -734,8 +802,8 @@ class FeishuFS(FeishuFSBase):
 
 class FeishuWikiFile(CloudFSBufferedFile):
 
-    def __init__(self, fs: 'FeishuWikiFS', path: str, **kwargs) -> None:
-        content = fs._fetch_wiki_content(path)
+    def __init__(self, fs: 'FeishuWikiFS', path: str, include_references: bool = False, **kwargs) -> None:
+        content = fs._fetch_wiki_content(path, include_references=include_references)
         self._wiki_content: bytes = content
         super().__init__(fs, path, size=len(content), **kwargs)
 
@@ -812,7 +880,65 @@ class FeishuWikiFS(FeishuFSBase):
             current_token = match.get('node_token') or ''
         return current_token
 
+    def resolve_wiki_ref(self, url_or_path: str) -> Dict[str, Any]:
+        norm = url_or_path.lstrip('/')
+        if norm.startswith('~link/'):
+            url = unquote(norm[len('~link/'):])
+            parsed = _parse_feishu_browser_url(url)
+            if not parsed:
+                raise ValueError(f'Cannot parse Feishu browser URL: {url!r}')
+            if parsed['kind'] == 'wiki_node':
+                node = self._get_node(parsed['token'])
+                return self._node_to_ref_dict(node, parsed['token'])
+            return {'node_token': '', 'space_id': '', 'title': '', 'obj_type': parsed['kind'],
+                    'obj_token': parsed['token'], 'has_child': False}
+        if norm.startswith('~node/'):
+            token = norm[len('~node/'):].rstrip('/').split('/')[0]
+            node = self._get_node(token)
+            return self._node_to_ref_dict(node, token)
+        if _FEISHU_BARE_HOST_RE.match(url_or_path):
+            parsed = _parse_feishu_browser_url(url_or_path)
+            if not parsed:
+                raise ValueError(f'Cannot parse Feishu browser URL: {url_or_path!r}')
+            if parsed['kind'] == 'wiki_node':
+                node = self._get_node(parsed['token'])
+                return self._node_to_ref_dict(node, parsed['token'])
+            return {'node_token': '', 'space_id': '', 'title': '', 'obj_type': parsed['kind'],
+                    'obj_token': parsed['token'], 'has_child': False}
+        node_token = self._resolve_path_to_token(url_or_path)
+        node = self._get_node(node_token)
+        return self._node_to_ref_dict(node, node_token)
+
+    @staticmethod
+    def _node_to_ref_dict(node: Dict[str, Any], fallback_token: str = '') -> Dict[str, Any]:
+        node_token = node.get('node_token') or fallback_token
+        return {
+            'node_token': node_token,
+            'space_id': node.get('space_id') or '',
+            'title': node.get('title') or '',
+            'obj_type': node.get('obj_type') or '',
+            'obj_token': node.get('obj_token') or '',
+            'has_child': bool(node.get('has_child')),
+            'creator': node.get('creator') or '',
+            'owner': node.get('owner') or '',
+            'node_creator': node.get('node_creator') or '',
+        }
+
+    def _list_child_nodes(self, node_token: str) -> List[Dict[str, Any]]:
+        return self._list_nodes_raw(node_token)
+
     def ls(self, path: str = '/', detail: bool = True, **kwargs) -> List:
+        if _is_wiki_locator_path(path):
+            ref = self.resolve_wiki_ref(path)
+            node_token = ref.get('node_token') or ''
+            obj_type = ref.get('obj_type') or ''
+            if not node_token:
+                if obj_type in ('docx', 'doc'):
+                    raise ValueError(f'ls: only wiki nodes can be listed; got obj_type={obj_type!r} for {path!r}')
+                return []
+            items = self._list_child_nodes(node_token)
+            entries = [self._node_to_entry(item) for item in items]
+            return entries if detail else [e['name'] for e in entries]
         self._require_space_id()
         node_token = self._resolve_path_to_token(path)
         items = self._list_nodes_raw(node_token)
@@ -820,6 +946,13 @@ class FeishuWikiFS(FeishuFSBase):
         return entries if detail else [e['name'] for e in entries]
 
     def info(self, path: str, **kwargs) -> Dict[str, Any]:
+        if _is_wiki_locator_path(path):
+            ref = self.resolve_wiki_ref(path)
+            node_token = ref.get('node_token') or ''
+            if not node_token:
+                return self._entry(path, ftype='directory')
+            node = self._get_node(node_token)
+            return self._node_to_entry(node, default_name=ref.get('title') or path)
         token = self._resolve_path_to_token(path)
         if not token:
             return self._entry('/', ftype='directory')
@@ -882,49 +1015,102 @@ class FeishuWikiFS(FeishuFSBase):
             raise ValueError(f'Cannot parse Feishu browser URL: {url!r}')
         return self._resolve_link_content(parsed)
 
-    def _fetch_wiki_content(self, path: str) -> bytes:
+    def _resolve_doc_token_from_path(self, path: str) -> Tuple[str, str]:
+        norm = path.lstrip('/')
+        if norm.startswith('~link/'):
+            url = unquote(norm[len('~link/'):])
+            parsed = _parse_feishu_browser_url(url)
+            if not parsed:
+                return '', ''
+            if parsed['kind'] == 'wiki_node':
+                node = self._get_node(parsed['token'])
+                return node.get('obj_token') or '', node.get('obj_type') or ''
+            return parsed['token'], parsed['kind']
+        if norm.startswith('~node/'):
+            token = norm[len('~node/'):].rstrip('/').split('/')[0]
+            node = self._get_node(token)
+            return node.get('obj_token') or '', node.get('obj_type') or ''
+        if norm.startswith('~docx/'):
+            return norm[len('~docx/'):].split('/')[0], 'docx'
+        if norm.startswith('~doc/'):
+            return norm[len('~doc/'):].split('/')[0], 'doc'
+        return '', ''
+
+    def _list_document_references(self, path: str) -> List[Dict[str, Any]]:
+        doc_token, obj_type = self._resolve_doc_token_from_path(path)
+        if not doc_token or obj_type not in ('doc', 'docx'):
+            return []
+        try:
+            blocks = self._get_doc_blocks_raw(doc_token, with_descendants=True)
+        except Exception as exc:
+            LOG.warning(f'_list_document_references: failed to get blocks for {path!r}: {exc}')
+            return []
+        refs: List[Dict[str, Any]] = []
+        for el in _iter_docx_elements(blocks):
+            url = _ref_from_element(el)
+            if url:
+                parsed = _parse_feishu_browser_url(url)
+                ref_type = 'mention_doc' if 'mention_doc' in el else (
+                    'link_preview' if 'link_preview' in el else 'hyperlink')
+                refs.append({'url': url, 'ref_type': ref_type,
+                             'kind': parsed['kind'] if parsed else 'external'})
+        return _dedupe_refs(refs)
+
+    def _fetch_wiki_content(self, path: str, include_references: bool = False) -> bytes:
         norm = path.lstrip('/')
         if norm.startswith('~link/'):
             url = unquote(norm[len('~link/'):])
             parsed = _parse_feishu_browser_url(url)
             if not parsed:
                 raise ValueError(f'Cannot parse Feishu browser URL from path: {path!r}')
-            return self._resolve_link_content(parsed)
-        if norm.startswith('~node/'):
-            token = norm[len('~node/'):].split('/')[0]
-            return self._resolve_link_content({'kind': 'wiki_node', 'token': token})
-        if norm.startswith('~docx/'):
+            body = self._resolve_link_content(parsed)
+        elif norm.startswith('~node/'):
+            token = norm[len('~node/'):].rstrip('/').split('/')[0]
+            body = self._resolve_link_content({'kind': 'wiki_node', 'token': token})
+        elif norm.startswith('~docx/'):
             token = norm[len('~docx/'):].split('/')[0]
-            return self._download_doc_raw(token, obj_type='docx')
-        if norm.startswith('~doc/'):
+            body = self._download_doc_raw(token, obj_type='docx')
+        elif norm.startswith('~doc/'):
             token = norm[len('~doc/'):].split('/')[0]
-            return self._download_doc_raw(token, obj_type='doc')
-        node_token = self._resolve_path_to_token(path)
-        if not node_token:
-            return b''
-        node = self._get_node(node_token)
-        obj_type = node.get('obj_type')
-        obj_token = node.get('obj_token') or ''
-        if not obj_type or not obj_token:
-            return b''
-        if obj_type in {'doc', 'docx'}:
-            return self._download_doc_raw(obj_token, obj_type=obj_type)
-        if obj_type == 'file':
-            return self._download_file_raw(obj_token)
-        return b''
+            body = self._download_doc_raw(token, obj_type='doc')
+        else:
+            node_token = self._resolve_path_to_token(path)
+            if not node_token:
+                return b''
+            node = self._get_node(node_token)
+            obj_type = node.get('obj_type')
+            obj_token = node.get('obj_token') or ''
+            if not obj_type or not obj_token:
+                return b''
+            if obj_type in {'doc', 'docx'}:
+                body = self._download_doc_raw(obj_token, obj_type=obj_type)
+            elif obj_type == 'file':
+                body = self._download_file_raw(obj_token)
+            else:
+                return b''
+        if include_references:
+            refs = self._list_document_references(path)
+            footer = _format_references_footer(refs)
+            if footer:
+                body = body + footer.encode('utf-8')
+        return body
 
     def cat_file(self, path: str, start: Optional[int] = None, end: Optional[int] = None,
                  **kwargs) -> bytes:
         data = self._fetch_wiki_content(path)
         return data[start:end] if (start is not None or end is not None) else data
 
+    def read_bytes(self, path: str, include_references: bool = False) -> bytes:
+        return self._fetch_wiki_content(path, include_references=include_references)
+
     def _open(self, path: str, mode: str = 'rb', block_size: Optional[int] = None,
               autocommit: bool = True, cache_options: Optional[Dict] = None,
-              **kwargs) -> CloudFSBufferedFile:
+              include_references: bool = False, **kwargs) -> CloudFSBufferedFile:
         if 'b' not in mode:
             raise ValueError('FeishuWikiFS only supports binary mode')
         if 'r' in mode:
-            return FeishuWikiFile(self, path, mode=mode, block_size=block_size or self.blocksize,
+            return FeishuWikiFile(self, path, include_references=include_references,
+                                  mode=mode, block_size=block_size or self.blocksize,
                                   autocommit=autocommit, cache_options=cache_options)
         norm = path.lstrip('/')
         if norm.startswith(('~link/', '~node/', '~docx/', '~doc/')):
@@ -1090,4 +1276,6 @@ class FeishuWikiFS(FeishuFSBase):
             name=title, size=size, ftype='directory' if is_dir else 'file',
             mtime=mtime, title=title, obj_type=obj_type,
             obj_token=node.get('obj_token'), node_token=node_token,
+            creator=node.get('creator') or '', owner=node.get('owner') or '',
+            node_creator=node.get('node_creator') or '',
         )

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -1,0 +1,527 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+
+from lazyllm.tools.fs.supplier.feishu import (
+    _parse_feishu_browser_url,
+    _SPACE_ID_DYNAMIC,
+    FeishuFS,
+    FeishuWikiFS,
+)
+from lazyllm.tools.fs.client import _FSRouter, _feishu_needs_wiki, _FEISHU_WIKI_PATH_PREFIXES
+
+
+class TestParseFeishuBrowserUrl(unittest.TestCase):
+
+    def test_wiki_url(self):
+        result = _parse_feishu_browser_url('https://sensetime.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb')
+        self.assertEqual(result, {'kind': 'wiki_node', 'token': 'MCjOwGxwSimztPkO5X6cv8uxnwb'})
+
+    def test_wiki_url_with_query(self):
+        result = _parse_feishu_browser_url(
+            'https://sensetime.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb?renamingWikiNode=true'
+        )
+        self.assertEqual(result, {'kind': 'wiki_node', 'token': 'MCjOwGxwSimztPkO5X6cv8uxnwb'})
+
+    def test_docx_url(self):
+        result = _parse_feishu_browser_url('https://company.feishu.cn/docx/AbCdEfGh12345678')
+        self.assertEqual(result, {'kind': 'docx', 'token': 'AbCdEfGh12345678'})
+
+    def test_docs_url(self):
+        result = _parse_feishu_browser_url('https://company.larksuite.com/docs/doccnOldStyleToken')
+        self.assertEqual(result, {'kind': 'doc', 'token': 'doccnOldStyleToken'})
+
+    def test_wiki_with_fragment(self):
+        result = _parse_feishu_browser_url(
+            'https://company.feishu.cn/wiki/SomeToken123#anchor'
+        )
+        self.assertEqual(result, {'kind': 'wiki_node', 'token': 'SomeToken123'})
+
+    def test_invalid_url(self):
+        self.assertIsNone(_parse_feishu_browser_url('https://feishu.cn/'))
+        self.assertIsNone(_parse_feishu_browser_url('not-a-url'))
+        self.assertIsNone(_parse_feishu_browser_url(''))
+
+    def test_uppercase_path(self):
+        result = _parse_feishu_browser_url('https://xxx.feishu.cn/WIKI/Token999')
+        self.assertEqual(result, {'kind': 'wiki_node', 'token': 'Token999'})
+
+
+class TestSpaceIdDynamic(unittest.TestCase):
+
+    def test_dynamic_constant(self):
+        self.assertEqual(_SPACE_ID_DYNAMIC, 'dynamic')
+
+    @patch('lazyllm.tools.fs.supplier.feishu.FeishuWikiFS.__init__', return_value=None)
+    def test_feishu_fs_new_dynamic_routes_to_wiki(self, mock_init):
+        # FeishuFS.__new__ with space_id='dynamic' should instantiate FeishuWikiFS with space_id=''
+        with patch.object(FeishuWikiFS, '__init__', return_value=None) as wiki_init:
+            instance = FeishuFS.__new__(
+                FeishuFS,
+                app_id='test_id', app_secret='test_secret',
+                space_id='dynamic', dynamic_auth=True,
+            )
+            self.assertIsInstance(instance, FeishuWikiFS)
+            call_kwargs = wiki_init.call_args[1]
+            self.assertEqual(call_kwargs.get('space_id'), '')
+
+    @patch('lazyllm.tools.fs.supplier.feishu.FeishuWikiFS.__init__', return_value=None)
+    def test_feishu_fs_new_real_space_id_unchanged(self, mock_init):
+        with patch.object(FeishuWikiFS, '__init__', return_value=None) as wiki_init:
+            instance = FeishuFS.__new__(
+                FeishuFS,
+                app_id='test_id', app_secret='test_secret',
+                space_id='wikcnRealSpaceId', dynamic_auth=True,
+            )
+            self.assertIsInstance(instance, FeishuWikiFS)
+            call_kwargs = wiki_init.call_args[1]
+            self.assertEqual(call_kwargs.get('space_id'), 'wikcnRealSpaceId')
+
+    def test_feishu_fs_new_no_space_id_returns_drive(self):
+        with patch('lazyllm.tools.fs.supplier.feishu.FeishuFSBase.__init__', return_value=None):
+            instance = FeishuFS.__new__(FeishuFS, dynamic_auth=True)
+            self.assertIs(type(instance), FeishuFS)
+
+
+class TestEffectiveSpaceId(unittest.TestCase):
+
+    def _make_wiki_fs(self, space_id: str = '') -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = space_id
+        return fs
+
+    def test_returns_constructor_space_id_first(self):
+        fs = self._make_wiki_fs('wikcnABC')
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': 'wikcnOther'}
+            self.assertEqual(fs._effective_space_id(), 'wikcnABC')
+
+    def test_falls_back_to_globals_config(self):
+        fs = self._make_wiki_fs('')
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': 'wikcnFromGlobals'}
+            self.assertEqual(fs._effective_space_id(), 'wikcnFromGlobals')
+
+    def test_returns_empty_when_both_absent(self):
+        fs = self._make_wiki_fs('')
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': None}
+            self.assertEqual(fs._effective_space_id(), '')
+
+    def test_require_space_id_raises_when_empty(self):
+        fs = self._make_wiki_fs('')
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': None}
+            with self.assertRaises(ValueError):
+                fs._require_space_id()
+
+    def test_require_space_id_ok_when_globals_set(self):
+        fs = self._make_wiki_fs('')
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': 'wikcnXYZ'}
+            fs._require_space_id()  # should not raise
+
+
+class TestFetchWikiContentPaths(unittest.TestCase):
+
+    def _make_wiki_fs(self) -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = ''
+        return fs
+
+    def test_tilde_node_path(self):
+        fs = self._make_wiki_fs()
+        node_token = 'MCjOwGxwSimztPkO5X6cv8uxnwb'
+        fs._resolve_link_content = MagicMock(return_value=b'node content')
+        result = fs._fetch_wiki_content(f'/~node/{node_token}')
+        fs._resolve_link_content.assert_called_once_with({'kind': 'wiki_node', 'token': node_token})
+        self.assertEqual(result, b'node content')
+
+    def test_tilde_docx_path(self):
+        fs = self._make_wiki_fs()
+        fs._download_doc_raw = MagicMock(return_value=b'docx content')
+        result = fs._fetch_wiki_content('/~docx/DocId123')
+        fs._download_doc_raw.assert_called_once_with('DocId123', obj_type='docx')
+        self.assertEqual(result, b'docx content')
+
+    def test_tilde_doc_path(self):
+        fs = self._make_wiki_fs()
+        fs._download_doc_raw = MagicMock(return_value=b'doc content')
+        result = fs._fetch_wiki_content('/~doc/OldDocToken')
+        fs._download_doc_raw.assert_called_once_with('OldDocToken', obj_type='doc')
+        self.assertEqual(result, b'doc content')
+
+    def test_tilde_link_path(self):
+        from urllib.parse import quote
+        fs = self._make_wiki_fs()
+        url = 'https://sensetime.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb'
+        fs._resolve_link_content = MagicMock(return_value=b'linked content')
+        result = fs._fetch_wiki_content('/~link/' + quote(url, safe=''))
+        fs._resolve_link_content.assert_called_once_with({'kind': 'wiki_node', 'token': 'MCjOwGxwSimztPkO5X6cv8uxnwb'})
+        self.assertEqual(result, b'linked content')
+
+    def test_tilde_link_invalid_url_raises(self):
+        fs = self._make_wiki_fs()
+        with self.assertRaises(ValueError):
+            fs._fetch_wiki_content('/~link/not-a-valid-feishu-url')
+
+    def test_title_path_requires_space_id(self):
+        fs = self._make_wiki_fs()
+        with patch('lazyllm.tools.fs.supplier.feishu.lazyllm_globals') as mock_globals:
+            mock_globals.config = {'feishu_wiki_space_id': None}
+            with self.assertRaises(ValueError):
+                fs._fetch_wiki_content('/some/path')
+
+
+class TestGetNodeSpaceIdBackfill(unittest.TestCase):
+
+    def _make_wiki_fs(self, space_id='') -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = space_id
+        fs._base_url = 'https://open.feishu.cn/open-apis'
+        return fs
+
+    def test_backfills_space_id_from_node_response(self):
+        fs = self._make_wiki_fs('')
+        node_data = {'data': {'node': {'space_id': 'wikcnBackfilled', 'obj_type': 'docx', 'obj_token': 'tok'}}}
+        fs._get = MagicMock(return_value=node_data)
+        node = fs._get_node('someToken')
+        self.assertEqual(fs._space_id, 'wikcnBackfilled')
+        self.assertEqual(node['space_id'], 'wikcnBackfilled')
+
+    def test_does_not_overwrite_existing_space_id(self):
+        fs = self._make_wiki_fs('wikcnOriginal')
+        node_data = {'data': {'node': {'space_id': 'wikcnOther', 'obj_type': 'docx', 'obj_token': 'tok'}}}
+        fs._get = MagicMock(return_value=node_data)
+        fs._get_node('someToken')
+        self.assertEqual(fs._space_id, 'wikcnOriginal')
+
+
+class TestFSRouterParse(unittest.TestCase):
+
+    def setUp(self):
+        self.router = _FSRouter()
+
+    def test_bare_feishu_url_normalized(self):
+        protocol, space_id, real_path = self.router._parse(
+            'https://sensetime.feishu.cn/wiki/MCjOwGxwSimztPkO5X6cv8uxnwb'
+        )
+        self.assertEqual(protocol, 'feishu')
+        self.assertEqual(space_id, 'dynamic')
+        self.assertTrue(real_path.startswith('/~link/'))
+        self.assertIn('feishu.cn', real_path)
+
+    def test_feishu_tilde_node_path_gets_dynamic_space(self):
+        protocol, space_id, real_path = self.router._parse('feishu:/~node/MCjOwG')
+        self.assertEqual(protocol, 'feishu')
+        self.assertEqual(space_id, 'dynamic')
+        self.assertEqual(real_path, '/~node/MCjOwG')
+
+    def test_feishu_at_space_preserved(self):
+        protocol, space_id, real_path = self.router._parse('feishu@wikcnXXX:/some/path')
+        self.assertEqual(protocol, 'feishu')
+        self.assertEqual(space_id, 'wikcnXXX')
+        self.assertEqual(real_path, '/some/path')
+
+    def test_feishu_at_dynamic_preserved(self):
+        protocol, space_id, real_path = self.router._parse('feishu@dynamic:/~node/Tok')
+        self.assertEqual(protocol, 'feishu')
+        self.assertEqual(space_id, 'dynamic')
+        self.assertEqual(real_path, '/~node/Tok')
+
+    def test_larksuite_bare_url(self):
+        protocol, space_id, real_path = self.router._parse(
+            'https://company.larksuite.com/wiki/SomeToken'
+        )
+        self.assertEqual(protocol, 'feishu')
+        self.assertEqual(space_id, 'dynamic')
+
+    def test_local_path_unchanged(self):
+        protocol, space_id, real_path = self.router._parse('/tmp/file.txt')
+        self.assertEqual(protocol, 'file')
+        self.assertIsNone(space_id)
+        self.assertEqual(real_path, '/tmp/file.txt')
+
+    def test_regular_feishu_cloud_drive_path(self):
+        protocol, space_id, real_path = self.router._parse('feishu:/folder/file.txt')
+        self.assertEqual(protocol, 'feishu')
+        self.assertIsNone(space_id)
+        self.assertEqual(real_path, '/folder/file.txt')
+
+
+class TestFeishuNeedsWiki(unittest.TestCase):
+
+    def test_with_space_id(self):
+        self.assertTrue(_feishu_needs_wiki('wikcnXXX', '/'))
+
+    def test_with_dynamic(self):
+        self.assertTrue(_feishu_needs_wiki('dynamic', '/'))
+
+    def test_tilde_prefix(self):
+        for prefix in _FEISHU_WIKI_PATH_PREFIXES:
+            self.assertTrue(_feishu_needs_wiki(None, f'/{prefix}token'))
+
+    def test_plain_path_no_space_no_config(self):
+        mock_config = MagicMock()
+        mock_config.get = MagicMock(return_value=None)
+        with patch('lazyllm.tools.fs.client.globals') as mock_globals:
+            mock_globals.config = mock_config
+            self.assertFalse(_feishu_needs_wiki(None, '/folder/file'))
+
+    def test_plain_path_with_globals_config(self):
+        with patch('lazyllm.tools.fs.client.globals') as mock_globals:
+            mock_globals.config.get = MagicMock(return_value='wikcnFromGlobals')
+            self.assertTrue(_feishu_needs_wiki(None, '/folder/file'))
+
+
+if __name__ == '__main__':
+    unittest.main()
+
+
+class TestIsWikiLocatorPath(unittest.TestCase):
+
+    def test_bare_feishu_url(self):
+        from lazyllm.tools.fs.supplier.feishu import _is_wiki_locator_path
+        self.assertTrue(_is_wiki_locator_path('https://company.feishu.cn/wiki/SomeToken'))
+
+    def test_tilde_node(self):
+        from lazyllm.tools.fs.supplier.feishu import _is_wiki_locator_path
+        self.assertTrue(_is_wiki_locator_path('/~node/SomeToken'))
+        self.assertTrue(_is_wiki_locator_path('~node/SomeToken'))
+
+    def test_tilde_link(self):
+        from lazyllm.tools.fs.supplier.feishu import _is_wiki_locator_path
+        self.assertTrue(_is_wiki_locator_path('/~link/https%3A%2F%2Fxxx.feishu.cn%2Fwiki%2FTok'))
+
+    def test_plain_path_not_locator(self):
+        from lazyllm.tools.fs.supplier.feishu import _is_wiki_locator_path
+        self.assertFalse(_is_wiki_locator_path('/some/title/path'))
+        self.assertFalse(_is_wiki_locator_path('https://example.com/wiki/Tok'))
+
+
+class TestRefFromElement(unittest.TestCase):
+
+    def test_mention_doc_with_url(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        el = {'mention_doc': {'url': 'https://company.feishu.cn/wiki/TokA', 'token': 'TokA', 'obj_type': 'wiki_node'}}
+        self.assertEqual(_ref_from_element(el), 'https://company.feishu.cn/wiki/TokA')
+
+    def test_mention_doc_without_url_builds_path(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        el = {'mention_doc': {'token': 'TokB', 'obj_type': 'docx'}}
+        result = _ref_from_element(el)
+        self.assertIn('TokB', result)
+
+    def test_text_run_with_feishu_link(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        el = {'text_run': {'content': 'click', 'text_element_style': {
+            'link': {'url': 'https://company.feishu.cn/wiki/TokC'}}}}
+        self.assertEqual(_ref_from_element(el), 'https://company.feishu.cn/wiki/TokC')
+
+    def test_text_run_with_external_link_ignored(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        el = {'text_run': {'content': 'click', 'text_element_style': {
+            'link': {'url': 'https://example.com/page'}}}}
+        self.assertIsNone(_ref_from_element(el))
+
+    def test_link_preview_feishu(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        el = {'link_preview': {'url': 'https://company.feishu.cn/docx/DocId'}}
+        self.assertEqual(_ref_from_element(el), 'https://company.feishu.cn/docx/DocId')
+
+    def test_no_ref_returns_none(self):
+        from lazyllm.tools.fs.supplier.feishu import _ref_from_element
+        self.assertIsNone(_ref_from_element({'text_run': {'content': 'plain text'}}))
+
+
+class TestDedupeRefs(unittest.TestCase):
+
+    def test_deduplication(self):
+        from lazyllm.tools.fs.supplier.feishu import _dedupe_refs
+        refs = [
+            {'url': 'https://a.feishu.cn/wiki/T1', 'ref_type': 'mention_doc'},
+            {'url': 'https://a.feishu.cn/wiki/T1', 'ref_type': 'hyperlink'},
+            {'url': 'https://a.feishu.cn/wiki/T2', 'ref_type': 'hyperlink'},
+        ]
+        result = _dedupe_refs(refs)
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]['url'], 'https://a.feishu.cn/wiki/T1')
+        self.assertEqual(result[1]['url'], 'https://a.feishu.cn/wiki/T2')
+
+
+class TestFormatReferencesFooter(unittest.TestCase):
+
+    def test_empty_refs(self):
+        from lazyllm.tools.fs.supplier.feishu import _format_references_footer
+        self.assertEqual(_format_references_footer([]), '')
+
+    def test_footer_format(self):
+        from lazyllm.tools.fs.supplier.feishu import _format_references_footer
+        refs = [
+            {'url': 'https://a.feishu.cn/wiki/T1', 'ref_type': 'mention_doc'},
+            {'url': 'https://a.feishu.cn/docx/D2', 'ref_type': 'hyperlink'},
+        ]
+        footer = _format_references_footer(refs)
+        self.assertIn('lazyllm-feishu-references', footer)
+        self.assertIn('[1] mention_doc | https://a.feishu.cn/wiki/T1', footer)
+        self.assertIn('[2] hyperlink | https://a.feishu.cn/docx/D2', footer)
+        self.assertIn('end lazyllm-feishu-references', footer)
+
+
+class TestWikiLsWithLocatorPath(unittest.TestCase):
+
+    def _make_wiki_fs(self) -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = ''
+        fs._base_url = 'https://open.feishu.cn/open-apis'
+        return fs
+
+    def test_ls_bare_wiki_url_returns_children(self):
+        fs = self._make_wiki_fs()
+        node_token = 'MCjOwGxwSimztPkO5X6cv8uxnwb'
+        node_data = {'node_token': node_token, 'space_id': 'wikcnABC', 'title': 'Root',
+                     'obj_type': 'docx', 'obj_token': 'ObjTok', 'has_child': True}
+        child_nodes = [
+            {'node_token': 'child1', 'title': 'Child1', 'obj_type': 'docx', 'has_child': False},
+            {'node_token': 'child2', 'title': 'Child2', 'obj_type': 'docx', 'has_child': False},
+        ]
+        fs._get_node = MagicMock(return_value=node_data)
+        fs._list_nodes_raw = MagicMock(return_value=child_nodes)
+        url = f'https://company.feishu.cn/wiki/{node_token}'
+        entries = fs.ls(url, detail=True)
+        self.assertEqual(len(entries), 2)
+        self.assertEqual(entries[0]['name'], 'Child1')
+        self.assertEqual(entries[1]['name'], 'Child2')
+        fs._list_nodes_raw.assert_called_once_with(node_token)
+
+    def test_ls_tilde_node_path(self):
+        fs = self._make_wiki_fs()
+        node_token = 'NodeTok123'
+        node_data = {'node_token': node_token, 'space_id': 'wikcnABC', 'title': 'Doc',
+                     'obj_type': 'docx', 'obj_token': 'ObjTok', 'has_child': True}
+        child_nodes = [{'node_token': 'c1', 'title': 'Sub', 'obj_type': 'docx', 'has_child': False}]
+        fs._get_node = MagicMock(return_value=node_data)
+        fs._list_nodes_raw = MagicMock(return_value=child_nodes)
+        entries = fs.ls(f'/~node/{node_token}', detail=False)
+        self.assertEqual(entries, ['Sub'])
+
+    def test_ls_node_no_children_returns_empty(self):
+        fs = self._make_wiki_fs()
+        node_token = 'LeafTok'
+        node_data = {'node_token': node_token, 'space_id': 'wikcnABC', 'title': 'Leaf',
+                     'obj_type': 'docx', 'obj_token': 'ObjTok', 'has_child': False}
+        fs._get_node = MagicMock(return_value=node_data)
+        fs._list_nodes_raw = MagicMock(return_value=[])
+        entries = fs.ls(f'/~node/{node_token}')
+        self.assertEqual(entries, [])
+
+    def test_ls_docx_direct_link_raises(self):
+        fs = self._make_wiki_fs()
+        parsed_docx = {'kind': 'docx', 'token': 'DocxTok'}
+        with patch('lazyllm.tools.fs.supplier.feishu._parse_feishu_browser_url', return_value=parsed_docx):
+            with self.assertRaises(ValueError):
+                fs.ls('https://company.feishu.cn/docx/DocxTok')
+
+
+class TestWikiInfoWithLocatorPath(unittest.TestCase):
+
+    def _make_wiki_fs(self) -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = ''
+        fs._base_url = 'https://open.feishu.cn/open-apis'
+        return fs
+
+    def test_info_bare_wiki_url(self):
+        fs = self._make_wiki_fs()
+        node_token = 'InfoTok'
+        node_data = {'node_token': node_token, 'space_id': 'wikcnABC', 'title': 'MyDoc',
+                     'obj_type': 'docx', 'obj_token': 'ObjTok', 'has_child': False,
+                     'creator': 'user1', 'owner': 'user2'}
+        fs._get_node = MagicMock(return_value=node_data)
+        entry = fs.info(f'https://company.feishu.cn/wiki/{node_token}')
+        self.assertEqual(entry['name'], 'MyDoc')
+        self.assertEqual(entry['creator'], 'user1')
+        self.assertEqual(entry['owner'], 'user2')
+        self.assertEqual(entry['node_token'], node_token)
+
+
+class TestFetchWikiContentWithReferences(unittest.TestCase):
+
+    def _make_wiki_fs(self) -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = ''
+        fs._base_url = 'https://open.feishu.cn/open-apis'
+        return fs
+
+    def test_include_references_false_no_footer(self):
+        fs = self._make_wiki_fs()
+        fs._resolve_link_content = MagicMock(return_value=b'body text')
+        result = fs._fetch_wiki_content('/~node/SomeTok', include_references=False)
+        self.assertEqual(result, b'body text')
+
+    def test_include_references_true_appends_footer(self):
+        fs = self._make_wiki_fs()
+        node_data = {'node_token': 'SomeTok', 'obj_type': 'docx', 'obj_token': 'DocId'}
+        fs._get_node = MagicMock(return_value=node_data)
+        fs._download_doc_raw = MagicMock(return_value=b'body text')
+        refs = [{'url': 'https://a.feishu.cn/wiki/T1', 'ref_type': 'mention_doc', 'kind': 'wiki_node'}]
+        fs._list_document_references = MagicMock(return_value=refs)
+        result = fs._fetch_wiki_content('/~node/SomeTok', include_references=True)
+        text = result.decode('utf-8')
+        self.assertIn('body text', text)
+        self.assertIn('lazyllm-feishu-references', text)
+        self.assertIn('https://a.feishu.cn/wiki/T1', text)
+
+    def test_include_references_true_no_refs_no_footer(self):
+        fs = self._make_wiki_fs()
+        node_data = {'node_token': 'SomeTok', 'obj_type': 'docx', 'obj_token': 'DocId'}
+        fs._get_node = MagicMock(return_value=node_data)
+        fs._download_doc_raw = MagicMock(return_value=b'body text')
+        fs._list_document_references = MagicMock(return_value=[])
+        result = fs._fetch_wiki_content('/~node/SomeTok', include_references=True)
+        self.assertEqual(result, b'body text')
+
+
+class TestReadBytesWithKwargs(unittest.TestCase):
+
+    def _make_wiki_fs(self) -> FeishuWikiFS:
+        fs = object.__new__(FeishuWikiFS)
+        fs._space_id = ''
+        fs._base_url = 'https://open.feishu.cn/open-apis'
+        return fs
+
+    def test_read_bytes_default_no_references(self):
+        fs = self._make_wiki_fs()
+        fs._fetch_wiki_content = MagicMock(return_value=b'content')
+        result = fs.read_bytes('/~node/Tok')
+        fs._fetch_wiki_content.assert_called_once_with('/~node/Tok', include_references=False)
+        self.assertEqual(result, b'content')
+
+    def test_read_bytes_with_include_references(self):
+        fs = self._make_wiki_fs()
+        fs._fetch_wiki_content = MagicMock(return_value=b'content+refs')
+        result = fs.read_bytes('/~node/Tok', include_references=True)
+        fs._fetch_wiki_content.assert_called_once_with('/~node/Tok', include_references=True)
+        self.assertEqual(result, b'content+refs')
+
+
+class TestNodeToEntryCreatorOwner(unittest.TestCase):
+
+    def test_creator_owner_in_entry(self):
+        node = {
+            'node_token': 'Tok1', 'title': 'Doc', 'obj_type': 'docx',
+            'obj_token': 'ObjTok', 'has_child': False,
+            'creator': 'user_a', 'owner': 'user_b', 'node_creator': 'user_c',
+        }
+        entry = FeishuWikiFS._node_to_entry(node)
+        self.assertEqual(entry['creator'], 'user_a')
+        self.assertEqual(entry['owner'], 'user_b')
+        self.assertEqual(entry['node_creator'], 'user_c')
+
+    def test_missing_creator_defaults_to_empty(self):
+        node = {'node_token': 'Tok2', 'title': 'Doc2', 'obj_type': 'docx', 'has_child': False}
+        entry = FeishuWikiFS._node_to_entry(node)
+        self.assertEqual(entry['creator'], '')
+        self.assertEqual(entry['owner'], '')
+        self.assertEqual(entry['node_creator'], '')
+

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
 import unittest
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 from lazyllm.tools.fs.supplier.feishu import (
     _parse_feishu_browser_url,
@@ -524,4 +524,3 @@ class TestNodeToEntryCreatorOwner(unittest.TestCase):
         self.assertEqual(entry['creator'], '')
         self.assertEqual(entry['owner'], '')
         self.assertEqual(entry['node_creator'], '')
-


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

为 `FeishuWikiFS` 新增子文档列举与引用附录能力，使 Agent 可通过统一的 `ls` / `read_bytes` 接口完成「读文 + 看引用 + 再读选中链接」闭环，无需额外工具。

---

# 🎯 问题背景 / Problem Context

原有 `FeishuWikiFS` 的 `ls` 只支持标题路径，`read_bytes` / `open` 不透传 kwargs，且正文中的引用链接完全丢失。Agent 无法通过裸飞书 URL 列举子页，也无法感知文档内的引用关系。

---

# 🔍 相关 Issue / Related Issue

N/A

---

# ✅ 变更类型 / Type of Change

- [x] New feature
- [x] Refactor

---

# 🧪 如何测试 / How Has This Been Tested?

新增 22 个单元测试（8 个测试类），全部通过：

```
LAZYLLM_DEFAULT_LAUNCHER=empty pytest -vvs tests/basic_tests/Tools/test_feishu_fs_url.py
# 61 passed, 1 warning
```

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
from lazyllm.tools.fs import FS

# 通过裸 URL 列举子页（不拉取正文）
children = FS.ls('https://xxx.feishu.cn/wiki/SomeNodeToken')
# [{'name': 'Child1', 'node_token': '...', 'creator': '...', 'owner': '...', ...}, ...]

# 读正文 + 尾部引用附录
text = FS.read_bytes('https://xxx.feishu.cn/wiki/SomeNodeToken', include_references=True).decode()
# 正文内容
# --- lazyllm-feishu-references ---
# [1] mention_doc | https://xxx.feishu.cn/wiki/RefToken
# [2] hyperlink   | https://xxx.feishu.cn/docx/DocId
# --- end lazyllm-feishu-references ---

# Agent 按需再读引用
FS.read_bytes('https://xxx.feishu.cn/wiki/RefToken')
```

---

# 🔄 重构对比 / Refactor Comparison

## Before

- `ls(path)` 仅支持标题路径，需要预先配置 `space_id`
- `read_bytes(path)` 无 kwargs，正文不含引用信息
- `_node_to_entry` 不含 `creator` / `owner` 字段
- `fetch_url` 是唯一的 URL 入口，不在 `__public_apis__` 中

## After

- `ls(url_or_path)` 支持裸飞书 URL、`~link/<encoded>`、`~node/<token>`、标题路径
- `read_bytes(path, include_references=False)` 支持 `include_references=True` 时在正文末尾追加 `lazyllm-feishu-references` 附录
- `info(url_or_path)` 同样支持裸 URL / `~node` 路径，返回含 `creator`/`owner` 的节点元数据
- `_node_to_entry` 新增 `creator`/`owner`/`node_creator` 字段
- `fetch_url` 改为薄包装（deprecated），文档引导使用 `read_bytes`
- `client.py` 的 `read_bytes` 增加 `**kwargs` 透传

---

# ⚠️ 注意事项 / Additional Notes

- `include_references` 默认 `False`，与现有行为完全兼容，不影响已有测试
- `FeishuWikiFS.__public_apis__` 未变更，与 `LazyLLMFSBase` 保持一致
- docx 直链（非 wiki 节点）调用 `ls` 会抛 `ValueError`，避免 Agent 误判
- 引用抽取仅针对 `doc`/`docx` 类型节点，不预拉取被引用文档正文

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：** Cursor

---

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```
@feishuwikifs_子文档与引用_ea336c50.plan.md (1-232)
请按计划执行，注意参考 @.cursor/rules/coding-standards.mdc
```

## AI 初始输出质量 / Initial Output Quality

- [ ] 一次正确 / Correct on first try
- [x] 部分正确 / Partially correct
- [ ] 基本不可用 / Mostly unusable

## 问题点 / Issues

1. 第一次 `StrReplace` 替换 `_resolve_path_to_token` 时，误将 `_feishu_acquire_access_token` 的 `def` 行一并替换，导致语法错误（函数定义缺失 `def` 关键字）
2. `ls` 对 docx 直链的 `ValueError` 判断逻辑初版有误（允许了 `obj_type='docx'` 的情况），导致 1 个测试失败

---

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**操作：** 发现 `_feishu_acquire_access_token` 函数 `def` 行丢失，用 `StrReplace` 补回 `def _feishu_acquire_access_token(` 行

**原因：** AI 在替换 `_resolve_path_to_token` 结尾时，`old_string` 的边界恰好截断了下一个函数的 `def` 行

### 第二次修正 / Second Correction

**操作：** 修改 `ls` 中对 `docx` 直链的判断逻辑——改为在 `node_token` 为空且 `obj_type in ('docx', 'doc')` 时抛 `ValueError`

**原因：** 初版逻辑在白名单中保留了 `'docx'`，导致 `resolve_wiki_ref` 返回 `node_token=''` 时不报错而是返回空列表

### 最终策略总结 / Final Strategy Summary

整体由 AI 主导，人工主要做边界逻辑修正和 `StrReplace` 边界问题的修复。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

- AI 生成代码占比 / AI-generated code：`95%`
- 人工修改占比 / Human modifications：`5%`

**主要人工修改点 / Key Human Modifications：**

- 逻辑修正 / Logic fixes（`ls` 对 docx 直链的 ValueError 判断）
- 边界处理 / Edge case handling（`StrReplace` 边界导致的 `def` 行丢失修复）

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

（无独立失败 Prompt，问题源于工具调用边界）

### ❌ 问题表现 / Issue Description

`StrReplace` 的 `old_string` 边界跨越了两个函数的分界处，导致下一个函数的 `def` 行被截断，产生语法错误。

### ✅ 改进后 Prompt / Improved Prompt

在后续 `StrReplace` 中确保 `old_string` 不跨越函数边界，每次替换范围限定在单个函数内。

---

# 🧩 可复用经验 / Reusable Patterns

- **Prompt 模板：** 附上详细设计文档（plan.md）+ coding-standards 规则，AI 可直接按计划分步实现
- **常见坑：** `StrReplace` 的 `old_string` 需精确定位，避免跨函数边界；大文件分步替换优于整体重写
- **推荐做法：** 每步实现后立即运行测试，及时发现边界问题
