### PR TITLE
[Feature] Enable streaming tracing mechanism in agentic scenarios 

### DIFF
--- a/lazyllm/module/servermodule.py
+++ b/lazyllm/module/servermodule.py
@@ -171,7 +171,7 @@ class LLMBase(object):
               stream: Optional[Union[bool, Dict[str, str]]] = None, history: Optional[List[List[str]]] = None,
               copy_static_params: bool = False):
         new = copy.copy(self)
-        new._hooks = set()
+        new._hooks = self._hooks.copy()
         new._set_mid()
         if prompt is not None: new.prompt(prompt, history=history)
         if format is not None: new.formatter(format)

--- a/lazyllm/tools/rag/rank_fusion/reciprocal_rank_fusion.py
+++ b/lazyllm/tools/rag/rank_fusion/reciprocal_rank_fusion.py
@@ -30,7 +30,7 @@ class RRFFusion(ModuleBase):
                 continue
         return normalized_lists
 
-    def __call__(self, *args: Union[List[DocNode], List[List[DocNode]]]) -> list[DocNode]:
+    def forward(self, *args: Union[List[DocNode], List[List[DocNode]]]) -> list[DocNode]:
         # Reciprocal Rank Fusion on multiple rank lists. https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf
 
         # Associate each doc's content with its RRF score for later sorting by it

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -26,11 +26,11 @@ def _find_trace_path(storage_dir: Path, trace_id: str) -> Optional[Path]:
     return paths[0] if paths else None
 
 
-def _trace_path(storage_dir: Path, trace_id: str) -> Path:
+def _trace_path(storage_dir: Path, trace_id: str, timestamp: Optional[str] = None) -> Path:
     path = _find_trace_path(storage_dir, trace_id)
     if path is not None:
         return path
-    timestamp = datetime.now().strftime('%Y%m%d%H%M%S')
+    timestamp = timestamp or datetime.now().strftime('%Y%m%d%H%M%S')
     return storage_dir / f'{timestamp}_{trace_id}.jsonl'
 
 
@@ -43,12 +43,22 @@ def _strip_otel_id_prefix(value):
     return value[2:] if isinstance(value, str) and value.startswith('0x') else value
 
 
-def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> str:
+def _local_file_timestamp(otel_time: Any) -> Optional[str]:
+    if not isinstance(otel_time, str) or not otel_time:
+        return None
+    try:
+        text = otel_time.removesuffix('Z') + '+00:00' if otel_time.endswith('Z') else otel_time
+        return datetime.fromisoformat(text).astimezone().strftime('%Y%m%d%H%M%S')
+    except ValueError:
+        return None
+
+
+def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> tuple[str, Optional[str]]:
     raw = span.to_json(indent=None)
     payload = json.loads(raw)
     if not isinstance(payload, dict):
         raise TypeError(f'span.to_json() must return JSON object, got {type(payload).__name__}')
-    return json.dumps(payload, ensure_ascii=False)
+    return json.dumps(payload, ensure_ascii=False), _local_file_timestamp(payload.get('start_time'))
 
 
 def _choose_root_span(spans: List[RawSpanRecord]) -> Optional[RawSpanRecord]:
@@ -196,11 +206,15 @@ class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
             return SpanExportResult.FAILURE
 
         grouped: Dict[str, List[str]] = {}
+        timestamps: Dict[str, str] = {}
         try:
             for span in spans:
                 context = span.get_span_context()
                 trace_id = f'{context.trace_id:032x}'
-                grouped.setdefault(trace_id, []).append(_span_to_json_line(span))
+                line, timestamp = _span_to_json_line(span)
+                grouped.setdefault(trace_id, []).append(line)
+                if timestamp is not None:
+                    timestamps.setdefault(trace_id, timestamp)
         except Exception as exc:
             LOG.warning(f'LocalFileSpanExporter failed to serialize spans: {exc}')
             return SpanExportResult.FAILURE
@@ -208,7 +222,7 @@ class LocalFileSpanExporter(opentelemetry.sdk.trace.export.SpanExporter):
         try:
             for trace_id, lines in grouped.items():
                 with _trace_lock(self.storage_dir, trace_id):
-                    path = _trace_path(self.storage_dir, trace_id)
+                    path = _trace_path(self.storage_dir, trace_id, timestamps.get(trace_id))
                     with path.open('a', encoding='utf-8') as file_obj:
                         file_obj.writelines(f'{line}\n' for line in lines)
         except Exception as exc:

--- a/lazyllm/tracing/backends/local/backend.py
+++ b/lazyllm/tracing/backends/local/backend.py
@@ -1,7 +1,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from filelock import FileLock, Timeout
 
@@ -47,13 +47,13 @@ def _local_file_timestamp(otel_time: Any) -> Optional[str]:
     if not isinstance(otel_time, str) or not otel_time:
         return None
     try:
-        text = otel_time.removesuffix('Z') + '+00:00' if otel_time.endswith('Z') else otel_time
+        text = otel_time[:-1] + '+00:00' if otel_time.endswith('Z') else otel_time
         return datetime.fromisoformat(text).astimezone().strftime('%Y%m%d%H%M%S')
     except ValueError:
         return None
 
 
-def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> tuple[str, Optional[str]]:
+def _span_to_json_line(span: 'opentelemetry.sdk.trace.ReadableSpan') -> Tuple[str, Optional[str]]:
     raw = span.to_json(indent=None)
     payload = json.loads(raw)
     if not isinstance(payload, dict):

--- a/lazyllm/tracing/collect/runtime.py
+++ b/lazyllm/tracing/collect/runtime.py
@@ -4,6 +4,7 @@ import functools
 import inspect
 import json
 import threading
+from contextlib import ExitStack, contextmanager, nullcontext
 from typing import Any, Dict, Optional
 
 from lazyllm.common import LOG
@@ -217,8 +218,10 @@ class TracingRuntime:
                     f'(trace_id={ctx.trace_id!r}, parent_span_id={ctx.parent_span_id!r}): {exc}'
                 )
 
-        span_cm = self._tracer.start_as_current_span(span_name, context=parent_context)
-        otel_span = span_cm.__enter__()
+        span_cm = ExitStack()
+        otel_span = span_cm.enter_context(
+            self._tracer.start_as_current_span(span_name, context=parent_context, end_on_exit=False)
+        )
         span_context = otel_span.get_span_context()
         trace_id_hex = f'{span_context.trace_id:032x}'
         span_id_hex = f'{span_context.span_id:016x}'
@@ -400,7 +403,8 @@ class TracingRuntime:
             otel_span.set_status(status_cls(status_code.ERROR, str(span.error)))
             otel_span.record_exception(span.error)
 
-        span._otel_span_cm.__exit__(None, None, None)
+        _detach_span_context(span)
+        otel_span.end()
 
         if trace_matches:
             active_trace._record_span_end(span)
@@ -457,31 +461,79 @@ def _extract_trace_config(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return {k: kwargs.pop(k) for k in list(kwargs) if k in _TRACE_CONFIG_KEYS}
 
 
-def _wrap_asyncgen_with_trace(result, old_ctx: LazyTraceContext, stream_ctx: LazyTraceContext):
+def _detach_span_context(span):
+    span_cm = span._otel_span_cm if span else None
+    if span_cm is not None:
+        span_cm.close()
+        span._otel_span_cm = None
+
+
+@contextmanager
+def _stream_trace_scope(stream_ctx: LazyTraceContext, stream_trace, span):
+    old_ctx = get_trace_context()
+    old_trace = _current_trace.get()
+    span_cm = nullcontext()
+    set_trace_context(stream_ctx)
+    _current_trace.set(stream_trace)
+    if span:
+        span_cm = opentelemetry.trace.use_span(span._otel_span, end_on_exit=False)
+    try:
+        with span_cm:
+            yield
+    except Exception as e:
+        if span:
+            set_span_error(span, e)
+        raise
+    finally:
+        _current_trace.set(old_trace)
+        set_trace_context(old_ctx)
+
+
+def _finalize_stream_span(result, stream_ctx: LazyTraceContext, stream_trace, span):
+    if not span:
+        return
+    with _stream_trace_scope(stream_ctx, stream_trace, span):
+        if span.error is None:
+            set_span_output(span, {'stream': True, 'type': type(result).__name__})
+        finish_span(span)
+
+
+def _wrap_asyncgen_with_trace(result, stream_ctx: LazyTraceContext, stream_trace, span):
     async def wrapped():
-        set_trace_context(stream_ctx)
+        sentinel = object()
         try:
-            async for item in result:
+            while True:
+                with _stream_trace_scope(stream_ctx, stream_trace, span):
+                    item = await anext(result, sentinel)
+                if item is sentinel:
+                    return
                 yield item
         finally:
-            set_trace_context(old_ctx)
+            try:
+                with _stream_trace_scope(stream_ctx, stream_trace, span):
+                    await result.aclose()
+            finally:
+                _finalize_stream_span(result, stream_ctx, stream_trace, span)
     return wrapped()
 
 
-def _wrap_generator_with_trace(result, old_ctx: LazyTraceContext, stream_ctx: LazyTraceContext):
+def _wrap_generator_with_trace(result, stream_ctx: LazyTraceContext, stream_trace, span):
     def wrapped():
-        set_trace_context(stream_ctx)
+        sentinel = object()
         try:
-            yield from result
+            while True:
+                with _stream_trace_scope(stream_ctx, stream_trace, span):
+                    item = next(result, sentinel)
+                if item is sentinel:
+                    return
+                yield item
         finally:
-            set_trace_context(old_ctx)
+            try:
+                with _stream_trace_scope(stream_ctx, stream_trace, span):
+                    result.close()
+            finally:
+                _finalize_stream_span(result, stream_ctx, stream_trace, span)
     return wrapped()
-
-
-def _close_stream_span(span, result):
-    if span:
-        set_span_output(span, {'stream': True, 'type': type(result).__name__})
-        finish_span(span)
 
 
 def _run_with_trace(func, args, kwargs, trace_config):
@@ -493,6 +545,7 @@ def _run_with_trace(func, args, kwargs, trace_config):
     module_trace = trace_config.get('module_trace')
 
     old_ctx = get_trace_context()
+    old_trace = _current_trace.get()
     new_ctx_data = old_ctx.to_dict()
 
     new_ctx_data['trace_id'] = trace_id
@@ -518,16 +571,21 @@ def _run_with_trace(func, args, kwargs, trace_config):
 
     try:
         result = func(*args, **kwargs)
+        stream_wrapper = None
         if inspect.isasyncgen(result):
+            stream_wrapper = _wrap_asyncgen_with_trace
+        elif inspect.isgenerator(result):
+            stream_wrapper = _wrap_generator_with_trace
+
+        if stream_wrapper:
             stream_ctx = get_trace_context()
-            _close_stream_span(span, result)
+            stream_trace = _current_trace.get()
+            stream_span = span
+            _detach_span_context(span)
+            _current_trace.set(old_trace)
             span = None
-            return _wrap_asyncgen_with_trace(result, old_ctx, stream_ctx)
-        if inspect.isgenerator(result):
-            stream_ctx = get_trace_context()
-            _close_stream_span(span, result)
-            span = None
-            return _wrap_generator_with_trace(result, old_ctx, stream_ctx)
+            return stream_wrapper(result, stream_ctx, stream_trace, stream_span)
+
         if span:
             set_span_output(span, result)
         return result

--- a/lazyllm/tracing/collect/runtime.py
+++ b/lazyllm/tracing/collect/runtime.py
@@ -1,6 +1,7 @@
 import atexit
 import contextvars
 import functools
+import inspect
 import json
 import threading
 from typing import Any, Dict, Optional
@@ -456,6 +457,33 @@ def _extract_trace_config(kwargs: Dict[str, Any]) -> Dict[str, Any]:
     return {k: kwargs.pop(k) for k in list(kwargs) if k in _TRACE_CONFIG_KEYS}
 
 
+def _wrap_asyncgen_with_trace(result, old_ctx: LazyTraceContext, stream_ctx: LazyTraceContext):
+    async def wrapped():
+        set_trace_context(stream_ctx)
+        try:
+            async for item in result:
+                yield item
+        finally:
+            set_trace_context(old_ctx)
+    return wrapped()
+
+
+def _wrap_generator_with_trace(result, old_ctx: LazyTraceContext, stream_ctx: LazyTraceContext):
+    def wrapped():
+        set_trace_context(stream_ctx)
+        try:
+            yield from result
+        finally:
+            set_trace_context(old_ctx)
+    return wrapped()
+
+
+def _close_stream_span(span, result):
+    if span:
+        set_span_output(span, {'stream': True, 'type': type(result).__name__})
+        finish_span(span)
+
+
 def _run_with_trace(func, args, kwargs, trace_config):
     trace_id = trace_config.get('trace_id')
     parent_span_id = trace_config.get('parent_span_id')
@@ -490,6 +518,16 @@ def _run_with_trace(func, args, kwargs, trace_config):
 
     try:
         result = func(*args, **kwargs)
+        if inspect.isasyncgen(result):
+            stream_ctx = get_trace_context()
+            _close_stream_span(span, result)
+            span = None
+            return _wrap_asyncgen_with_trace(result, old_ctx, stream_ctx)
+        if inspect.isgenerator(result):
+            stream_ctx = get_trace_context()
+            _close_stream_span(span, result)
+            span = None
+            return _wrap_generator_with_trace(result, old_ctx, stream_ctx)
         if span:
             set_span_output(span, result)
         return result

--- a/lazyllm/tracing/collect/runtime.py
+++ b/lazyllm/tracing/collect/runtime.py
@@ -3,6 +3,7 @@ import contextvars
 import functools
 import inspect
 import json
+import secrets
 import threading
 from contextlib import ExitStack, contextmanager, nullcontext
 from typing import Any, Dict, Optional
@@ -21,6 +22,7 @@ from .trace_config import collect_trace_config, resolve_semantic_type_for_target
 _TRACE_SERVICE_NAME = 'lazyllm'
 _current_trace: 'contextvars.ContextVar[Optional[LazyTrace]]' = contextvars.ContextVar(
     '_lazyllm_current_trace', default=None)
+_ZERO_SPAN_ID = '0' * 16
 
 
 def current_trace() -> Optional[LazyTrace]:
@@ -158,6 +160,21 @@ class TracingRuntime:
             return None
         return getattr(target, '_flow_id', None)
 
+    @staticmethod
+    def _synthetic_parent_span_id() -> str:
+        span_id = secrets.token_hex(8)
+        return span_id if span_id != _ZERO_SPAN_ID else '0000000000000001'
+
+    @staticmethod
+    def _span_context(*, trace_id: str, span_id: str, sampled: Optional[bool], is_remote: bool):
+        trace_flags_value = 0x00 if sampled is False else 0x01
+        return opentelemetry.trace.SpanContext(
+            trace_id=int(trace_id, 16),
+            span_id=int(span_id, 16),
+            is_remote=is_remote,
+            trace_flags=opentelemetry.trace.TraceFlags(trace_flags_value),
+        )
+
     def _populate_identity(
         self,
         span: LazySpan,
@@ -200,12 +217,11 @@ class TracingRuntime:
         if is_root_span and ctx.trace_id and ctx.parent_span_id:
             try:
                 # Reattach to the caller-provided parent context when enable_trace resumes an existing trace.
-                trace_flags_value = 0x00 if ctx.sampled is False else 0x01
-                parent_sc = opentelemetry.trace.SpanContext(
-                    trace_id=int(ctx.trace_id, 16),
-                    span_id=int(ctx.parent_span_id, 16),
+                parent_sc = self._span_context(
+                    trace_id=ctx.trace_id,
+                    span_id=ctx.parent_span_id,
+                    sampled=ctx.sampled,
                     is_remote=False,
-                    trace_flags=opentelemetry.trace.TraceFlags(trace_flags_value),
                 )
                 parent_context = opentelemetry.trace.set_span_in_context(
                     opentelemetry.trace.NonRecordingSpan(parent_sc)
@@ -217,6 +233,19 @@ class TracingRuntime:
                     f'Failed to reconstruct parent SpanContext '
                     f'(trace_id={ctx.trace_id!r}, parent_span_id={ctx.parent_span_id!r}): {exc}'
                 )
+        elif is_root_span and ctx.trace_id:
+            try:
+                parent_sc = self._span_context(
+                    trace_id=ctx.trace_id,
+                    span_id=self._synthetic_parent_span_id(),
+                    sampled=ctx.sampled,
+                    is_remote=True,
+                )
+                parent_context = opentelemetry.trace.set_span_in_context(
+                    opentelemetry.trace.NonRecordingSpan(parent_sc)
+                )
+            except (ValueError, TypeError) as exc:
+                LOG.warning(f'Failed to start root trace with caller trace_id={ctx.trace_id!r}: {exc}')
 
         span_cm = ExitStack()
         otel_span = span_cm.enter_context(


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 修复 Tracing 模块的三个问题，涉及本地文件 trace 时间戳、generator/async generator 返回值支持、以及 `LLMBase.share` 的 hooks 浅拷贝缺陷

---

# 🎯 问题背景 / Problem Context

- **本地 trace 文件时间戳不一致**：`LocalFileSpanExporter` 使用本地 `datetime.now()` 生成文件名时间戳，与 OpenTelemetry span 内部的 `start_time` 不一致，导致同一 trace 的文件名时间与实际发生时间有偏差，且在 batch 导出时多个 span 可能产生不同的本地时间戳。
- **traced 函数返回 generator 时 trace span 未正确关闭**：当被 `@trace` 装饰的函数返回 generator 或 async generator 时，span 在函数返回时就立即关闭了，但 generator 的实际消费还未开始，导致 trace 无法正确覆盖整个生命周期。
- **`LLMBase.share()` 丢失 hooks**：`share()` 使用 `copy.copy(self)` 创建浅拷贝，但随后将 `_hooks` 重置为空 `set()`，导致新实例丢失了父实例的所有 hooks。

---

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. 验证 `LLMBase.share()` 返回的新实例保留了父实例的 `_hooks`
2. 对返回 generator / async generator 的函数添加 `@trace` 装饰器，确认 span 在 generator 消费完毕后才关闭，且上下文正确切换
3. 使用 `LocalFileSpanExporter` 导出 span，检查生成的 trace 文件名时间戳与 span 的 `start_time` 一致

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
# generator 返回值现在能正确被 trace
@trace
def stream_response():
    for chunk in llm_stream():
        yield chunk  # span 在整个 generator 消费期间保持活跃
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# LLMBase.share — hooks 被清空
new._hooks = set()

# _trace_path — 始终使用本地时间
timestamp = datetime.now().strftime('%Y%m%d%H%M%S')

# _run_with_trace — generator 返回时未处理
result = func(*args, **kwargs)
if span:
    set_span_output(span, result)
return result
```

## After

```python
# LLMBase.share — 浅拷贝 hooks
new._hooks = self._hooks.copy()

# _trace_path — 优先使用 OTel span 内的 start_time
timestamp = timestamp or datetime.now().strftime('%Y%m%d%H%M%S')

# _run_with_trace — 包装 generator/async generator
result = func(*args, **kwargs)
if inspect.isasyncgen(result):
    ...
if inspect.isgenerator(result):
    ...
```

# ⚠️ 注意事项 / Additional Notes

* generator 包装逻辑通过 `inspect.isgenerator` / `inspect.isasyncgen` 判断，不影响普通返回值的函数
* 本地 trace 文件名时间戳回退机制：若 span 无 `start_time` 则仍使用 `datetime.now()`

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
```

## AI 初始输出质量 / Initial Output Quality

* [ ] 一次正确 / Correct on first try
* [x] 部分正确 / Partially correct
* [ ] 基本不可用 / Mostly unusable

*

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`80%`
* 人工修改占比 / Human modifications：`%`

**主要人工修改点 / Key Human Modifications：**

* [x] 逻辑修正 / Logic fixes
* [ ] 边界处理 / Edge case handling
* [ ] 性能优化 / Performance optimization
* [x] 代码风格 / Code style
* [ ] 架构调整 / Architecture adjustments
