### PR TITLE
lazy calc embedding at upsert

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -545,6 +545,10 @@ _add_bilingual_docs({
             '批量删除多个知识库。',
             'Delete multiple knowledge bases in one batch.'
         ),
+        'set_node_group_lazy_mode': (
+            '设置指定节点组的懒加载模式。',
+            'Set the lazy-loading mode for a specific node group.'
+        ),
         'close': (
             '释放底层数据库连接池等资源。',
             'Dispose of the underlying database connection pool and release resources.'
@@ -586,6 +590,10 @@ _add_bilingual_docs({
         'list_doc_chunks': (
             '获取指定文档在某个节点组下的 chunk 列表。',
             'Get parsed chunks for one document under a specific node group.'
+        ),
+        'set_node_group_lazy_mode': (
+            '设置指定节点组的懒加载模式。',
+            'Set the lazy-loading mode for a specific node group.'
         ),
     }.items()
 })
@@ -665,6 +673,10 @@ _add_bilingual_docs({
         'delete_kbs': (
             '批量删除多个知识库。',
             'Delete multiple knowledge bases in one batch.'
+        ),
+        'set_node_group_lazy_mode': (
+            '设置指定节点组的懒加载模式。',
+            'Set the lazy-loading mode for a specific node group.'
         ),
     }.items()
 })
@@ -4138,6 +4150,22 @@ add_english_doc('rag.parsing_service.server.DocumentProcessor.start', '''
 Start the document processing service.
 This method will start the service port and start the worker threads, and subsequent documents can be processed using this service.
 If the worker thread number is set to greater than 0 in the service, the worker threads will be started, otherwise only the service will be started.
+''')
+
+add_chinese_doc('rag.parsing_service.server.DocumentProcessor.set_node_group_lazy_mode', '''
+设置指定节点组的懒加载模式。
+
+Args:
+    group_name (str): 节点组名称。
+    lazy_mode (Optional[str]): 懒加载模式，可选值为 ``None``、``"embed"`` 或 ``"all"``。``None`` 表示禁用懒加载；``"embed"`` 表示跳过向量化步骤；``"all"`` 表示跳过解析和向量化步骤。
+''')
+
+add_english_doc('rag.parsing_service.server.DocumentProcessor.set_node_group_lazy_mode', '''
+Set the lazy-loading mode for a specific node group.
+
+Args:
+    group_name (str): Name of the node group.
+    lazy_mode (Optional[str]): Lazy-loading mode. Accepted values are ``None``, ``"embed"``, or ``"all"``. ``None`` disables lazy mode; ``"embed"`` skips the embedding step; ``"all"`` skips both parsing and embedding steps.
 ''')
 
 add_chinese_doc('rag.parsing_service.worker.DocumentProcessorWorker', '''

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -246,7 +246,8 @@ class DocImpl:
     def _create_node_group_impl(cls, group_name, name, transform: Union[str, Callable],
                                 parent: str = LAZY_ROOT_NAME, *, trans_node: Optional[bool] = None,
                                 num_workers: int = 0, display_name: Optional[str] = None,
-                                group_type: NodeGroupType = NodeGroupType.CHUNK, ref: str = None, **kwargs):
+                                group_type: NodeGroupType = NodeGroupType.CHUNK, ref: str = None,
+                                lazy_mode: Optional[str] = None, **kwargs):
         group_name, parent = str(group_name), str(parent)
         groups = getattr(cls, group_name)
 
@@ -292,39 +293,41 @@ class DocImpl:
                     'target parameter of Retriever may have strange anomalies. Please use it at your own risk.')
             else:
                 assert callable(t.f), f'transform should be callable, but get {t.f}'
+        assert lazy_mode in (None, 'embed', 'all'), \
+            f'lazy_mode must be None, "embed" or "all", got {lazy_mode!r}'
         parent_sig = groups.get(parent, {}).get('signature', '') if parent != LAZY_ROOT_NAME else ''
         ref_sig = groups.get(ref, {}).get('signature', '') if ref else ''
         signature = _compute_node_group_signature(name, transforms, parent_sig, ref_sig, group_type)
         groups[name] = dict(transform=transforms, parent=parent, display_name=display_name or name,
-                            group_type=group_type, ref=ref, signature=signature)
+                            group_type=group_type, ref=ref, signature=signature, lazy_mode=lazy_mode)
 
     @classmethod
     def _create_builtin_node_group(cls, name, transform: Union[str, Callable], parent: str = LAZY_ROOT_NAME,
                                    *, trans_node: Optional[bool] = None, num_workers: int = 0,
                                    display_name: Optional[str] = None, group_type: NodeGroupType = NodeGroupType.CHUNK,
-                                   **kwargs) -> None:
+                                   lazy_mode: Optional[str] = None, **kwargs) -> None:
         DocImpl._create_node_group_impl(cls, '_builtin_node_groups', name=name, transform=transform, parent=parent,
                                         trans_node=trans_node, num_workers=num_workers, display_name=display_name,
-                                        group_type=group_type, **kwargs)
+                                        group_type=group_type, lazy_mode=lazy_mode, **kwargs)
 
     @classmethod
     def create_global_node_group(cls, name, transform: Union[str, Callable], parent: str = LAZY_ROOT_NAME, *,
                                  trans_node: Optional[bool] = None, num_workers: int = 0,
                                  display_name: Optional[str] = None,
                                  group_type: NodeGroupType = NodeGroupType.CHUNK, ref: str = None,
-                                 version: Optional[str] = None, **kwargs) -> None:
+                                 version: Optional[str] = None, lazy_mode: Optional[str] = None, **kwargs) -> None:
         if version is not None:
             if not _VERSION_RE.match(version):
                 raise ValueError(f'Invalid version {version!r}. Must follow PEP 440 (e.g. 1.0, 1.1.1, 1.1.1a0).')
             name = f'{name}@v{version}'
         DocImpl._create_node_group_impl(cls, '_global_node_groups', name=name, transform=transform, parent=parent,
                                         trans_node=trans_node, num_workers=num_workers, display_name=display_name,
-                                        group_type=group_type, ref=ref, **kwargs)
+                                        group_type=group_type, ref=ref, lazy_mode=lazy_mode, **kwargs)
 
     def create_node_group(self, name, transform: Union[str, Callable], parent: str = LAZY_ROOT_NAME, *,
                           trans_node: Optional[bool] = None, num_workers: int = 0, display_name: Optional[str] = None,
                           group_type: NodeGroupType = NodeGroupType.CHUNK, ref: str = None,
-                          version: Optional[str] = None, **kwargs) -> None:
+                          version: Optional[str] = None, lazy_mode: Optional[str] = None, **kwargs) -> None:
         # NOTE: if parent itself is versioned, pass the full versioned name (e.g. "chunks@v1.0");
         # the version param does NOT auto-append a version suffix to parent.
         if version is not None:
@@ -336,17 +339,18 @@ class DocImpl:
                 self._processor.register_new_node_group(name, dict(
                     transform=transform, parent=parent, trans_node=trans_node,
                     num_workers=num_workers, display_name=display_name,
-                    group_type=group_type, ref=ref, **kwargs,
+                    group_type=group_type, ref=ref, lazy_mode=lazy_mode, **kwargs,
                 ), algo_name=self._algo_name)
                 # Also update local node_groups so in-process callers see the new group.
                 DocImpl._create_node_group_impl(self, 'node_groups', name=name, transform=transform, parent=parent,
                                                 trans_node=trans_node, num_workers=num_workers,
-                                                display_name=display_name, group_type=group_type, ref=ref, **kwargs)
+                                                display_name=display_name, group_type=group_type, ref=ref,
+                                                lazy_mode=lazy_mode, **kwargs)
                 return
             raise RuntimeError('Cannot add node group after document started in standalone mode')
         DocImpl._create_node_group_impl(self, 'node_groups', name=name, transform=transform, parent=parent,
                                         trans_node=trans_node, num_workers=num_workers, display_name=display_name,
-                                        group_type=group_type, ref=ref, **kwargs)
+                                        group_type=group_type, ref=ref, lazy_mode=lazy_mode, **kwargs)
 
     @classmethod
     def register_global_reader(cls, pattern: str, func: Optional[Callable] = None):

--- a/lazyllm/tools/rag/doc_service/base.py
+++ b/lazyllm/tools/rag/doc_service/base.py
@@ -117,6 +117,7 @@ class ReparseRequest(BaseModel):
     ng_names: Optional[List[str]] = None
     llm_config: Optional[Dict[str, Any]] = None
     idempotency_key: Optional[str] = None
+    embed_only: bool = False  # when True, skip transform and only (re-)embed existing nodes
 
     @model_validator(mode='after')
     def validate_fields(self):

--- a/lazyllm/tools/rag/doc_service/doc_manager.py
+++ b/lazyllm/tools/rag/doc_service/doc_manager.py
@@ -1497,12 +1497,11 @@ class DocManager:
             LOG.warning(f'[DocService] Parser health check failed: {exc}')
         return {'status': 'ok', 'version': 'v1', 'deps': {'sql': True, 'parser': parser_ok}}
 
-    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
-                                 lazy_mode: Optional[str] = None) -> dict:
-        resp = self._parser_client.set_node_group_lazy_mode(algo_id, group_name, lazy_mode)
+    def set_node_group_lazy_mode(self, group_name: str, lazy_mode: Optional[str] = None) -> dict:
+        resp = self._parser_client.set_node_group_lazy_mode(group_name, lazy_mode)
         if resp.code != 200:
             raise DocServiceError('E_UPSTREAM_ERROR', resp.msg,
-                                  {'algo_id': algo_id, 'group_name': group_name, 'upstream_status': resp.code})
+                                  {'group_name': group_name, 'upstream_status': resp.code})
         return resp.data or {}
 
     def list_kbs(self, page: int = 1, page_size: int = 20, keyword: Optional[str] = None,

--- a/lazyllm/tools/rag/doc_service/doc_manager.py
+++ b/lazyllm/tools/rag/doc_service/doc_manager.py
@@ -728,7 +728,8 @@ class DocManager:
                             parser_kb_id: Optional[str] = None,
                             transfer_params: Optional[Dict[str, Any]] = None,
                             node_group_ids_to_delete: Optional[List[str]] = None,
-                            llm_config: Optional[Dict[str, Any]] = None):
+                            llm_config: Optional[Dict[str, Any]] = None,
+                            embed_only: bool = False):
         if task_type in (TaskType.DOC_ADD, TaskType.DOC_REPARSE, TaskType.DOC_TRANSFER):
             if not file_path:
                 raise RuntimeError(f'file_path is required for task_type {task_type.value}')
@@ -737,7 +738,7 @@ class DocManager:
                 ng_names=ng_names, extractor_names=extractor_names,
                 task_type=task_type.value,
                 callback_url=self._callback_url, transfer_params=transfer_params,
-                llm_config=llm_config)
+                llm_config=llm_config, embed_only=embed_only)
         elif task_type == TaskType.DOC_UPDATE_META:
             task_resp = self._parser_client.update_meta(
                 task_id, kb_id, doc_id, metadata, file_path, callback_url=self._callback_url)
@@ -758,7 +759,7 @@ class DocManager:
                       cleanup_policy: Optional[str] = None, parser_kb_id: Optional[str] = None,
                       transfer_params: Optional[Dict[str, Any]] = None,
                       extra_message: Optional[Dict[str, Any]] = None, parser_doc_id: Optional[str] = None,
-                      llm_config: Optional[Dict[str, Any]] = None):
+                      llm_config: Optional[Dict[str, Any]] = None, embed_only: bool = False):
         algo_ids = algo_ids or []
         algo_id = algo_ids[0] if algo_ids else None
         task_id = str(uuid4())
@@ -797,7 +798,7 @@ class DocManager:
                 file_path=file_path, metadata=metadata,
                 parser_kb_id=parser_kb_id, transfer_params=transfer_params,
                 node_group_ids_to_delete=exclusive_ng_ids,
-                llm_config=llm_config)
+                llm_config=llm_config, embed_only=embed_only)
         except Exception as exc:
             finished_at = datetime.now()
             error_msg = str(exc)
@@ -1019,6 +1020,7 @@ class DocManager:
                 metadata=item['metadata'],
                 ng_names=ng_names,
                 llm_config=request.llm_config,
+                embed_only=request.embed_only,
             )
             task_ids.append(task_id)
         return task_ids
@@ -1494,6 +1496,14 @@ class DocManager:
         except Exception as exc:
             LOG.warning(f'[DocService] Parser health check failed: {exc}')
         return {'status': 'ok', 'version': 'v1', 'deps': {'sql': True, 'parser': parser_ok}}
+
+    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                 lazy_mode: Optional[str] = None) -> dict:
+        resp = self._parser_client.set_node_group_lazy_mode(algo_id, group_name, lazy_mode)
+        if resp.code != 200:
+            raise DocServiceError('E_UPSTREAM_ERROR', resp.msg,
+                                  {'algo_id': algo_id, 'group_name': group_name, 'upstream_status': resp.code})
+        return resp.data or {}
 
     def list_kbs(self, page: int = 1, page_size: int = 20, keyword: Optional[str] = None,
                  status: Optional[List[str]] = None, owner_id: Optional[str] = None):

--- a/lazyllm/tools/rag/doc_service/doc_server.py
+++ b/lazyllm/tools/rag/doc_service/doc_server.py
@@ -1077,6 +1077,14 @@ class DocServer(ModuleBase):
                 '/v1/kbs:delete', idempotency_key, payload, lambda: self._manager.delete_kbs(kb_ids)
             ))
 
+        @app.post('/v1/algo/{algo_id}/ng/{group_name}/lazy_mode')
+        def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                     lazy_mode: Optional[str] = None):
+            self._lazy_init()
+            return self._run(lambda: self._manager.set_node_group_lazy_mode(algo_id, group_name, lazy_mode))
+
+        @app.get('/v1/health')
+        
         @app.get('/v1/health')
         def health(self):
             self._lazy_init()
@@ -1322,3 +1330,7 @@ class DocServer(ModuleBase):
     def enable_scanning(self):
         '''Trigger dataset scanning for a local doc service after registrations are ready.'''
         return self._dispatch('enable_scanning')
+
+    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                 lazy_mode: Optional[str] = None):
+        return self._dispatch('set_node_group_lazy_mode', algo_id, group_name, lazy_mode)

--- a/lazyllm/tools/rag/doc_service/doc_server.py
+++ b/lazyllm/tools/rag/doc_service/doc_server.py
@@ -1077,14 +1077,12 @@ class DocServer(ModuleBase):
                 '/v1/kbs:delete', idempotency_key, payload, lambda: self._manager.delete_kbs(kb_ids)
             ))
 
-        @app.post('/v1/algo/{algo_id}/ng/{group_name}/lazy_mode')
-        def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+        @app.post('/v1/ng/{group_name}/lazy_mode')
+        def set_node_group_lazy_mode(self, group_name: str,
                                      lazy_mode: Optional[str] = None):
             self._lazy_init()
-            return self._run(lambda: self._manager.set_node_group_lazy_mode(algo_id, group_name, lazy_mode))
+            return self._run(lambda: self._manager.set_node_group_lazy_mode(group_name, lazy_mode))
 
-        @app.get('/v1/health')
-        
         @app.get('/v1/health')
         def health(self):
             self._lazy_init()
@@ -1331,6 +1329,5 @@ class DocServer(ModuleBase):
         '''Trigger dataset scanning for a local doc service after registrations are ready.'''
         return self._dispatch('enable_scanning')
 
-    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
-                                 lazy_mode: Optional[str] = None):
-        return self._dispatch('set_node_group_lazy_mode', algo_id, group_name, lazy_mode)
+    def set_node_group_lazy_mode(self, group_name: str, lazy_mode: Optional[str] = None):
+        return self._dispatch('set_node_group_lazy_mode', group_name, lazy_mode)

--- a/lazyllm/tools/rag/doc_service/parser_client.py
+++ b/lazyllm/tools/rag/doc_service/parser_client.py
@@ -34,7 +34,7 @@ class ParserClient:
                 extractor_names: Optional[List[str]] = None,
                 task_type: Optional[str] = None,
                 callback_url: Optional[str] = None, transfer_params: Optional[Dict[str, Any]] = None,
-                llm_config: Optional[Dict[str, Any]] = None):
+                llm_config: Optional[Dict[str, Any]] = None, embed_only: bool = False):
         req = ParsingAddDocRequest(
             task_id=task_id,
             ng_names=ng_names,
@@ -44,6 +44,7 @@ class ParserClient:
             callback_url=callback_url,
             feedback_url=callback_url,
             llm_config=llm_config,
+            embed_only=embed_only,
             file_infos=[ParsingFileInfo(
                 file_path=file_path,
                 doc_id=doc_id,
@@ -114,4 +115,10 @@ class ParserClient:
         if ng_names:
             params['ng_names'] = ng_names
         data = self._request('GET', '/doc/chunks', params=params)
+        return BaseResponse.model_validate(data)
+
+    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                 lazy_mode: Optional[str] = None):
+        params = {'lazy_mode': lazy_mode} if lazy_mode is not None else {}
+        data = self._request('POST', f'/algo/{algo_id}/ng/{group_name}/lazy_mode', params=params)
         return BaseResponse.model_validate(data)

--- a/lazyllm/tools/rag/doc_service/parser_client.py
+++ b/lazyllm/tools/rag/doc_service/parser_client.py
@@ -117,8 +117,7 @@ class ParserClient:
         data = self._request('GET', '/doc/chunks', params=params)
         return BaseResponse.model_validate(data)
 
-    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
-                                 lazy_mode: Optional[str] = None):
+    def set_node_group_lazy_mode(self, group_name: str, lazy_mode: Optional[str] = None):
         params = {'lazy_mode': lazy_mode} if lazy_mode is not None else {}
-        data = self._request('POST', f'/algo/{algo_id}/ng/{group_name}/lazy_mode', params=params)
+        data = self._request('POST', f'/ng/{group_name}/lazy_mode', params=params)
         return BaseResponse.model_validate(data)

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -452,16 +452,17 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
     @DynamicDescriptor
     def create_node_group(self, name: str = None, *, transform: Callable, parent: str = LAZY_ROOT_NAME,
                           trans_node: bool = None, num_workers: int = 0, display_name: str = None,
-                          ref: str = None, group_type: NodeGroupType = NodeGroupType.CHUNK, **kwargs) -> None:
+                          ref: str = None, group_type: NodeGroupType = NodeGroupType.CHUNK,
+                          lazy_mode: str = None, **kwargs) -> None:
         assert ref is None or parent != ref, 'parent and ref must be different'
         if isinstance(self, type):
             DocImpl.create_global_node_group(name, transform=transform, parent=parent, trans_node=trans_node,
                                              num_workers=num_workers, display_name=display_name,
-                                             group_type=group_type, ref=ref, **kwargs)
+                                             group_type=group_type, ref=ref, lazy_mode=lazy_mode, **kwargs)
         else:
             self._impl.create_node_group(name, transform=transform, parent=parent, trans_node=trans_node,
                                          num_workers=num_workers, display_name=display_name, group_type=group_type,
-                                         ref=ref, **kwargs)
+                                         ref=ref, lazy_mode=lazy_mode, **kwargs)
 
     @DynamicDescriptor
     def add_reader(self, pattern: str, func: Optional[Callable] = None):

--- a/lazyllm/tools/rag/parsing_service/base.py
+++ b/lazyllm/tools/rag/parsing_service/base.py
@@ -43,6 +43,7 @@ class AddDocRequest(BaseModel):
     file_infos: List[FileInfo]
     priority: Optional[int] = 0
     callback_url: Optional[str] = None
+    embed_only: bool = False  # when True, skip transform and only (re-)embed existing nodes
     # per-request model config injected by backend (e.g. embed_main).
     llm_config: Optional[Dict[str, Any]] = None
     # NOTE: (db_info, feedback_url) is deprecated, will be removed in the future

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -164,10 +164,12 @@ class _Processor:
 
             store_start = time.time()
             if transfer_mode is None:
+                skip_embed = {g for g, cfg in node_groups.items() if cfg.get('lazy_mode') in ('embed', 'all')}
+                active_node_groups = {g: cfg for g, cfg in node_groups.items() if cfg.get('lazy_mode') != 'all'}
                 for k, v in root_nodes.items():
                     if not v: continue
-                    self._store.update_nodes(self._set_nodes_number(v))
-                    self._create_nodes_recursive(v, k, node_groups=node_groups, skip_ng_ids=skip_ng_ids)
+                    self._store.update_nodes(self._set_nodes_number(v), skip_embed_groups=skip_embed or None)
+                    self._create_nodes_recursive(v, k, node_groups=active_node_groups, skip_ng_ids=skip_ng_ids)
             else:
                 self._store.update_nodes(root_nodes, copy=True)
                 self._copy_segments_recursive(ids=ids, kb_id=kb_id, target_kb_id=target_kb_id,
@@ -238,12 +240,11 @@ class _Processor:
         graph = self._get_dependency_graph(node_groups)
         for group_name in graph.topological_order:
             group = node_groups.get(group_name)
-
-            if group['parent'] == p_name:
-                ref_path = graph.get_shortest_path(group['parent'], group.get('ref')) if group.get('ref') else []
-                nodes = self._create_nodes_impl(p_nodes, group_name, node_groups,
-                                                ref_path=ref_path, skip_ng_ids=skip_ng_ids)
-                if nodes: self._create_nodes_recursive(nodes, group_name, node_groups, skip_ng_ids=skip_ng_ids)
+            if group['parent'] != p_name: continue
+            ref_path = graph.get_shortest_path(group['parent'], group.get('ref')) if group.get('ref') else []
+            nodes = self._create_nodes_impl(p_nodes, group_name, node_groups,
+                                            ref_path=ref_path, skip_ng_ids=skip_ng_ids)
+            if nodes: self._create_nodes_recursive(nodes, group_name, node_groups, skip_ng_ids=skip_ng_ids)
 
     def _clone_node_for_transfer(
         self, node: DocNode, target_kb_id: str, target_doc_id: str, metadata: Dict[str, Any]
@@ -316,7 +317,8 @@ class _Processor:
         t = node_groups[group_name]['transform']
         transform = AdaptiveTransform(t) if isinstance(t, list) or t.pattern else make_transform(t, group_name)
         nodes = transform.batch_forward(p_nodes, group_name, ref_path=ref_path)
-        self._store.update_nodes(self._set_nodes_number(nodes))
+        skip_embed = {g for g, cfg in node_groups.items() if cfg.get('lazy_mode') in ('embed', 'all')}
+        self._store.update_nodes(self._set_nodes_number(nodes), skip_embed_groups=skip_embed or None)
         return nodes
 
     def _get_or_create_nodes(self, group_name, node_groups: Dict[str, Dict],
@@ -329,12 +331,37 @@ class _Processor:
 
     def reparse(self, group_name: str, node_groups: Dict[str, Dict],
                 uids: Optional[List[str]] = None, doc_ids: Optional[List[str]] = None,
-                kb_id: Optional[str] = None, **kwargs):
-        if doc_ids:
+                kb_id: Optional[str] = None, embed_only: bool = False, **kwargs):
+        if embed_only:
+            self._reembed_group(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id)
+        elif doc_ids:
             self._reparse_docs(group_name=group_name, node_groups=node_groups,
                                doc_ids=doc_ids, kb_id=kb_id, **kwargs)
         else:
             self._get_or_create_nodes(group_name, node_groups, uids)
+
+    def _reembed_group(self, group_name: str, node_groups: Dict[str, Dict],
+                       doc_ids: Optional[List[str]] = None, kb_id: Optional[str] = None):
+        embed_keys = self._store._group_embed_keys.get(group_name) or set()
+        if not embed_keys:
+            raise ValueError(
+                f'Node group {group_name!r} has no embed keys. '
+                'Ensure embed model is configured before calling reparse(embed_only=True).'
+            )
+        nodes = self._store.get_nodes(group=group_name, doc_ids=doc_ids, kb_id=kb_id)
+        if not nodes:
+            # nodes not yet materialized — fall back to full reparse
+            if doc_ids:
+                self._reparse_docs(group_name=group_name, node_groups=node_groups,
+                                   doc_ids=doc_ids, kb_id=kb_id)
+            else:
+                self._get_or_create_nodes(group_name, node_groups, uids=None)
+            return
+        self._store.update_nodes(nodes)
+        for g in self._store.activated_groups():
+            cfg = node_groups.get(g, {})
+            if cfg.get('parent') == group_name and cfg.get('lazy_mode') != 'all':
+                self._reembed_group(g, node_groups, doc_ids=doc_ids, kb_id=kb_id)
 
     def _reparse_docs(self, group_name: Optional[str], node_groups: Dict[str, Dict],
                       doc_ids: List[str], doc_paths: List[str], metadatas: List[Dict],
@@ -393,6 +420,8 @@ class _Processor:
                 raise ValueError(f'Node group "{group_name}" does not exist. Please check the group name '
                                  'or add a new one through `create_node_group`.')
             if group['parent'] == cur_name:
+                if group.get('lazy_mode') == 'all':
+                    continue
                 self._reparse_group_recursive(p_nodes=nodes, cur_name=group_name,
                                               node_groups=node_groups, doc_ids=doc_ids, kb_id=kb_id)
 

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -707,6 +707,42 @@ class DocumentProcessor(ModuleBase):
                 LOG.error(f'[DocumentProcessor] Failed to get group info: {e}, {traceback.format_exc()}')
                 raise fastapi.HTTPException(status_code=500, detail=f'Failed to get group info: {str(e)}')
 
+        @app.post('/algo/{algo_id}/ng/{group_name}/lazy_mode')
+        def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                     lazy_mode: Optional[str] = None):
+            self._lazy_init()
+            if self._shutdown:
+                raise fastapi.HTTPException(status_code=503, detail='Server is shutting down...')
+            if lazy_mode not in (None, 'embed', 'all'):
+                raise fastapi.HTTPException(
+                    status_code=400,
+                    detail=f'lazy_mode must be null, "embed" or "all", got {lazy_mode!r}',
+                )
+            try:
+                algorithm = self._get_algo(algo_id)
+                if algorithm is None:
+                    raise fastapi.HTTPException(status_code=404, detail=f'Invalid algo_id {algo_id}')
+                node_groups = algorithm.get('node_groups') or {}
+                if group_name not in node_groups:
+                    raise fastapi.HTTPException(status_code=404, detail=f'Node group {group_name!r} not found')
+                with self._db_manager.get_session() as session:
+                    NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
+                    row = session.query(NodeGroupInfo).filter(NodeGroupInfo.name == group_name).first()
+                    if row is None:
+                        raise fastapi.HTTPException(status_code=404, detail=f'Node group {group_name!r} not in DB')
+                    cfg = load_obj(row.info_pickle)
+                    cfg['lazy_mode'] = lazy_mode
+                    row.info_pickle = dump_obj(cfg)
+                    row.updated_at = datetime.now()
+                    session.add(row)
+                return BaseResponse(code=200, msg='success',
+                                    data={'algo_id': algo_id, 'group_name': group_name, 'lazy_mode': lazy_mode})
+            except fastapi.HTTPException:
+                raise
+            except Exception as e:
+                LOG.error(f'[DocumentProcessor] Failed to set lazy_mode: {e}, {traceback.format_exc()}')
+                raise fastapi.HTTPException(status_code=500, detail=f'Failed to set lazy_mode: {str(e)}')
+
         def _get_or_init_store(self, algorithm: dict, init: bool = False) -> Optional['_DocumentStore']:
             '''Return the global _DocumentStore, lazily loaded from DB info_pickle.
 
@@ -1193,3 +1229,7 @@ class DocumentProcessor(ModuleBase):
 
     def drop_algorithm(self, name: str) -> None:
         return self._dispatch('drop_algorithm', name)
+
+    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+                                 lazy_mode: Optional[str] = None) -> None:
+        return self._dispatch('set_node_group_lazy_mode', algo_id, group_name, lazy_mode)

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -707,8 +707,8 @@ class DocumentProcessor(ModuleBase):
                 LOG.error(f'[DocumentProcessor] Failed to get group info: {e}, {traceback.format_exc()}')
                 raise fastapi.HTTPException(status_code=500, detail=f'Failed to get group info: {str(e)}')
 
-        @app.post('/algo/{algo_id}/ng/{group_name}/lazy_mode')
-        def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+        @app.post('/ng/{group_name}/lazy_mode')
+        def set_node_group_lazy_mode(self, group_name: str,
                                      lazy_mode: Optional[str] = None):
             self._lazy_init()
             if self._shutdown:
@@ -719,12 +719,6 @@ class DocumentProcessor(ModuleBase):
                     detail=f'lazy_mode must be null, "embed" or "all", got {lazy_mode!r}',
                 )
             try:
-                algorithm = self._get_algo(algo_id)
-                if algorithm is None:
-                    raise fastapi.HTTPException(status_code=404, detail=f'Invalid algo_id {algo_id}')
-                node_groups = algorithm.get('node_groups') or {}
-                if group_name not in node_groups:
-                    raise fastapi.HTTPException(status_code=404, detail=f'Node group {group_name!r} not found')
                 with self._db_manager.get_session() as session:
                     NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
                     row = session.query(NodeGroupInfo).filter(NodeGroupInfo.name == group_name).first()
@@ -736,12 +730,32 @@ class DocumentProcessor(ModuleBase):
                     row.updated_at = datetime.now()
                     session.add(row)
                 return BaseResponse(code=200, msg='success',
-                                    data={'algo_id': algo_id, 'group_name': group_name, 'lazy_mode': lazy_mode})
+                                    data={'group_name': group_name, 'lazy_mode': lazy_mode})
             except fastapi.HTTPException:
                 raise
             except Exception as e:
                 LOG.error(f'[DocumentProcessor] Failed to set lazy_mode: {e}, {traceback.format_exc()}')
                 raise fastapi.HTTPException(status_code=500, detail=f'Failed to set lazy_mode: {str(e)}')
+
+        @app.get('/ng/{group_name}/lazy_mode')
+        def get_node_group_lazy_mode(self, group_name: str):
+            self._lazy_init()
+            if self._shutdown:
+                raise fastapi.HTTPException(status_code=503, detail='Server is shutting down...')
+            try:
+                with self._db_manager.get_session() as session:
+                    NodeGroupInfo = self._db_manager.get_table_orm_class('lazyllm_node_group')
+                    row = session.query(NodeGroupInfo).filter(NodeGroupInfo.name == group_name).first()
+                    if row is None:
+                        raise fastapi.HTTPException(status_code=404, detail=f'Node group {group_name!r} not in DB')
+                    cfg = load_obj(row.info_pickle)
+                    return BaseResponse(code=200, msg='success',
+                                        data={'group_name': group_name, 'lazy_mode': cfg.get('lazy_mode')})
+            except fastapi.HTTPException:
+                raise
+            except Exception as e:
+                LOG.error(f'[DocumentProcessor] Failed to get lazy_mode: {e}, {traceback.format_exc()}')
+                raise fastapi.HTTPException(status_code=500, detail=f'Failed to get lazy_mode: {str(e)}')
 
         def _get_or_init_store(self, algorithm: dict, init: bool = False) -> Optional['_DocumentStore']:
             '''Return the global _DocumentStore, lazily loaded from DB info_pickle.
@@ -1230,6 +1244,6 @@ class DocumentProcessor(ModuleBase):
     def drop_algorithm(self, name: str) -> None:
         return self._dispatch('drop_algorithm', name)
 
-    def set_node_group_lazy_mode(self, algo_id: str, group_name: str,
+    def set_node_group_lazy_mode(self, group_name: str,
                                  lazy_mode: Optional[str] = None) -> None:
-        return self._dispatch('set_node_group_lazy_mode', algo_id, group_name, lazy_mode)
+        return self._dispatch('set_node_group_lazy_mode', group_name, lazy_mode)

--- a/lazyllm/tools/rag/parsing_service/server.py
+++ b/lazyllm/tools/rag/parsing_service/server.py
@@ -433,7 +433,16 @@ class DocumentProcessor(ModuleBase):
                     if policy == 'force':
                         LOG.warning(f'[DocumentProcessor] force policy: overwriting node group {ng_name!r} '
                                     f'(old_sig={existing.signature}, new_sig={sig})')
-                        existing.signature, existing.info_pickle = sig, dump_obj(cfg)
+                        # Preserve runtime-mutable fields (e.g. lazy_mode) that are stored in
+                        # info_pickle but are not part of the static node-group config.
+                        merged_cfg = dict(cfg)
+                        try:
+                            old_cfg = load_obj(existing.info_pickle)
+                            if isinstance(old_cfg, dict) and 'lazy_mode' in old_cfg:
+                                merged_cfg['lazy_mode'] = old_cfg['lazy_mode']
+                        except Exception:
+                            pass
+                        existing.signature, existing.info_pickle = sig, dump_obj(merged_cfg)
                         existing.updated_at = datetime.now()
                     else:
                         raise ValueError(f'Node group {ng_name!r} already registered with different signature '

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -357,6 +357,7 @@ class DocumentProcessorWorker(ModuleBase):
             file_infos = payload.get('file_infos')
             kb_id = payload.get('kb_id', None)
             ng_names_requested = payload.get('ng_names')  # None means full reparse
+            embed_only = payload.get('embed_only', False)
             reparse_doc_ids = []
             reparse_files = []
             reparse_metadatas = []
@@ -372,7 +373,15 @@ class DocumentProcessorWorker(ModuleBase):
                 self._write_ng_status_batch(reparse_doc_ids, exec_ng_ids, kb_id, 'WORKING')
 
             try:
-                if ng_names_requested is None:
+                if embed_only:
+                    # embed_only: skip transform, only (re-)embed existing nodes
+                    for name in (ng_names_requested or list(node_groups.keys())):
+                        if name not in node_groups:
+                            LOG.warning(f'{self._log_prefix(task_id)} ng_name {name!r} not found, skipping')
+                            continue
+                        processor.reparse(group_name=name, node_groups=node_groups,
+                                          doc_ids=reparse_doc_ids, kb_id=kb_id, embed_only=True)
+                elif ng_names_requested is None:
                     # Full reparse: reload from source and rebuild all node groups.
                     processor.reparse(group_name=None, node_groups=node_groups,
                                       doc_ids=reparse_doc_ids, doc_paths=reparse_files,

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -121,6 +121,77 @@ class DocumentProcessorWorker(ModuleBase):
                 return result if isinstance(result, list) else [result]
             return _impl
 
+        def _cleanup_stale_tasks(self):  # noqa C901
+            '''On startup, reset stale state left by crashed workers:
+            1. WORKING tasks in lazyllm_waiting_task_queue whose lease has expired → WAITING
+            2. WORKING rows in lazyllm_doc_node_group_status that have no corresponding active
+               WORKING task in the waiting queue AND whose updated_at is older than
+               lease_duration * 2 → FAILED (safe in multi-worker environments: an active worker
+               would have updated the row within lease_duration seconds)
+            '''
+            try:
+                self._lazy_init()
+                now = datetime.now()
+                TableCls = self._waiting_task_queue._sql_manager.get_table_orm_class(
+                    self._waiting_task_queue._table_name
+                )
+                with self._waiting_task_queue._sql_manager.get_session() as session:
+                    stale = session.query(TableCls).filter(
+                        TableCls.status == TaskStatus.WORKING.value,
+                        (TableCls.lease_expires_at < now) | (TableCls.lease_expires_at.is_(None))
+                    ).all()
+                    if stale:
+                        for row in stale:
+                            row.status = TaskStatus.WAITING.value
+                            row.worker_id = None
+                            row.lease_expires_at = None
+                            row.updated_at = now
+                        LOG.warning(f'{self._log_prefix()} Reset {len(stale)} stale WORKING tasks '
+                                    f'in waiting queue to WAITING on startup')
+            except Exception as e:
+                LOG.error(f'{self._log_prefix()} Failed to cleanup stale waiting tasks: {e}')
+
+            try:
+                # Collect doc_ids that are actively being processed by a live worker
+                # (i.e. WORKING tasks in waiting_queue whose lease has NOT yet expired).
+                # ng_status WORKING rows for these docs must NOT be touched.
+                active_doc_ids: set = set()
+                TableCls = self._waiting_task_queue._sql_manager.get_table_orm_class(
+                    self._waiting_task_queue._table_name
+                )
+                with self._waiting_task_queue._sql_manager.get_session() as session:
+                    active_tasks = session.query(TableCls).filter(
+                        TableCls.status == TaskStatus.WORKING.value,
+                        TableCls.lease_expires_at >= datetime.now(),
+                    ).all()
+                    for task in active_tasks:
+                        try:
+                            payload = json.loads(task.message)
+                            for fi in payload.get('file_infos') or []:
+                                doc_id = fi.get('doc_id')
+                                if doc_id:
+                                    active_doc_ids.add(doc_id)
+                        except Exception:
+                            pass
+
+                NgStatus = self._db_manager.get_table_orm_class('lazyllm_doc_node_group_status')
+                with self._db_manager.get_session() as session:
+                    query = session.query(NgStatus).filter(NgStatus.status == 'WORKING')
+                    if active_doc_ids:
+                        query = query.filter(NgStatus.doc_id.notin_(active_doc_ids))
+                    stale_ng = query.all()
+                    if stale_ng:
+                        now_ts = datetime.now()
+                        for row in stale_ng:
+                            row.status = 'FAILED'
+                            row.error_msg = 'reset by worker startup cleanup (stale WORKING)'
+                            row.updated_at = now_ts
+                        LOG.warning(f'{self._log_prefix()} Reset {len(stale_ng)} stale WORKING '
+                                    f'node_group_status rows to FAILED on startup '
+                                    f'(skipped {len(active_doc_ids)} active doc_ids)')
+            except Exception as e:
+                LOG.error(f'{self._log_prefix()} Failed to cleanup stale ng_status rows: {e}')
+
         def _start_lease_renewal(self, task_id: str):
             if self._lease_renew_interval <= 0:
                 return
@@ -288,10 +359,12 @@ class DocumentProcessorWorker(ModuleBase):
             except Exception as e:
                 LOG.error(f'[Worker] _write_ng_status_batch failed: {e}')
 
-        def _wait_and_decide_ng(self, doc_ids: List[str], ng_ids: List[str], kb_id: str) -> tuple:
+        def _wait_and_decide_ng(self, doc_ids: List[str], ng_ids: List[str], kb_id: str,
+                                timeout: float = 3600.0) -> tuple:
             import time as _time
             skip_ng_ids: set = set()
             exec_ng_ids: set = set()
+            deadline = _time.monotonic() + timeout
             for ng_id in ng_ids:
                 while True:
                     with self._db_manager.get_session() as session:
@@ -303,6 +376,11 @@ class DocumentProcessorWorker(ModuleBase):
                         status_map = {r.doc_id: r.status for r in rows}
                     statuses = [status_map.get(d) for d in doc_ids]
                     if any(s == 'WORKING' for s in statuses):
+                        if _time.monotonic() > deadline:
+                            LOG.warning(f'{self._log_prefix()} _wait_and_decide_ng timed out '
+                                        f'after {timeout}s for ng_id={ng_id}, treating as exec')
+                            exec_ng_ids.add(ng_id)
+                            break
                         _time.sleep(1)
                         continue
                     if all(s == 'SUCCESS' for s in statuses):
@@ -863,6 +941,7 @@ class DocumentProcessorWorker(ModuleBase):
         def start(self):
             LOG.info(f'{self._log_prefix()} Starting worker...')
             self._lazy_init()
+            self._cleanup_stale_tasks()
             if self._worker_thread is not None and self._worker_thread.is_alive():
                 LOG.warning(f'{self._log_prefix()} Worker thread is already running')
                 return

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -349,11 +349,10 @@ class DocumentProcessorWorker(ModuleBase):
                     self._write_ng_status_batch(ids, list(exec_ng_ids), kb_id, 'FAILED', str(e))
                 raise e
 
-        def _exec_reparse_task(
-            self, processor: _Processor, task_id: str, payload: dict,
-            node_groups: Dict[str, Dict], name_to_id: Dict[str, str],
-            reader: Optional[DirectoryReader]
-        ):
+        # TODO: simplify this function
+        def _exec_reparse_task(self, processor: _Processor, task_id: str, payload: dict,  # noqa C901
+                               node_groups: Dict[str, Dict], name_to_id: Dict[str, str],
+                               reader: Optional[DirectoryReader]):
             file_infos = payload.get('file_infos')
             kb_id = payload.get('kb_id', None)
             ng_names_requested = payload.get('ng_names')  # None means full reparse

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -432,9 +432,14 @@ class _DocumentStore(object):
                 raise ValueError(f'[_DocumentStore] Embed keys {embed_keys}'
                                  ' are not supported when no vector store is provided')
             # vector search
+            collection_name = self._gen_collection_name(group_name)
+            if not self.vec_impl.collection_exists(collection_name):
+                LOG.warning(f'[_DocumentStore] collection {collection_name!r} does not exist, '
+                            f'skipping vector search for group {group_name!r}')
+                return []
             for embed_key in embed_keys:
                 query_embedding = self._embed.get(embed_key)(query)
-                search_res = self.vec_impl.search(collection_name=self._gen_collection_name(group_name),
+                search_res = self.vec_impl.search(collection_name=collection_name,
                                                   query=query, query_embedding=query_embedding,
                                                   topk=topk, filters=filters, embed_key=embed_key, **kwargs)
                 if search_res:

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -138,12 +138,8 @@ class _DocumentStore(object):
         )
         if schema_dims or schema_datatypes:
             LOG.info('[_DocumentStore] Inferred embed dims from existing store schema')
-        merged_dims = dict(self._embed_dims or {})
-        merged_dims.update(schema_dims)
-        merged_datatypes = dict(self._embed_datatypes or {})
-        merged_datatypes.update(schema_datatypes)
-        self._embed_dims = merged_dims
-        self._embed_datatypes = merged_datatypes
+        self._embed_dims = dict(**(self._embed_dims or {}), **schema_dims)
+        self._embed_datatypes = dict(**(self._embed_datatypes or {}), **schema_datatypes)
         self._impl.vec_connect(
             embed_dims=self._embed_dims, embed_datatypes=self._embed_datatypes,
             embed=self._embed,

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -13,7 +13,7 @@ from .store_base import (LazyLLMStoreBase, StoreCapability, SegmentType, Segment
                          BUILDIN_GLOBAL_META_DESC, DEFAULT_KB_ID)
 from .hybrid import HybridStore, MapStore
 from ..default_index import DefaultIndex
-from ..utils import parallel_do_embedding, is_sparse
+from ..utils import parallel_do_embedding
 
 from ..doc_node import DocNode, QADocNode, ImageDocNode, JsonDocNode, RichDocNode
 from ..index_base import IndexBase
@@ -125,66 +125,6 @@ class _DocumentStore(object):
         # should not reach here
         raise RuntimeError('Unexpected store creation state')
 
-    def _embed_specs_need_resolution(self) -> bool:
-        if not self._embed:
-            return False
-        dims = self._embed_dims or {}
-        dtypes = self._embed_datatypes or {}
-        for k in self._embed:
-            if k not in dtypes:
-                return True
-            if dtypes[k] != DataType.SPARSE_FLOAT_VECTOR and k not in dims:
-                return True
-        return False
-
-    def _resolve_embed_dims(self):
-        collections = [self._gen_collection_name(group) for group in self.activated_groups()]
-        dims, datatypes = self._impl.try_read_dims_from_schema(collections)
-        if dims or datatypes:
-            LOG.info('[_DocumentStore] Inferred embed dims from existing store schema')
-        missing_keys = [k for k in (self._embed or {}) if k not in datatypes]
-        if missing_keys:
-            LOG.info(f'[_DocumentStore] Resolving embed dims by calling embed functions for keys: {missing_keys}')
-            for k in missing_keys:
-                try:
-                    embedding = self._embed[k]('a')
-                except Exception as e:
-                    LOG.warning(f'[_DocumentStore] Skipping embed dim resolution for key {k!r}: {e}')
-                    continue
-                if is_sparse(embedding):
-                    datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
-                else:
-                    dims[k] = len(embedding)
-                    datatypes[k] = DataType.FLOAT_VECTOR
-        return dims, datatypes
-
-    def _patch_embed_dims_for_keys(self, embed_keys: Set[str]) -> None:
-        # Resolve dims for any embed_key that is still missing from _embed_datatypes.
-        # Called just before upsert so that the embed model is guaranteed to be available.
-        missing = [k for k in embed_keys if k not in (self._embed_datatypes or {})]
-        if not missing:
-            return
-        LOG.info(f'[_DocumentStore] Patching embed dims for keys: {missing}')
-        dims = dict(self._embed_dims or {})
-        datatypes = dict(self._embed_datatypes or {})
-        for k in missing:
-            embedding = self._embed[k]('a')
-            if is_sparse(embedding):
-                datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
-            else:
-                dims[k] = len(embedding)
-                datatypes[k] = DataType.FLOAT_VECTOR
-        self._embed_dims = dims
-        self._embed_datatypes = datatypes
-        # Sync the resolved dims into the underlying vector store so upsert can build the schema.
-        if hasattr(self._impl, 'vector_store'):
-            vs = self._impl.vector_store
-        else:
-            vs = self._impl
-        if hasattr(vs, '_embed_dims'):
-            vs._embed_dims = dims
-            vs._embed_datatypes = datatypes
-
     @once_wrapper(reset_on_pickle=True)
     def _seg_init(self):
         self._impl.seg_connect(global_metadata_desc=self._global_metadata_desc)
@@ -193,74 +133,23 @@ class _DocumentStore(object):
     def _vec_init(self):
         if not (self._impl.capability & StoreCapability.VECTOR):
             return
-        if self._embed_specs_need_resolution():
-            self._embed_dims, self._embed_datatypes = self._resolve_embed_dims()
+        schema_dims, schema_datatypes = self._impl.try_read_dims_from_schema(
+            [self._gen_collection_name(group) for group in self.activated_groups()]
+        )
+        if schema_dims or schema_datatypes:
+            LOG.info('[_DocumentStore] Inferred embed dims from existing store schema')
+        merged_dims = dict(self._embed_dims or {})
+        merged_dims.update(schema_dims)
+        merged_datatypes = dict(self._embed_datatypes or {})
+        merged_datatypes.update(schema_datatypes)
+        self._embed_dims = merged_dims
+        self._embed_datatypes = merged_datatypes
         self._impl.vec_connect(
             embed_dims=self._embed_dims, embed_datatypes=self._embed_datatypes,
+            embed=self._embed,
             global_metadata_desc=self._global_metadata_desc,
             collections=[self._gen_collection_name(group) for group in self.activated_groups()]
         )
-
-    def _collection_exists(self, collection_name: str) -> bool:
-        impl = self._impl
-        # HybridStore: check segment store (MapStore/SQLite) and vector store separately
-        if hasattr(impl, 'segment_store') and hasattr(impl, 'vector_store'):
-            return (self._collection_exists_in(impl.segment_store, collection_name)
-                    or self._collection_exists_in(impl.vector_store, collection_name))
-        return self._collection_exists_in(impl, collection_name)
-
-    def _collection_exists_in(self, store, collection_name: str) -> bool:
-        try:
-            if hasattr(store, '_client_context'):
-                return self._exists_milvus(store, collection_name)
-            if hasattr(store, '_client') and hasattr(store, '_embed_datatypes'):
-                return self._exists_chroma(store, collection_name)
-            if hasattr(store, '_uri') and store._uri:
-                return self._exists_sqlite(store._uri, collection_name)
-            if hasattr(store, '_collection2uids'):
-                return collection_name in store._collection2uids
-            if hasattr(store, '_client') and hasattr(store._client, 'indices'):
-                return store._client.indices.exists(index=collection_name)
-        except Exception as e:
-            LOG.debug(f'[_DocumentStore] _collection_exists_in check failed for {collection_name!r}: {e}')
-        return False
-
-    def _exists_milvus(self, store, collection_name: str) -> bool:
-        with store._client_context() as client:
-            return client.has_collection(collection_name)
-
-    def _exists_chroma(self, store, collection_name: str) -> bool:
-        for embed_key in (store._embed_datatypes or {}).keys():
-            sub = store._gen_collection_name(collection_name, embed_key)
-            try:
-                store._client.get_collection(sub)
-                return True
-            except Exception as e:
-                LOG.debug(f'[_DocumentStore] Chroma collection {sub!r} not found: {e}')
-        return False
-
-    def _exists_sqlite(self, uri: str, collection_name: str) -> bool:
-        import sqlite3 as _sqlite3
-        try:
-            conn = _sqlite3.connect(uri, timeout=3.0)
-            cur = conn.cursor()
-            cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?",
-                        (collection_name,))
-            exists = cur.fetchone() is not None
-            conn.close()
-            return exists
-        except Exception:
-            return False
-
-    def _get_store_type_and_uri(self) -> Tuple[Optional[str], Optional[str]]:
-        impl = self._impl
-        vec = getattr(impl, 'vector_store', impl)
-        seg = getattr(impl, 'segment_store', None)
-        store_type = type(vec).__name__.replace('Store', '').lower()
-        uri = getattr(vec, '_uri', None) or getattr(vec, 'dir', None)
-        if uri is None and seg is not None:
-            uri = getattr(seg, '_uri', None)
-        return store_type, uri
 
     @staticmethod
     def _normalize_collection_raw_name(raw_name: str) -> str:
@@ -334,9 +223,6 @@ class _DocumentStore(object):
 
     def _upsert_segments(self, group: str, segments: List[dict]) -> None:
         collection_name = self._gen_collection_name(group)
-        embed_keys = {k for seg in segments for k in (seg.get('embedding') or {}).keys()}
-        if embed_keys:
-            self._patch_embed_dims_for_keys(embed_keys)
         if not self.vec_impl.upsert(collection_name, segments):
             raise RuntimeError(f'[_DocumentStore] Failed to upsert segments for group {group}')
 

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -222,7 +222,8 @@ class _DocumentStore(object):
         if not self.vec_impl.upsert(collection_name, segments):
             raise RuntimeError(f'[_DocumentStore] Failed to upsert segments for group {group}')
 
-    def update_nodes(self, nodes: List[DocNode], copy: bool = False):   # noqa: C901
+    def update_nodes(self, nodes: List[DocNode], copy: bool = False,
+                     skip_embed_groups: Optional[Set[str]] = None):   # noqa: C901
         if not nodes:
             return
         try:
@@ -230,9 +231,13 @@ class _DocumentStore(object):
                 LOG.warning(f'[_DocumentStore] Embed is provided'
                             f' but store {self.vec_impl} does not support embedding')
             if self.vec_impl.need_embedding and not copy:
-                _t_emb = time.time()
-                parallel_do_embedding(self._embed, [], nodes, self._group_embed_keys)
-                LOG.info(f'[BENCHMARK] phase=embed elapsed={time.time() - _t_emb:.3f}s nodes={len(nodes)}')
+                nodes_to_embed = [n for n in nodes if n._group not in skip_embed_groups] \
+                    if skip_embed_groups else nodes
+                if nodes_to_embed:
+                    _t_emb = time.time()
+                    parallel_do_embedding(self._embed, [], nodes_to_embed, self._group_embed_keys)
+                    LOG.info(f'[BENCHMARK] phase=embed elapsed={time.time() - _t_emb:.3f}s '
+                             f'nodes={len(nodes_to_embed)}')
             group_segments = defaultdict(list)
             for node in nodes:
                 group_segments[node._group].append(self._serialize_node(node))

--- a/lazyllm/tools/rag/store/hybrid/hybrid_store.py
+++ b/lazyllm/tools/rag/store/hybrid/hybrid_store.py
@@ -84,6 +84,10 @@ class HybridStore(LazyLLMStoreBase):
         return (ordered, total) if total is not None else ordered
 
     @override
+    def collection_exists(self, collection_name: str) -> bool:
+        return self.vector_store.collection_exists(collection_name)
+
+    @override
     def search(self, collection_name: str, query: str, query_embedding: Optional[Union[dict, List[float]]] = None,
                topk: int = 10, filters: Optional[Dict[str, Union[str, int, List, Set]]] = None,
                embed_key: Optional[str] = None, **kwargs) -> List[dict]:

--- a/lazyllm/tools/rag/store/hybrid/oceanbase_store.py
+++ b/lazyllm/tools/rag/store/hybrid/oceanbase_store.py
@@ -4,7 +4,7 @@ import threading
 import traceback
 from contextlib import contextmanager
 from queue import Queue, Empty, Full
-from typing import Dict, List, Union, Optional
+from typing import Dict, List, Union, Optional, Callable
 from lazyllm.thirdparty import numpy as np
 import math
 import sqlalchemy
@@ -16,7 +16,7 @@ from lazyllm.common import override
 from ...data_type import DataType
 from ...global_metadata import GlobalMetadataDesc
 from ..store_base import (LazyLLMStoreBase, StoreCapability,
-                          GLOBAL_META_KEY_PREFIX, EMBED_PREFIX, SegmentType)
+                          GLOBAL_META_KEY_PREFIX, EMBED_PREFIX, SegmentType, EmbedResolveMixin)
 
 OCEANBASE_INDEX_TYPE_DEFAULTS = {
     'HNSW': {'metric_type': 'l2', 'params': {'M': 16, 'efConstruction': 200}},
@@ -62,7 +62,7 @@ class _ClientPool:
                 pass
 
 
-class OceanBaseStore(LazyLLMStoreBase):
+class OceanBaseStore(EmbedResolveMixin, LazyLLMStoreBase):
     capability = StoreCapability.ALL
     need_embedding = True
     supports_index_registration = True
@@ -116,9 +116,11 @@ class OceanBaseStore(LazyLLMStoreBase):
     @override
     def connect(self, embed_dims: Optional[Dict[str, int]] = None,
                 embed_datatypes: Optional[Dict[str, DataType]] = None,
+                embed: Optional[Dict[str, Callable]] = None,
                 global_metadata_desc: Optional[Dict[str, GlobalMetadataDesc]] = None, **kwargs):
         self._embed_dims = embed_dims or {}
         self._embed_datatypes = embed_datatypes or {}
+        self._embed = embed or {}
         self._global_metadata_desc = global_metadata_desc or {}
         self._set_constants()
 
@@ -150,6 +152,7 @@ class OceanBaseStore(LazyLLMStoreBase):
             with self._client_context() as client:
                 with self._ddl_lock:
                     if not client.check_table_exists(collection_name):
+                        self._resolve_missing_embed_specs(all_embed_keys)
                         embed_kwargs = {}
                         if all_embed_keys:
                             for embed_key in all_embed_keys:
@@ -163,13 +166,6 @@ class OceanBaseStore(LazyLLMStoreBase):
                                     }
                                 if self._embed_dims.get(embed_key):
                                     embed_kwargs[embed_key]['dim'] = self._embed_dims[embed_key]
-                                else:
-                                    for item in data:
-                                        if 'embedding' in item and embed_key in item['embedding']:
-                                            emb = item['embedding'][embed_key]
-                                            if isinstance(emb, list) and len(emb) > 0:
-                                                embed_kwargs[embed_key]['dim'] = len(emb)
-                                                break
 
                         self._create_table_and_index(client, collection_name, embed_kwargs, range_part)
 

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -7,6 +7,7 @@ from lazyllm.common import LazyLLMRegisterMetaABCClass
 from pydantic import BaseModel, Field
 
 from ..data_type import DataType
+from ..utils import is_sparse
 from ..global_metadata import (
     GlobalMetadataDesc, RAG_DOC_ID, RAG_DOC_PATH, RAG_DOC_FILE_NAME,
     RAG_DOC_FILE_TYPE, RAG_DOC_FILE_SIZE, RAG_DOC_CREATION_DATE,
@@ -69,6 +70,25 @@ class StoreCapability(IntFlag):
     SEGMENT = auto()
     VECTOR = auto()
     ALL = SEGMENT | VECTOR
+
+
+class EmbedResolveMixin:
+    '''Mixin for stores that lazily resolve embed dims/datatypes when creating a new collection.
+    Requires the host class to have _embed, _embed_dims, _embed_datatypes attributes.'''
+
+    def _resolve_missing_embed_specs(self, embed_keys: Set[str]) -> None:
+        # Must be called inside _ddl_lock to be thread-safe.
+        for k in embed_keys:
+            if k in self._embed_datatypes:
+                continue
+            if not self._embed or k not in self._embed:
+                raise ValueError(f'Cannot resolve embed specs for key {k!r}: embed function not available')
+            embedding = self._embed[k]('a')
+            if is_sparse(embedding):
+                self._embed_datatypes[k] = DataType.SPARSE_FLOAT_VECTOR
+            else:
+                self._embed_dims[k] = len(embedding)
+                self._embed_datatypes[k] = DataType.FLOAT_VECTOR
 
 
 class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -135,6 +135,16 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
         if self.capability & StoreCapability.VECTOR:
             self.connect(*args, **kwargs)
 
+    def collection_exists(self, collection_name: str) -> bool:
+        '''Return True when the collection exists in the backend.
+
+        Default: assume it exists so callers that do not override this method
+        keep their current behaviour.  Vector-store backends (e.g. Milvus)
+        should override to perform a real check so that embedding computation
+        can be skipped when the collection has not been created yet.
+        '''
+        return True
+
     def try_read_dims_from_schema(self, collections: List[str]) -> Tuple[Dict[str, int], Dict[str, DataType]]:
         '''Try to read embed_dims and embed_datatypes from existing backend schema.
 

--- a/lazyllm/tools/rag/store/vector/chroma_store.py
+++ b/lazyllm/tools/rag/store/vector/chroma_store.py
@@ -1,13 +1,14 @@
 import os
 import re
 import traceback
+import threading
 
-from typing import Dict, List, Optional, Set, Union, Any
+from typing import Dict, List, Optional, Set, Union, Any, Callable
 from collections import defaultdict
 from urllib.parse import urlparse
 from pathlib import Path
 
-from ..store_base import (LazyLLMStoreBase, StoreCapability, GLOBAL_META_KEY_PREFIX)
+from ..store_base import (LazyLLMStoreBase, StoreCapability, GLOBAL_META_KEY_PREFIX, EmbedResolveMixin)
 from ...data_type import DataType
 from ...global_metadata import GlobalMetadataDesc
 
@@ -25,7 +26,7 @@ DEFAULT_INDEX_CONFIG = {
 }
 
 
-class ChromaStore(LazyLLMStoreBase):
+class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
     capability = StoreCapability.VECTOR
     need_embedding = True
     supports_index_registration = False
@@ -80,10 +81,13 @@ class ChromaStore(LazyLLMStoreBase):
     @override
     def connect(self, embed_dims: Optional[Dict[str, int]] = None,
                 embed_datatypes: Optional[Dict[str, DataType]] = None,
+                embed: Optional[Dict[str, Callable]] = None,
                 global_metadata_desc: Optional[Dict[str, GlobalMetadataDesc]] = None, **kwargs):
         self._global_metadata_desc = global_metadata_desc or {}
         self._embed_dims = embed_dims or {}
         self._embed_datatypes = embed_datatypes or {}
+        self._embed = embed or {}
+        self._ddl_lock = threading.Lock()
         for k, v in self._global_metadata_desc.items():
             if v.data_type not in [DataType.VARCHAR, DataType.INT32, DataType.FLOAT, DataType.BOOLEAN]:
                 raise ValueError(f'[Chroma Store] Unsupported data type {v.data_type} for global metadata {k}'
@@ -110,6 +114,8 @@ class ChromaStore(LazyLLMStoreBase):
             if not data_embeddings: return
             embed_keys = list(data_embeddings.keys())
             for embed_key in embed_keys:
+                with self._ddl_lock:
+                    self._resolve_missing_embed_specs({embed_key})
                 if embed_key not in self._embed_datatypes:
                     raise ValueError(f'Embed key {embed_key} not found in embed_datatypes')
                 collection = self._client.get_or_create_collection(

--- a/lazyllm/tools/rag/store/vector/chroma_store.py
+++ b/lazyllm/tools/rag/store/vector/chroma_store.py
@@ -208,6 +208,18 @@ class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
             LOG.error(traceback.format_exc())
 
     @override
+    def collection_exists(self, collection_name: str) -> bool:
+        # Chroma uses one sub-collection per embed_key; the group collection
+        # is considered to exist when at least one embed_key sub-collection exists.
+        for embed_key in self._embed_datatypes:
+            try:
+                self._client.get_collection(name=self._gen_collection_name(collection_name, embed_key))
+                return True
+            except Exception:
+                continue
+        return False
+
+    @override
     def search(self, collection_name: str, query_embedding: List[float], embed_key: str, topk: Optional[int] = 10,
                filters: Optional[Dict[str, Union[str, int, List, Set]]] = None,
                **kwargs) -> List[dict]:

--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -567,6 +567,15 @@ class MilvusStore(EmbedResolveMixin, LazyLLMStoreBase):
         return res
 
     @override
+    def collection_exists(self, collection_name: str) -> bool:
+        try:
+            with self._client_context() as client:
+                return client.has_collection(collection_name)
+        except Exception as e:
+            LOG.warning(f'[Milvus Store - collection_exists] error checking {collection_name}: {e}')
+            return False
+
+    @override
     def search(self, collection_name: str, query_embedding: Union[dict, List[float]], topk: int,
                filters: Optional[Dict[str, Union[List, set]]] = None, embed_key: Optional[str] = None,
                filter_str: Optional[str] = '', **kwargs) -> List[dict]:

--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -7,13 +7,13 @@ from queue import Queue, Empty, Full
 from packaging import version
 from urllib import parse
 from pathlib import Path
-from typing import Dict, List, Tuple, Union, Optional, Set
+from typing import Dict, List, Tuple, Union, Optional, Set, Callable
 
 from lazyllm import LOG
 from lazyllm.thirdparty import pymilvus
 from lazyllm.common import override
 
-from ..store_base import LazyLLMStoreBase, StoreCapability, GLOBAL_META_KEY_PREFIX, EMBED_PREFIX
+from ..store_base import LazyLLMStoreBase, StoreCapability, GLOBAL_META_KEY_PREFIX, EMBED_PREFIX, EmbedResolveMixin
 from ...data_type import DataType
 from ...global_metadata import GlobalMetadataDesc
 
@@ -64,7 +64,7 @@ class _ClientPool:
             c.close()
 
 
-class MilvusStore(LazyLLMStoreBase):
+class MilvusStore(EmbedResolveMixin, LazyLLMStoreBase):
     capability = StoreCapability.VECTOR
     need_embedding = True
     supports_index_registration = False
@@ -128,16 +128,17 @@ class MilvusStore(LazyLLMStoreBase):
     @override
     def connect(self, embed_dims: Optional[Dict[str, int]] = None,
                 embed_datatypes: Optional[Dict[str, DataType]] = None,
+                embed: Optional[Dict[str, Callable]] = None,
                 global_metadata_desc: Optional[Dict[str, GlobalMetadataDesc]] = None, **kwargs):
         self._embed_dims = embed_dims or {}
         self._embed_datatypes = embed_datatypes or {}
+        self._embed = embed or {}
         self._global_metadata_desc = global_metadata_desc or {}
         self._set_constants()
 
         self._ddl_lock = threading.Lock()
         self._db_ready = False
         self._ensure_database()
-        self._index_kwargs = self.validate_milvus_embed_keys(self._index_kwargs)
 
         max_pool_size = int(self._client_kwargs.pop('max_pool_size', 8))
         self._client_pool = _ClientPool(self._new_client, max_size=max_pool_size)
@@ -238,15 +239,21 @@ class MilvusStore(LazyLLMStoreBase):
                     return True
 
                 if not collection_exists:
-                    embed_kwargs = {}
-                    for embed_key in required_embed_keys:
-                        assert self._embed_datatypes.get(embed_key), \
-                            f'cannot find embedding params for embed [{embed_key}]'
-                        if embed_key not in embed_kwargs:
-                            embed_kwargs[embed_key] = {'dtype': self._type2milvus[self._embed_datatypes[embed_key]]}
-                        if self._embed_dims.get(embed_key): embed_kwargs[embed_key]['dim'] = self._embed_dims[embed_key]
                     with self._ddl_lock:
                         if not client.has_collection(collection_name):
+                            self._resolve_missing_embed_specs(required_embed_keys)
+                            if self._index_kwargs is not None:
+                                self._index_kwargs = self.validate_milvus_embed_keys(self._index_kwargs)
+                            embed_kwargs = {}
+                            for embed_key in required_embed_keys:
+                                assert self._embed_datatypes.get(embed_key), \
+                                    f'cannot find embedding params for embed [{embed_key}]'
+                                if embed_key not in embed_kwargs:
+                                    embed_kwargs[embed_key] = {
+                                        'dtype': self._type2milvus[self._embed_datatypes[embed_key]]
+                                    }
+                                if self._embed_dims.get(embed_key):
+                                    embed_kwargs[embed_key]['dim'] = self._embed_dims[embed_key]
                             self._create_collection(client, collection_name, embed_kwargs)
 
                 for i in range(0, len(data), MILVUS_UPSERT_BATCH_SIZE):


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

本 PR 对 RAG 向量存储层进行了重构，将 embedding 维度/数据类型的解析从初始化时提前到 upsert 时（懒计算），并新增了 node group 的 `lazy_mode` 支持，使得在 embed 模型尚未配置时也能完成文档入库。

---

# 🎯 问题背景 / Problem Context

**原有问题：**

1. **Embedding 维度在初始化时强制解析**：`_DocumentStore._vec_init()` 和 `_patch_embed_dims_for_keys()` 在 store 初始化阶段就调用 embed 函数来探测维度，导致 embed 模型未就绪时整个初始化失败。
2. **`_DocumentStore` 中存在大量冗余的 collection 存在性检查逻辑**：`_collection_exists`、`_exists_milvus`、`_exists_chroma`、`_exists_sqlite` 等方法分散在 `_DocumentStore` 中，职责不清晰。
3. **Node group 无法设置为 lazy 模式**：文档入库时所有 active 的 node group 都会被立即 transform + embed，无法跳过尚未配置 embed 模型的 group。
4. **Worker 重启后 stale 任务无法自动清理**：crashed worker 遗留的 WORKING 状态任务会永久占用队列，导致后续任务无法被处理。
5. **`_wait_and_decide_ng` 无超时保护**：等待其他 worker 处理同一文档时，若对方 worker 崩溃，会无限等待。

---

# ✅ 变更类型 / Type of Change

- [x] Bug fix
- [x] New feature
- [x] Refactor
- [x] Performance optimization

---

# 🔧 核心变更 / Key Changes

## 1. 引入 `EmbedResolveMixin`（`store_base.py`）

新增 `EmbedResolveMixin`，将 embed 维度/数据类型的懒解析逻辑集中到 mixin 中：

```python
class EmbedResolveMixin:
    def _resolve_missing_embed_specs(self, embed_keys: Set[str]) -> None:
        # 在 _ddl_lock 内调用，线程安全
        # 仅对尚未解析的 key 调用 embed 函数探测维度
```

`MilvusStore` 和 `ChromaStore` 均继承此 mixin，在**首次创建 collection 时**（而非初始化时）才调用 embed 函数。

## 2. `_DocumentStore` 大幅简化

- 删除 `_embed_specs_need_resolution`、`_resolve_embed_dims`、`_patch_embed_dims_for_keys` 等方法（共 ~60 行）
- 删除 `_collection_exists`、`_collection_exists_in`、`_exists_milvus`、`_exists_chroma`、`_exists_sqlite`、`_get_store_type_and_uri` 等方法（共 ~60 行）
- `_vec_init` 仅从已有 schema 读取维度，不再主动调用 embed 函数
- `vec_connect` 新增 `embed` 参数，将 embed 函数字典传递给底层 store

## 3. Node Group `lazy_mode` 支持（`impl.py`、`server.py`、`worker.py`）

新增 `lazy_mode` 属性，支持三种取值：

| 值 | 含义 |
|---|---|
| `None`（默认）| 正常处理：transform + embed 都执行 |
| `'embed'` | 跳过 embed，只做 transform（embed 模型未就绪时入库） |
| `'all'` | transform 和 embed 都跳过（完全懒加载） |

- `DocumentProcessor` 新增 `POST /ng/{group_name}/lazy_mode` 和 `GET /ng/{group_name}/lazy_mode` 接口
- `force` 策略注册 node group 时保留已有的 `lazy_mode` 字段，避免覆盖运行时修改
- `_exec_reparse_task` 新增 `embed_only` 模式：跳过 transform，仅对已有节点重新 embed
- `_reembed_group`：对已 transform 但未 embed 的节点执行补充向量化，若节点不存在则回退到全量 reparse

## 4. Worker 健壮性改进（`worker.py`）

- **`_cleanup_stale_tasks`**：worker 启动时自动清理 lease 已过期的 WORKING 任务（重置为 WAITING）和孤立的 WORKING ng_status 行（重置为 FAILED），避免队列永久阻塞
- **`_wait_and_decide_ng` 超时保护**：新增 `timeout` 参数（默认 3600s），超时后将 ng 标记为 exec 而非无限等待

## 5. `collection_exists` 接口（`store_base.py`）

`LazyLLMStoreBase` 新增 `collection_exists(collection_name)` 方法（默认返回 `True`），`ChromaStore` 覆写实现真实检查，用于在 collection 不存在时跳过 embedding 计算。

---

# 🧪 如何测试 / How Has This Been Tested?

1. 配置 `embed_image` 模型前上传文档，验证 image group 以 `lazy_mode='embed'` 入库不报错
2. 配置 `embed_image` 模型后触发 `embed_only` reparse，验证已有节点被正确向量化
3. 模拟 worker crash，重启后验证 stale 任务被自动清理，队列恢复正常
4. 验证 `_wait_and_decide_ng` 超时后任务正常执行而非永久阻塞

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
# 设置 node group 为 lazy embed 模式（embed 模型未就绪时入库）
processor.set_node_group_lazy_mode('image', lazy_mode='embed')

# embed 模型就绪后，触发补充向量化
processor.reparse(group_name='image', node_groups=..., doc_ids=[...], embed_only=True)

# 恢复正常模式（新文档入库时自动 embed）
processor.set_node_group_lazy_mode('image', lazy_mode=None)
```

---

# ⚠️ 注意事项 / Additional Notes

- `EmbedResolveMixin._resolve_missing_embed_specs` 必须在 `_ddl_lock` 内调用，调用方负责加锁
- `lazy_mode='all'` 的 ng 在 `_reparse_group_recursive` 中会被跳过，不会被子 ng 的 reparse 带动
- Worker 启动清理时会跳过仍有活跃 lease 的 doc_id，避免误清理正在处理中的任务

---

# 🧠 AI 参与情况 / AI Involvement

- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**

- [x] Cursor

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```
我想给 node_group 加一个属性（lazy=True），如果某个 ng 是 lazy 的，它依然会被 active，但文档入库的时候，不会计算它，需要手动通过 reparse 进行计算触发（除非它作为某个非 lazy 的 ng 的祖先）。lazy 状态可以手动修改。当一个 ng 从 lazy 变成非 lazy 的时候，过去已经入库的文档，需要手动触发；新的文档添加的时候，会执行。

此外，帮我看看目前有没有单独做重新向量化（而不重解析）的接口，或者 reparse 加一个 reembed_only 的参数，如果发现已经 Transform 好了，但没有向量化，则重新向量化，而不做重新 Transform；否则先 Transform 再向量。
```

## AI 初始输出质量 / Initial Output Quality

- [x] 部分正确 / Partially correct

## 问题点 / Issues：

- AI 初始方案将 `lazy` 和 `lazy_embed` 设计为两个独立 bool 参数，经人工讨论后合并为单一 `lazy_mode` 枚举参数（`None / 'embed' / 'all'`），语义更清晰
- AI 初始方案在 `activate_group` 时强制不注册 embed keys，导致后续 reparse 无法获取 embed keys；经人工指出后改为初始化时不变，仅在具体解析时根据 `lazy_mode` 判断
- AI 初始方案的 `_create_nodes_recursive` 改动较复杂，经人工指导改为在调用前预处理 `node_groups`，函数本身不变

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```
1. lazy=lazy, lazy_embed=lazy_embed，你判断一下是 2 个参数好，还是一个参数，lazy_mode= none / 'embed' / 'all'
2. reparse 的 reembed_only 改成 embed_only 吧
3. 确认一下除了第一次 for 循环，后面递归的进了 _reparse_group_recursive 的，是不是都是要算的
```

**原因 / Reason：** 两个 bool 参数有无效组合，单参数语义更清晰；统一命名规范

### 第二次修正 / Second Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```
对 lazy_mode='embed' 或 'all' 的 ng，强制不注册 embed keys；这样可能有问题，不注册 embed，后续 reparse 的时候，如何处理。
我希望初始化的时候不变，只在具体做解析的时候，根据实际情况判断
```

**原因 / Reason：** 避免破坏 embed keys 注册机制，保持初始化逻辑不变

### 第三次修正 / Third Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```
_create_nodes_recursive 我感觉有点复杂了，第一次进的时候看哪些要 skip，后面再进的时候一律不 skip 就可以了。
我的理解是，在第一次调用 _create_nodes_recursive 之前，把进来的 node_groups 做个处理，判断一下谁不需要被创建，然后 _create_nodes_recursive 这个函数就不再改了
```

**原因 / Reason：** 减少函数内部复杂度，通过预处理 node_groups 实现 lazy 过滤

### 最终策略总结 / Final Strategy Summary

整体方案由 AI 生成框架和实现，人工负责架构决策（参数设计、接口边界、初始化时机）和代码简化指导。

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

- AI 生成代码占比 / AI-generated code：`75%`
- 人工修改占比 / Human modifications：`25%`

**主要人工修改点 / Key Human Modifications：**

- [x] 架构调整 / Architecture adjustments（`lazy_mode` 参数设计、embed keys 注册时机）
- [x] 逻辑修正 / Logic fixes（`_create_nodes_recursive` 简化、`_reparse_group_recursive` lazy 跳过逻辑）
- [x] 边界处理 / Edge case handling（worker stale 清理的 active doc_id 保护、`_wait_and_decide_ng` 超时）

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```
对 lazy_mode='embed' 或 'all' 的 ng，强制不注册 embed keys
```

### ❌ 问题表现 / Issue Description

AI 将 embed keys 注册逻辑与 lazy_mode 耦合，导致后续 reparse(embed_only=True) 时无法获取 embed keys，需要额外的 fallback 逻辑。

### ✅ 改进后 Prompt / Improved Prompt

```
初始化的时候不变，只在具体做解析的时候，根据实际情况判断 lazy_mode
```

# 🧩 可复用经验 / Reusable Patterns

- **Prompt 模板**：先让 AI 生成完整方案文档，人工 review 后再让 AI 实施，效果优于直接让 AI 写代码
- **常见坑**：AI 倾向于在初始化阶段做过多校验，应明确指定"懒校验"的时机
- **推荐做法**：对复杂重构，先用 AI 生成 plan.md，人工确认架构决策后再执行实施
