### PR TITLE
fix(multimodal): wrap image embedding as batch for ImageDocNode

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 import requests
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 from urllib.parse import urljoin
@@ -167,6 +167,25 @@ class LazyLLMOnlineEmbedModuleBase(OnlineEmbeddingModuleBase):
 
 class LazyLLMOnlineMultimodalEmbedModuleBase(OnlineEmbeddingModuleBase):
     __lazyllm_registry_key__ = LLMType.MULTIMODAL_EMBED
+
+    @staticmethod
+    def _format_embedding_for_modality(
+            result: Union[List[float], List[List[float]]],
+            modality: Optional[str]) -> Union[List[float], List[List[float]]]:
+        # ImageDocNode.do_embedding expects batch format: emb[0] is the full vector.
+        if modality != 'image':
+            return result
+        if not isinstance(result, list) or not result:
+            return result
+        if isinstance(result[0], (int, float)):
+            return [result]
+        return result
+
+    def forward(self, input: Union[List, str], url: str = None, model: str = None, **kwargs
+                ) -> Union[List[float], List[List[float]]]:
+        modality = kwargs.pop('modality', None)
+        result = super().forward(input, url=url, model=model, **kwargs)
+        return self._format_embedding_for_modality(result, modality)
 
 class LazyLLMOnlineRerankModuleBase(OnlineEmbeddingModuleBase):
     __lazyllm_registry_key__ = LLMType.RERANK

--- a/lazyllm/module/llms/onlinemodule/supplier/qwen.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/qwen.py
@@ -417,7 +417,8 @@ class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
             return [self._format_input_item(item, modality=modality) for item in input]
         raise ValueError('Input must be either a string or a list of strings/dictionaries')
 
-    def forward(self, input: Union[List, str], url: str = None, model: str = None, **kwargs) -> List[float]:
+    def forward(self, input: Union[List, str], url: str = None, model: str = None, **kwargs
+                ) -> Union[List[float], List[List[float]]]:
         model, _, url, kwargs = resolve_online_params(
             model, None, url, kwargs,
             model_aliases=('model_name', 'embed_model_name', 'embed_name'),
@@ -436,7 +437,8 @@ class QwenMultimodalEmbed(LazyLLMOnlineMultimodalEmbedModuleBase):
         if self._get_response_value(response, 'status_code') != HTTPStatus.OK:
             message = self._get_response_value(response, 'message', 'Unknown error')
             raise RuntimeError(f'Qwen multimodal embedding failed: {message}')
-        return self._parse_response(response, input=input)
+        result = self._parse_response(response, input=input)
+        return self._format_embedding_for_modality(result, modality)
 
     def _parse_response(self, response: Dict, input: Union[List, str]) -> List[float]:
         output = self._get_response_value(response, 'output', {})


### PR DESCRIPTION
# 问题：
之前版本 多模态emb 返回 emb_vector = [xxxxx]; 在进行parallel_do_embedding，写入数据库时进行一个 xxxx[0] 的操作，将模型返回的 emb 提取成 flat形式；

# 解决：
输出包裹一个 [], 作为二维列表