### PR TITLE
fix(embedding): add request context to OnlineEmbeddingModuleBase errors

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
@@ -8,6 +8,14 @@ from .utils import LazyLLMOnlineBase, resolve_online_params
 from lazyllm.components.utils.downloader import ModelManager
 
 
+def _format_embed_request_error(model: str, url: str, status_code: int, body: str) -> str:
+    body = (body or '').strip()
+    if len(body) > 2000:
+        body = body[:2000] + '...(truncated)'
+    return (f'Online embedding request failed: model={model!r} url={url!r} '
+            f'http_status={status_code}. Response body: {body or "<empty>"}')
+
+
 class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
     NO_PROXY = True
     __lazyllm_registry_disable__ = True
@@ -77,8 +85,9 @@ class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
                     return self._parse_response(r.json(), input=input)
                 else:
                     err_body = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)])
-                    LOG.error(f'[OnlineEmbeddingModuleBase] HTTP {r.status_code} url={runtime_url!r} body={err_body!r}')
-                    raise requests.RequestException(err_body)
+                    msg = _format_embed_request_error(runtime_model, runtime_url, r.status_code, err_body)
+                    LOG.error(f'[OnlineEmbeddingModuleBase] {msg}')
+                    raise requests.RequestException(msg)
 
     def _encapsulated_data(self, input: Union[List, str], **kwargs):
         if isinstance(input, str):
@@ -100,11 +109,20 @@ class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
     def _parse_response(self, response: Dict, input: Union[List, str]) -> Union[List[List[float]], List[float]]:
         data = response.get('data', [])
         if not data:
-            raise Exception('no data received')
+            raise ValueError(
+                f'Online embedding response for model {self._embed_model_name!r} contained no '
+                f"'data' (got keys {sorted(response.keys())}). This usually means the request was "
+                'rejected upstream or the response schema is unexpected.')
+        for idx, res in enumerate(data):
+            if not isinstance(res, dict) or res.get('embedding') is None:
+                raise ValueError(
+                    f'Online embedding response for model {self._embed_model_name!r} is missing the '
+                    f"'embedding' field at data[{idx}] (got {res!r}); refusing to return empty "
+                    'embeddings silently.')
         if isinstance(input, str):
-            return data[0].get('embedding', [])
+            return data[0]['embedding']
         else:
-            return [res.get('embedding', []) for res in data]
+            return [res['embedding'] for res in data]
 
     def run_embed_batch(self, input: List, data: List, proxies, url: str = None, **kwargs):
         ret = [[] for _ in range(len(input))]
@@ -125,7 +143,8 @@ class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
                         else:
                             error_msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)])
                             if self._batch_size == 1 or r.status_code in [401, 429]:
-                                raise requests.RequestException(error_msg)
+                                raise requests.RequestException(_format_embed_request_error(
+                                    kwargs.get('model', self._embed_model_name), url, r.status_code, error_msg))
                             else:
                                 msg = f'Online embedding:{self._embed_model_name} post failed, adjust batch_size: '
                                 msg = msg + f' from {self._batch_size} to {max(self._batch_size // 2, 1)}'
@@ -152,7 +171,8 @@ class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
                             wait(futures)
                             error_msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)])
                             if self._batch_size == 1 or r.status_code in [401, 429]:
-                                raise requests.RequestException(error_msg)
+                                raise requests.RequestException(_format_embed_request_error(
+                                    kwargs.get('model', self._embed_model_name), url, r.status_code, error_msg))
                             else:
                                 msg = f'Online embedding:{self._embed_model_name} post failed, adjust batch_size: '
                                 msg = msg + f' from {self._batch_size} to {max(self._batch_size // 2, 1)}'

--- a/tests/basic_tests/Modules/test_online_embedding_errors.py
+++ b/tests/basic_tests/Modules/test_online_embedding_errors.py
@@ -1,0 +1,65 @@
+import pytest
+
+from lazyllm.module.llms.onlinemodule.base.onlineEmbeddingModuleBase import (
+    OnlineEmbeddingModuleBase,
+    _format_embed_request_error,
+)
+
+
+def _make_base(model_name='test-embed'):
+    # Bypass __init__ (which would resolve providers / model type); _parse_response
+    # only relies on self._embed_model_name, so a bare instance is enough to unit-test
+    # the response-parsing and error-formatting behavior without any network access.
+    inst = OnlineEmbeddingModuleBase.__new__(OnlineEmbeddingModuleBase)
+    inst._embed_model_name = model_name
+    return inst
+
+
+class TestFormatRequestError:
+    def test_includes_model_url_and_status(self):
+        msg = _format_embed_request_error('m-1', 'http://x/embeddings', 503, 'upstream down')
+        assert "'m-1'" in msg
+        assert 'http://x/embeddings' in msg
+        assert '503' in msg
+        assert 'upstream down' in msg
+
+    def test_empty_body_is_marked(self):
+        msg = _format_embed_request_error('m-1', 'http://x', 500, '')
+        assert '<empty>' in msg
+
+    def test_long_body_truncated(self):
+        msg = _format_embed_request_error('m-1', 'http://x', 500, 'a' * 5000)
+        assert 'truncated' in msg
+        assert len(msg) < 5000
+
+
+class TestParseResponse:
+    def test_valid_str_input(self):
+        base = _make_base()
+        resp = {'data': [{'embedding': [0.1, 0.2, 0.3]}]}
+        assert base._parse_response(resp, input='hello') == [0.1, 0.2, 0.3]
+
+    def test_valid_list_input(self):
+        base = _make_base()
+        resp = {'data': [{'embedding': [0.1]}, {'embedding': [0.2]}]}
+        assert base._parse_response(resp, input=['a', 'b']) == [[0.1], [0.2]]
+
+    def test_no_data_raises_with_context(self):
+        base = _make_base('m-x')
+        with pytest.raises(ValueError) as exc:
+            base._parse_response({'error': 'bad key'}, input='hello')
+        assert "'m-x'" in str(exc.value)
+
+    def test_parse_response_missing_embedding_key_raises(self):
+        # Bug repro: previously this returned an empty list silently, producing
+        # zero-length embeddings downstream with no signal. It must now raise.
+        base = _make_base()
+        resp = {'data': [{'index': 0}]}  # no 'embedding' field
+        with pytest.raises(ValueError):
+            base._parse_response(resp, input='hello')
+
+    def test_parse_response_missing_embedding_key_in_batch_raises(self):
+        base = _make_base()
+        resp = {'data': [{'embedding': [0.1]}, {'index': 1}]}  # second item malformed
+        with pytest.raises(ValueError):
+            base._parse_response(resp, input=['a', 'b'])


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

`OnlineEmbeddingModuleBase` 在请求失败时抛出的错误缺乏上下文，难以定位问题：

- HTTP 失败时仅抛出 `requests.RequestException(raw_body)`，不含 model / url / 状态码。
- `_parse_response` 在响应缺少 `'data'` 时抛出裸 `Exception('no data received')`。
- 当某个响应条目缺少 `'embedding'` 字段时，`_parse_response` 会**静默返回空向量**，
  导致下游拿到零长度 embedding 而没有任何报错。

本 PR：

- 新增共享辅助函数 `_format_embed_request_error`，在 `forward` / `run_embed_batch`
  的三个 HTTP 失败点统一输出 model、url、HTTP status 以及截断后的响应体。
- 在 `_parse_response` 中校验响应条目：缺少 `'embedding'` 字段时抛出描述性的
  `ValueError`，而不是静默返回空 embedding。
- 新增无需联网的单元测试，覆盖错误信息格式化与 `_parse_response` 两条路径。

EN: Give `OnlineEmbeddingModuleBase` failures actionable context. HTTP errors now
report model / url / status via a shared `_format_embed_request_error` helper, and
`_parse_response` raises a descriptive error when a response item lacks the
`'embedding'` field instead of silently returning empty embeddings.

---

# 🎯 问题背景 / Problem Context

- 在线 embedding 调用失败时，原始错误信息只有上游返回的 body，缺少 model/url/状态码，
  排查成本高。
- 响应结构异常（缺 `embedding` 字段）时静默返回空向量，是一个隐蔽的正确性问题——
  错误会在下游（检索/相似度）才暴露，且难以溯源。

# 🔍 相关 Issue / Related Issue

* Relates to #892 （改善 `OnlineEmbeddingModule` 的错误体验 / improves the error experience）

> 说明：#892 提到的构造期 KeyError 与 `embed_model_name` 关键字顺序，在当前 `__new__`
> 中已支持 `model` 作为首位参数及 `embed_model_name`/`model_name` 别名；本 PR 聚焦于运行期
> 错误信息与响应校验这一相关面，故标注为 Relates to 而非 Closes。

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [x] Breaking change
* [ ] Documentation
* [ ] Performance optimization

> Breaking：`_parse_response` 在响应条目缺少 `'embedding'` 字段时由“静默返回空向量”
> 改为抛出 `ValueError`。合法的空 embedding 列表不受影响（判断的是缺失 key，而非空值）。

---

# 🧪 如何测试 / How Has This Been Tested?

1. `python -m pytest tests/basic_tests/Modules/test_online_embedding_errors.py -v` （8 passed，无需联网/API key）
2. `make lint-flake8`（flake8 + flake8-quotes + flake8-bugbear）对改动文件通过
3. 导入全部在线 supplier（glm/openai/qwen/doubao/siliconflow/...）确认未破坏继承基类的实现
