### PR TITLE
Fix Feishu copy tool and search auth

### DIFF
--- a/lazyllm/common/credential_mixin.py
+++ b/lazyllm/common/credential_mixin.py
@@ -15,19 +15,25 @@ from .auth import AuthStrategy, BearerTokenStrategy, Credential
 class CredentialMixin:
 
     _TOKEN_REFRESH_BUFFER: float = 60.0
-    def __key_source__(self) -> str: return self.get_current_token()
 
     def __init_credential__(
         self,
         credential: Credential,
         strategy: Optional[AuthStrategy] = None,
+        skip_auth: bool = False,
     ) -> None:
         self._credential: Credential = credential
         self._auth_strategy: AuthStrategy = strategy or BearerTokenStrategy()
+        self._skip_auth: bool = skip_auth
         self._token_lock: threading.Lock = threading.Lock()
         self._credential_override: contextvars.ContextVar[Optional[Credential]] = (
             contextvars.ContextVar('lazyllm_credential_override', default=None)
         )
+
+    def __key_source__(self) -> Any:
+        if self._skip_auth:
+            return True
+        return self.get_current_token()
 
     @property
     def _active_credential(self) -> Credential:

--- a/lazyllm/common/registry.py
+++ b/lazyllm/common/registry.py
@@ -66,6 +66,9 @@ class LazyDict(dict):
     def __getattr__(self, key):
         return self[self._match(key)]
 
+    def resolve(self, key):
+        return self[self._match(key)]
+
     def remove(self, key):
         super(__class__, self).pop(self._match(key))
 

--- a/lazyllm/docs/common.py
+++ b/lazyllm/docs/common.py
@@ -135,6 +135,33 @@ Note:
     Raises AttributeError if no matching key is found.
 ''')
 
+add_chinese_doc('registry.LazyDict.resolve', '''\
+解析键名并返回字典中匹配的值。
+
+Args:
+    key (str): 要解析的键。支持与__getattr__相同的键匹配规则，包括默认键、首字母小写和组名省略等特性。
+
+Returns:
+    Any: 匹配键对应的值。
+
+注意:
+    如果找不到匹配的键，将抛出AttributeError异常。
+''')
+
+add_english_doc('registry.LazyDict.resolve', '''\
+Resolve a key name and return the matching value from the dictionary.
+
+Args:
+    key (str): The key to resolve. Supports the same key matching rules as __getattr__,
+              including default keys, lowercase first character, and group name omission features.
+
+Returns:
+    Any: The value for the matched key.
+
+Note:
+    Raises AttributeError if no matching key is found.
+''')
+
 add_chinese_doc('registry.LazyDict.set_default', '''\
 设置字典的默认键。设置后可以通过.default属性访问该键对应的值。
 

--- a/lazyllm/docs/tools/search.py
+++ b/lazyllm/docs/tools/search.py
@@ -18,6 +18,7 @@ Args:
     api_key (str, optional): API 密钥；传入后以 static 模式存入 CredentialMixin；为空时使用 dynamic 模式，
         从 lazyllm.config['dynamic_tool_auth'] 中按 source_name 读取运行时密钥。
     auth_strategy (AuthStrategy, optional): 认证策略；未传时默认使用 BearerTokenStrategy。
+    skip_auth (bool): 是否在 ToolManager 凭据检查中跳过鉴权，默认 False。
 ''')
 
 add_english_doc('SearchBase', '''
@@ -30,6 +31,7 @@ Args:
     api_key (str, optional): API key; stored in CredentialMixin in static mode when provided. When omitted,
         dynamic mode reads the runtime key from lazyllm.config['dynamic_tool_auth'] by source_name.
     auth_strategy (AuthStrategy, optional): Authentication strategy; defaults to BearerTokenStrategy when omitted.
+    skip_auth (bool): Whether to bypass ToolManager credential checks, defaults to False.
 ''')
 
 add_example('SearchBase', '''
@@ -624,12 +626,18 @@ arXiv 预印本搜索。无需 API key，直接使用。
 Args:
     timeout (int): 请求超时秒数，默认 15。
     source_name (str): 结果来源标识，默认 "arxiv"。
+    skip_auth (bool): 注册为工具时是否跳过凭据检查，默认 False。
 ''')
 
 add_english_doc('ArxivSearch', '''
 Search arXiv preprints. No API key or token required.
 
 No sign-up or token needed; instantiate and call. API docs: https://info.arxiv.org/help/api/index.html .
+
+Args:
+    timeout (int): Request timeout in seconds, default 15.
+    source_name (str): Source identifier, default "arxiv".
+    skip_auth (bool): Whether to bypass credential checks when registered as a tool, defaults to False.
 ''')
 
 add_example('ArxivSearch', '''
@@ -685,6 +693,7 @@ Args:
     base_url (str): 站点根地址，默认 "https://en.wikipedia.org"，可改为 zh.wikipedia.org 等。
     timeout (int): 请求超时秒数，默认 10。
     source_name (str): 结果来源标识，默认 "wikipedia"。
+    skip_auth (bool): 注册为工具时是否跳过凭据检查，默认 False。
 ''')
 
 add_english_doc('WikipediaSearch', '''
@@ -696,6 +705,7 @@ Args:
     base_url (str): Site base URL, default "https://en.wikipedia.org"; use e.g. https://zh.wikipedia.org for other languages.
     timeout (int): Request timeout in seconds, default 10.
     source_name (str): Source identifier, default "wikipedia".
+    skip_auth (bool): Whether to bypass credential checks when registered as a tool, defaults to False.
 ''')
 
 add_example('WikipediaSearch', '''

--- a/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineEmbeddingModuleBase.py
@@ -45,6 +45,7 @@ class OnlineEmbeddingModuleBase(LazyLLMOnlineBase):
         url, done = self._normalize_embed_url(url)
         if done: return url
         suffix = 'rerank' if self.type == 'RERANK' else 'embeddings'
+        if not url.endswith('/'): url += '/'
         return urljoin(url, suffix)
 
     @property

--- a/lazyllm/tools/__init__.py
+++ b/lazyllm/tools/__init__.py
@@ -1,5 +1,8 @@
 from importlib import import_module
 from typing import TYPE_CHECKING
+
+from . import tool_config_inject  # noqa: F401
+
 if TYPE_CHECKING:
     # flake8: noqa: E401
     from .rag import (Document, GraphDocument, UrlGraphDocument, Reranker, Retriever, TempDocRetriever,

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -380,7 +380,7 @@ class ToolGroup(ToolContainer):
         _gateway_apply.__name__ = f'get_{group_name}_methods'
 
         register('tmp_tool')(_gateway_apply)
-        tool_cls = getattr(lazyllm.tmp_tool, _gateway_apply.__name__)
+        tool_cls = lazyllm.tmp_tool.resolve(_gateway_apply.__name__)
         tool = tool_cls()
         lazyllm.tmp_tool.remove(_gateway_apply.__name__)
         return tool
@@ -501,7 +501,7 @@ def _build_tool_from_element(
         return group
     if callable(element):
         register('tmp_tool')(element)
-        tool = getattr(lazyllm.tmp_tool, element.__name__)()
+        tool = lazyllm.tmp_tool.resolve(element.__name__)()
         lazyllm.tmp_tool.remove(element.__name__)
         return tool
     raise TypeError(f'ToolGroup child must be a ModuleTool, ToolGroup, dict, or callable, got {type(element)}')

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -232,6 +232,3 @@ class LazyLLMFSBase(AbstractFileSystem, CredentialMixin, metaclass=_CloudFSMeta)
 
 globals.config.add('dynamic_fs_auth', dict, None, 'DYNAMIC_FS_AUTH',
                    description='Per-source dynamic FS auth: {source: token}.')
-globals.config.add('dynamic_tool_auth', dict, None, 'DYNAMIC_TOOL_AUTH',
-                   description='Per-tool dynamic auth: {tool_name: token}. '
-                   'Used by search engines and other API-key-based tools.')

--- a/lazyllm/tools/tool_config_inject.py
+++ b/lazyllm/tools/tool_config_inject.py
@@ -5,6 +5,11 @@ import lazyllm
 from lazyllm import LOG
 
 
+lazyllm.globals.config.add('dynamic_tool_auth', dict, None, 'DYNAMIC_TOOL_AUTH',
+                           description='Per-tool dynamic auth: {tool_name: token}. '
+                           'Used by search engines and other API-key-based tools.')
+
+
 # Maps a canonical tool name to the globals.config key it writes into.
 # Add new tools here — no code changes needed elsewhere.
 #

--- a/lazyllm/tools/tools/search/arxiv_search.py
+++ b/lazyllm/tools/tools/search/arxiv_search.py
@@ -10,7 +10,7 @@ class ArxivSearch(SearchBase):
 
     def __init__(self, base_url: str = 'https://export.arxiv.org/api/query',
                  timeout: int = 15, source_name: str = 'arxiv',
-                 skip_auth: bool = False):
+                 skip_auth: bool = True):
         super().__init__(source_name=source_name, skip_auth=skip_auth)
         self._url = base_url
         self._timeout = timeout

--- a/lazyllm/tools/tools/search/arxiv_search.py
+++ b/lazyllm/tools/tools/search/arxiv_search.py
@@ -9,8 +9,9 @@ from .base import SearchBase, _make_result
 class ArxivSearch(SearchBase):
 
     def __init__(self, base_url: str = 'https://export.arxiv.org/api/query',
-                 timeout: int = 15, source_name: str = 'arxiv'):
-        super().__init__(source_name=source_name)
+                 timeout: int = 15, source_name: str = 'arxiv',
+                 skip_auth: bool = False):
+        super().__init__(source_name=source_name, skip_auth=skip_auth)
         self._url = base_url
         self._timeout = timeout
 

--- a/lazyllm/tools/tools/search/base.py
+++ b/lazyllm/tools/tools/search/base.py
@@ -48,15 +48,20 @@ class SearchBase(ModuleBase, CredentialMixin):
         api_key: Optional[str] = None,
         auth_strategy: Optional[AuthStrategy] = None,
         dynamic_auth: bool = False,
+        skip_auth: bool = False,
         **kwargs,
     ):
         ModuleBase.__init__(self, **kwargs)
         self._source_name = source_name or self.__class__.__name__.replace('Search', '').lower()
-        if dynamic_auth or api_key is None:
+        if dynamic_auth:
             credential = Credential(kind='dynamic')
         else:
-            credential = Credential(kind='static', secret_key=api_key)
-        self.__init_credential__(credential, strategy=auth_strategy or BearerTokenStrategy())
+            credential = Credential(kind='static', secret_key=api_key or '')
+        self.__init_credential__(
+            credential,
+            strategy=auth_strategy or BearerTokenStrategy(),
+            skip_auth=skip_auth,
+        )
 
     def _resolve_dynamic_token(self) -> str:
         mapping = lazyllm_globals.config['dynamic_tool_auth'] or {}

--- a/lazyllm/tools/tools/search/wikipedia_search.py
+++ b/lazyllm/tools/tools/search/wikipedia_search.py
@@ -13,8 +13,9 @@ class WikipediaSearch(SearchBase):
     _UA = f'LazyLLM/{lazyllm.__version__} (https://github.com/LazyAGI/LazyLLM; wikipedia-search)'
 
     def __init__(self, base_url: str = 'https://en.wikipedia.org',
-                 timeout: int = 10, source_name: str = 'wikipedia'):
-        super().__init__(source_name=source_name)
+                 timeout: int = 10, source_name: str = 'wikipedia',
+                 skip_auth: bool = False):
+        super().__init__(source_name=source_name, skip_auth=skip_auth)
         self._base_url = base_url.rstrip('/')
         self._api_url = f'{self._base_url}/w/api.php'
         self._timeout = timeout

--- a/lazyllm/tools/tools/search/wikipedia_search.py
+++ b/lazyllm/tools/tools/search/wikipedia_search.py
@@ -14,7 +14,7 @@ class WikipediaSearch(SearchBase):
 
     def __init__(self, base_url: str = 'https://en.wikipedia.org',
                  timeout: int = 10, source_name: str = 'wikipedia',
-                 skip_auth: bool = False):
+                 skip_auth: bool = True):
         super().__init__(source_name=source_name, skip_auth=skip_auth)
         self._base_url = base_url.rstrip('/')
         self._api_url = f'{self._base_url}/w/api.php'

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -1,7 +1,7 @@
 import lazyllm
 from lazyllm.tools import ToolManager
 from lazyllm.tools.agent.toolsManager import (
-    InstanceToolGroup, ToolGroup, _gen_args_info_from_moduletool_and_docstring, register,
+    InstanceToolGroup, ToolGroup, _build_tool_from_element, _gen_args_info_from_moduletool_and_docstring, register,
 )
 from lazyllm.common import LazyLLMRegisterMetaClass
 from lazyllm import locals as lazyllm_locals, init_session
@@ -11,7 +11,7 @@ def _gen_wrapped_moduletool(func):
     if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
         register.new_group('tmp_tool')
     register('tmp_tool')(func)
-    wrapped_module = getattr(lazyllm.tmp_tool, func.__name__)()
+    wrapped_module = lazyllm.tmp_tool.resolve(func.__name__)()
     lazyllm.tmp_tool.remove(func.__name__)
     return wrapped_module
 
@@ -106,6 +106,24 @@ class TestToolManager:
         except Exception:
             raised = True
         assert raised
+
+    def test_tmp_tool_name_can_match_dict_method(self):
+        def copy(path1: str, path2: str) -> str:
+            '''
+            Copy a file.
+
+            Args:
+                path1 (str): Source path.
+                path2 (str): Target path.
+
+            Returns:
+                str: Copy result.
+            '''
+            return f'{path1}->{path2}'
+
+        tool = _build_tool_from_element(copy)
+        assert not isinstance(tool, dict)
+        assert tool.name == 'copy'
 
 
 class MockSearchForTest:
@@ -755,6 +773,41 @@ class TestShouldSkipTransitions:
         lazyllm.globals.config['mock_fs_token'] = 'user-token-abc'
         assert grp.should_skip() is False
         lazyllm.globals.config['mock_fs_token'] = None
+
+    def test_required_search_without_key_skips_then_available_with_dynamic_auth(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        from lazyllm.tools.tools.search import BingSearch
+
+        old_auth = lazyllm.globals.config['dynamic_tool_auth']
+        lazyllm.globals.config['dynamic_tool_auth'] = {}
+        try:
+            inst = BingSearch()
+            mixin = SkipMixin(type(inst).__key_source__)
+            mixin._instance = inst
+            assert mixin.should_skip() is True
+
+            lazyllm.globals.config['dynamic_tool_auth'] = {'bing': 'bing-token'}
+            assert mixin.should_skip() is False
+        finally:
+            lazyllm.globals.config['dynamic_tool_auth'] = old_auth
+
+    def test_search_skip_auth_override_keeps_tool_available(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        from lazyllm.tools.tools.search import ArxivSearch, WikipediaSearch
+
+        for inst in (ArxivSearch(skip_auth=True), WikipediaSearch(skip_auth=True)):
+            mixin = SkipMixin(type(inst).__key_source__)
+            mixin._instance = inst
+            assert mixin.should_skip() is False
+
+    def test_search_without_key_skips_by_default(self):
+        from lazyllm.tools.agent.toolsManager import SkipMixin
+        from lazyllm.tools.tools.search import ArxivSearch
+
+        inst = ArxivSearch()
+        mixin = SkipMixin(type(inst).__key_source__)
+        mixin._instance = inst
+        assert mixin.should_skip() is True
 
     # ------------------------------------------------------------------ #
     # ToolGroupWrapper — callable key_source, mutate state


### PR DESCRIPTION
## Summary
- fix Feishu copy tool handling
- add required auth metadata for search tool
- move search skip-auth decision into CredentialMixin
- add skip_auth passthrough for SearchBase, ArxivSearch, and WikipediaSearch
- register dynamic_tool_auth from tool_config_inject instead of fs base
- extend tools manager test coverage
- add LazyDict.resolve API docs for doc generation checks

## Tests
- pytest tests/doc_check/test_doc_api_check.py::test_LazyDict_resolve -q
- pytest tests/advanced_tests/Tools/test_tools_manager.py -q
- python -c "import lazyllm; from lazyllm.tools.tools.search import BingSearch; print(lazyllm.globals.config['dynamic_tool_auth'])"