### PR TITLE
feat(tools): add Sciverse search provider

### DIFF
--- a/lazyllm/docs/tools/search.py
+++ b/lazyllm/docs/tools/search.py
@@ -618,6 +618,168 @@ Returns:
     List[Dict[str, Any]]: Results in unified format; extra may include authors, publishedDate, pageCount.
 ''')
 
+add_chinese_doc('SciverseSearch', '''
+Sciverse 科研文献搜索，支持面向问答的文献片段检索和元数据检索。
+
+如何申请 API Key：
+1. 打开 Sciverse 文档 https://sciverse.space/docs 并登录控制台。
+2. 在 Console > Tokens 创建 API Key。
+3. 构造时传入 api_key，或在工具调用时通过 dynamic_tool_auth["sciverse"] 注入。
+
+Args:
+    api_key (str, optional): Sciverse API key；为空时从 dynamic_tool_auth["sciverse"] 读取。
+    base_url (str): Sciverse API 根地址，默认 "https://api.sciverse.space"。
+    timeout (int): 请求超时秒数，默认 15。
+    source_name (str): 结果来源标识，默认 "sciverse"。
+''')
+
+add_english_doc('SciverseSearch', '''
+Search Sciverse scientific literature, including passage-oriented retrieval for question answering and metadata search.
+
+How to get an API key:
+1. Open Sciverse docs https://sciverse.space/docs and sign in to the console.
+2. Create an API key from Console > Tokens.
+3. Pass api_key to the constructor, or inject it at runtime through dynamic_tool_auth["sciverse"].
+
+Args:
+    api_key (str, optional): Sciverse API key; when omitted, reads dynamic_tool_auth["sciverse"].
+    base_url (str): Sciverse API base URL, default "https://api.sciverse.space".
+    timeout (int): Request timeout in seconds, default 15.
+    source_name (str): Source identifier, default "sciverse".
+''')
+
+add_example('SciverseSearch', '''
+from lazyllm.tools.tools import SciverseSearch
+sciverse = SciverseSearch(api_key='<your_sciverse_api_key>')
+res = sciverse('retrieval augmented generation evaluation', topk=5)
+''')
+
+add_chinese_doc('SciverseSearch.search', '''
+搜索 Sciverse 科研文献。
+
+Args:
+    query (str): 论文标题、作者、DOI、科研主题或自然语言问题。
+    topk (int): 返回条数，默认 5，最大 10。
+    include_content (bool): 是否在 extra.content 中保留摘要或片段文本，默认 True。
+    search_type (str): "agentic" 返回适合问答的文献片段；"meta" 返回偏文献元数据的结果。
+    year_from (int, optional): 发表年份下限，仅 meta 检索使用。
+    year_to (int, optional): 发表年份上限，仅 meta 检索使用。
+
+Returns:
+    List[dict]: 统一格式结果，extra 可含 doc_id、doi、year、venue、authors、score、content 等字段。
+''')
+
+add_english_doc('SciverseSearch.search', '''
+Search Sciverse scientific literature.
+
+Args:
+    query (str): Paper title, author, DOI, research topic, or natural-language question.
+    topk (int): Number of results, default 5, maximum 10.
+    include_content (bool): Whether to keep abstract or passage text in extra.content, default True.
+    search_type (str): "agentic" returns passage-oriented results for question answering; "meta" returns metadata-oriented results.
+    year_from (int, optional): Inclusive lower publication year bound, used by meta search.
+    year_to (int, optional): Inclusive upper publication year bound, used by meta search.
+
+Returns:
+    List[dict]: Results in unified format; extra may include doc_id, doi, year, venue, authors, score, content, and related fields.
+''')
+
+add_chinese_doc('SciverseSearch.get_content', '''
+读取单条 Sciverse 搜索结果的原文内容。
+
+优先使用 item.extra.doc_id 或 item.doc_id 调用官方 /content 接口；支持 offset / limit 分段读取。若 doc_id 不存在或接口失败，则回退为 item.extra.content、item.snippet 或基类 URL 抓取。
+
+Args:
+    item (Dict[str, Any]): SciverseSearch.search 或 meta_search 返回的单条结果。
+    offset (int, optional): 原文字符偏移；传入时启用分段读取。
+    limit (int): 单次读取字符数，默认 700；仅 offset 非空时传给接口。
+
+Returns:
+    str: 原文文本、片段文本或空字符串。
+''')
+
+add_english_doc('SciverseSearch.get_content', '''
+Read full text for one Sciverse search result.
+
+The method first calls the official /content endpoint with item.extra.doc_id or item.doc_id, supporting offset / limit pagination. If doc_id is missing or the endpoint fails, it falls back to item.extra.content, item.snippet, or the base URL fetcher.
+
+Args:
+    item (Dict[str, Any]): One item returned by SciverseSearch.search or meta_search.
+    offset (int, optional): Character offset in the source text; enables chunked reading when provided.
+    limit (int): Number of characters to read, default 700; sent only when offset is provided.
+
+Returns:
+    str: Full text, passage text, or an empty string.
+''')
+
+add_chinese_doc('SciverseSearch.meta_search', '''
+调用 Sciverse /meta-search 做高级论文元数据检索。
+
+search() 返回统一搜索列表，适合普通 Agent 检索；meta_search() 保留分页和统计信息，适合论文列表、筛选、排序、导出和深翻页场景。query 与 sort 不能同时使用；cursor 与 page>1 不能同时使用。
+
+Args:
+    query (str): 全文模糊检索词；可为空，仅用 filters / sort 精确检索。
+    filters (List[Dict[str, Any]], optional): 字段过滤条件，例如 {field, operator, value}。
+    sort (List[Dict[str, Any]], optional): 排序字段集合，例如 {field, order}。
+    fields (List[str], optional): 返回字段投影；为空时使用默认字段。
+    page (int): 页码，默认 1。
+    page_size (int): 每页条数，默认 25，范围 1-200。
+    cursor (str, optional): 深翻页 cursor；与 page>1 互斥。
+    freshness_boost (str): 新鲜度加权，NONE / MILD / STRONG。
+    include_content (bool): 是否在 extra.content 中保留摘要文本，默认 True。
+    year_from (int, optional): 发表年份下限，会追加到 filters。
+    year_to (int, optional): 发表年份上限，会追加到 filters。
+
+Returns:
+    Dict[str, Any]: 包含 items、total_count、total_pages、page、page_size、next_cursor、search_time_ms。
+''')
+
+add_english_doc('SciverseSearch.meta_search', '''
+Run advanced Sciverse /meta-search for literature metadata.
+
+search() returns the unified SearchBase result list for simple agent retrieval. meta_search() preserves pagination and statistics, making it better for paper lists, filtering, sorting, export, and deep pagination. query cannot be used together with sort; cursor cannot be used together with page > 1.
+
+Args:
+    query (str): Full-text fuzzy query; may be empty when using filters / sort only.
+    filters (List[Dict[str, Any]], optional): Field filters, e.g. {field, operator, value}.
+    sort (List[Dict[str, Any]], optional): Sort clauses, e.g. {field, order}.
+    fields (List[str], optional): Field projection; defaults to the built-in field list.
+    page (int): Page number, default 1.
+    page_size (int): Items per page, default 25, clamped to 1-200.
+    cursor (str, optional): Cursor for deep pagination; mutually exclusive with page > 1.
+    freshness_boost (str): Freshness weighting, NONE / MILD / STRONG.
+    include_content (bool): Whether to keep abstract text in extra.content, default True.
+    year_from (int, optional): Inclusive lower publication year bound, appended to filters.
+    year_to (int, optional): Inclusive upper publication year bound, appended to filters.
+
+Returns:
+    Dict[str, Any]: Includes items, total_count, total_pages, page, page_size, next_cursor, and search_time_ms.
+''')
+
+add_chinese_doc('SciverseSearch.meta_catalog', '''
+调用 Sciverse /meta-catalog 查看 meta-search 支持的字段目录。
+
+用于了解哪些字段可筛选、可排序、可全文搜索、默认返回哪些字段，以及支持哪些过滤算子。返回官方原始结构，方便 Agent 或 UI 动态生成筛选器。
+
+Args:
+    include_sample_values (bool): 是否返回枚举字段样本值，默认 False。
+
+Returns:
+    Dict[str, Any]: 官方字段目录响应，通常包含 fields、default_fields、filter_operators。
+''')
+
+add_english_doc('SciverseSearch.meta_catalog', '''
+Call Sciverse /meta-catalog to inspect fields supported by meta_search.
+
+Use this to discover which fields are filterable, sortable, searchable, returned by default, and which filter operators are available. The raw official response is returned so agents or UIs can build filters dynamically.
+
+Args:
+    include_sample_values (bool): Whether to include sample enum values, default False.
+
+Returns:
+    Dict[str, Any]: Official catalog response, usually including fields, default_fields, and filter_operators.
+''')
+
 add_chinese_doc('ArxivSearch', '''
 arXiv 预印本搜索。无需 API key，直接使用。
 

--- a/lazyllm/tools/tool_config_inject.py
+++ b/lazyllm/tools/tool_config_inject.py
@@ -36,6 +36,7 @@ TOOL_AUTH_REGISTRY: Dict[str, str] = {
     'semantic_scholar': 'dynamic_tool_auth',
     'google_books': 'dynamic_tool_auth',
     'stackoverflow': 'dynamic_tool_auth',
+    'sciverse': 'dynamic_tool_auth',
 }
 
 # Default config key for tools not listed in TOOL_AUTH_REGISTRY.

--- a/lazyllm/tools/tools/__init__.py
+++ b/lazyllm/tools/tools/__init__.py
@@ -10,6 +10,7 @@ from .search import (
     GoogleBooksSearch,
     ArxivSearch,
     WikipediaSearch,
+    SciverseSearch,
 )
 from .weather import Weather
 from .calculator import Calculator
@@ -28,6 +29,7 @@ __all__ = [
     'GoogleBooksSearch',
     'ArxivSearch',
     'WikipediaSearch',
+    'SciverseSearch',
     'Weather',
     'Calculator',
     'JsonExtractor',

--- a/lazyllm/tools/tools/search/__init__.py
+++ b/lazyllm/tools/tools/search/__init__.py
@@ -8,6 +8,7 @@ from .semantic_scholar_search import SemanticScholarSearch
 from .google_books_search import GoogleBooksSearch
 from .arxiv_search import ArxivSearch
 from .wikipedia_search import WikipediaSearch
+from .sciverse_search import SciverseSearch
 
 __all__ = [
     'SearchBase',
@@ -20,4 +21,5 @@ __all__ = [
     'GoogleBooksSearch',
     'ArxivSearch',
     'WikipediaSearch',
+    'SciverseSearch',
 ]

--- a/lazyllm/tools/tools/search/sciverse_search.py
+++ b/lazyllm/tools/tools/search/sciverse_search.py
@@ -1,0 +1,232 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from lazyllm.thirdparty import httpx
+
+from .base import SearchBase, _make_result
+
+
+_DEFAULT_META_FIELDS = [
+    'title',
+    'doi',
+    'doc_id',
+    'abstract',
+    'author',
+    'publication_published_year',
+    'publication_venue_name_unified',
+]
+
+
+def _items(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    data = payload.get('data')
+    source = data if isinstance(data, dict) else payload
+    items = source.get('hits') or source.get('results') or source.get('items') or []
+    return [item for item in items if isinstance(item, dict)] if isinstance(items, list) else []
+
+
+def _authors(value: Any) -> List[str]:
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if not isinstance(value, list):
+        return []
+    names = []
+    for item in value:
+        if isinstance(item, str):
+            name = item.strip()
+        elif isinstance(item, dict):
+            name = str(item.get('name') or item.get('display_name') or item.get('full_name') or '').strip()
+        else:
+            name = ''
+        if name:
+            names.append(name)
+    return names
+
+
+class SciverseSearch(SearchBase):
+    __public_apis__ = SearchBase.__public_apis__ + ['meta_search', 'meta_catalog']
+
+    def __init__(self, api_key: Optional[str] = None,
+                 base_url: str = 'https://api.sciverse.space',
+                 timeout: int = 15, source_name: str = 'sciverse'):
+        super().__init__(source_name=source_name, api_key=api_key, dynamic_auth=(api_key is None))
+        self._base_url = base_url.rstrip('/')
+        self._timeout = timeout
+
+    def get_content(self, item: Dict[str, Any], offset: Optional[int] = None, limit: int = 700) -> str:
+        extra = item.get('extra') or {}
+        doc_id = item.get('doc_id') or extra.get('doc_id')
+        if doc_id:
+            params: Dict[str, Any] = {'doc_id': doc_id}
+            if offset is not None:
+                params.update({'offset': max(0, int(offset)), 'limit': max(1, int(limit))})
+            try:
+                resp = httpx.get(
+                    f'{self._base_url}/content',
+                    headers=self.inject_auth_header(),
+                    params=params,
+                    timeout=self._timeout,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if isinstance(data, dict) and data.get('text'):
+                    return data['text']
+            except Exception:
+                pass
+        return extra.get('content') or item.get('snippet') or super().get_content(item)
+
+    def search(self, query: str, topk: int = 5, include_content: bool = True,
+               search_type: Literal['agentic', 'meta'] = 'agentic',
+               year_from: Optional[int] = None,
+               year_to: Optional[int] = None) -> List[dict]:
+        normalized_type = str(search_type or 'agentic').lower()
+        if normalized_type not in ('agentic', 'meta'):
+            raise ValueError("search_type must be one of 'agentic' or 'meta'")
+
+        limit = max(1, min(int(topk), 10))
+        if normalized_type == 'meta':
+            return self.meta_search(
+                query=query,
+                page_size=limit,
+                include_content=include_content,
+                year_from=year_from,
+                year_to=year_to,
+            )['items']
+
+        payload: Dict[str, Any] = {'query': query, 'top_k': limit}
+        headers = self.inject_auth_header({'Content-Type': 'application/json'})
+        resp = httpx.post(f'{self._base_url}/agentic-search', headers=headers, json=payload, timeout=self._timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            return []
+
+        return self._normalize_items(_items(data)[:limit], include_content=include_content, search_type='agentic')
+
+    def meta_search(
+        self,
+        query: str = '',
+        filters: Optional[List[Dict[str, Any]]] = None,
+        sort: Optional[List[Dict[str, Any]]] = None,
+        fields: Optional[List[str]] = None,
+        page: int = 1,
+        page_size: int = 25,
+        cursor: Optional[str] = None,
+        freshness_boost: Literal['NONE', 'MILD', 'STRONG'] = 'NONE',
+        include_content: bool = True,
+        year_from: Optional[int] = None,
+        year_to: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        if query and sort:
+            raise ValueError('meta_search sort cannot be used together with query')
+        if cursor and page > 1:
+            raise ValueError('meta_search cursor cannot be used together with page > 1')
+        normalized_freshness = str(freshness_boost or 'NONE').upper()
+        if normalized_freshness not in ('NONE', 'MILD', 'STRONG'):
+            raise ValueError("freshness_boost must be one of 'NONE', 'MILD', or 'STRONG'")
+
+        merged_filters = list(filters or [])
+        if year_from is not None:
+            merged_filters.append({
+                'field': 'publication_published_year',
+                'operator': 'FILTER_OP_GTE',
+                'value': int(year_from),
+            })
+        if year_to is not None:
+            merged_filters.append({
+                'field': 'publication_published_year',
+                'operator': 'FILTER_OP_LTE',
+                'value': int(year_to),
+            })
+
+        payload: Dict[str, Any] = {
+            'fields': list(fields or _DEFAULT_META_FIELDS),
+            'page_size': max(1, min(int(page_size), 200)),
+        }
+        if query:
+            payload['query'] = query
+        if merged_filters:
+            payload['filters'] = merged_filters
+        if sort:
+            payload['sort'] = sort
+        if cursor:
+            payload['cursor'] = cursor
+        else:
+            payload['page'] = max(1, int(page))
+        if normalized_freshness != 'NONE':
+            payload['freshness_boost'] = normalized_freshness
+
+        resp = httpx.post(
+            f'{self._base_url}/meta-search',
+            headers=self.inject_auth_header({'Content-Type': 'application/json'}),
+            json=payload,
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            data = {}
+
+        return {
+            'items': self._normalize_items(
+                _items(data),
+                include_content=include_content,
+                search_type='meta',
+            ),
+            'total_count': data.get('total_count'),
+            'total_pages': data.get('total_pages'),
+            'page': data.get('page'),
+            'page_size': data.get('page_size'),
+            'next_cursor': data.get('next_cursor'),
+            'search_time_ms': data.get('search_time_ms'),
+        }
+
+    def meta_catalog(self, include_sample_values: bool = False) -> Dict[str, Any]:
+        resp = httpx.get(
+            f'{self._base_url}/meta-catalog',
+            headers=self.inject_auth_header(),
+            params={'include_sample_values': str(bool(include_sample_values)).lower()},
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data if isinstance(data, dict) else {}
+
+    def _normalize_items(
+        self,
+        items: List[Dict[str, Any]],
+        *,
+        include_content: bool,
+        search_type: str,
+    ) -> List[dict]:
+        out: List[dict] = []
+        for item in items:
+            title = str(item.get('title') or item.get('paper_title') or item.get('name') or '').strip()
+            doi = str(item.get('doi') or item.get('publication_doi') or '').strip()
+            url = str(item.get('url') or item.get('paper_url') or item.get('source_url') or '').strip()
+            if not url and doi and search_type == 'meta':
+                url = f'https://doi.org/{doi}'
+
+            abstract = str(item.get('abstract') or item.get('summary') or item.get('description') or '').strip()
+            chunk = str(item.get('chunk') or item.get('text') or item.get('content') or '').strip()
+            content = chunk or abstract
+            extra = {
+                'doc_id': item.get('doc_id') or item.get('document_id') or item.get('id'),
+                'doi': doi,
+                'year': item.get('publication_published_year') or item.get('year') or item.get('published_year'),
+                'venue': item.get('publication_venue_name_unified') or item.get('publication_venue_name')
+                or item.get('venue') or item.get('journal'),
+                'authors': _authors(item.get('author') or item.get('authors') or item.get('author_names')),
+                'score': item.get('score') or item.get('relevance_score'),
+                'chunk_id': item.get('chunk_id'),
+                'page_no': item.get('page_no') or item.get('page'),
+                'offset': item.get('offset'),
+            }
+            if include_content and content:
+                extra['content'] = content
+            out.append(_make_result(
+                title=title,
+                url=url,
+                snippet='\n'.join(part for part in (abstract, chunk) if part),
+                source=self.source_name,
+                **{key: value for key, value in extra.items() if value not in (None, '', [])},
+            ))
+        return out


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Add Sciverse as a LazyLLM search provider built on `SearchBase`.
- Expose `search`, `meta_search`, `get_content`, and `meta_catalog` for paper retrieval workflows.
- Register `sciverse` dynamic auth and add Chinese/English tool docs.

---

# 🎯 问题背景 / Problem Context

- LazyMind needs the Sciverse paper search tool after recent tool-layer refactors.
- The implementation should reuse LazyLLM search abstractions and key source logic instead of adding app-local configuration.
- The tool API separates provider calls, result shaping, and documented business-facing methods.

# 🔍 相关 Issue / Related Issue

* None

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [x] New feature
* [x] Refactor
* [ ] Breaking change
* [x] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `PYTHONPATH=. python -m py_compile lazyllm/tools/tools/search/sciverse_search.py lazyllm/tools/tool_config_inject.py lazyllm/tools/tools/__init__.py lazyllm/tools/tools/search/__init__.py lazyllm/docs/tools/search.py`
2. Real Sciverse API smoke test with `LAZYLLM_SCIVERSE_API_KEY`: `meta_catalog`, `meta_search`, `search`, and `get_content`.
3. Smoke result: `catalog_fields 59`, `meta_items 2`, `agentic_items 2`, `content_lens [329, 300]`.

---

# 📷 Demo (Optional)

* N/A

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
from lazyllm.tools import SciverseSearch

searcher = SciverseSearch()
papers = searcher.meta_search(
    "deepseek",
    page_size=5,
    year_from=2024,
)

content = searcher.get_content(papers[0])
fields = searcher.meta_catalog()
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# No Sciverse search provider was available in LazyLLM.
```

## After

```python
from lazyllm.tools import SciverseSearch

searcher = SciverseSearch()
searcher.search("deepseek")
searcher.meta_search("deepseek", sort={"publication_published_year": "desc"})
searcher.meta_catalog()
```

# ⚠️ 注意事项 / Additional Notes

* This PR does not implement the Sciverse `/resource` API.
* Authentication is provided through LazyLLM dynamic tool auth under the `sciverse` key.

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
```text
Port the previously submitted Sciverse search tool into the current LazyLLM/LazyMind tool architecture, preserving author attribution and reusing existing search/key-source abstractions.
```

## 一开始制定了什么方案

- Put Sciverse in LazyLLM as a `SearchBase` provider.
- Reuse dynamic tool auth rather than adding LazyMind-specific config keys.
- Keep tool provider logic, algorithmic result normalization, and docs separated.

## 方案实施后存在什么问题

- The original provider shape was too long and had duplicated request/result handling.
- The public methods needed to match official Sciverse API capabilities while staying simple for LazyMind tool exposure.
- `search` and `meta_search` needed clearer boundaries in documentation.

## 我（用户）发现了哪些问题

- Unneeded config items should be removed.
- Sciverse should reuse LazyLLM search and key source logic.
- `meta_catalog` makes a fixed public field list less appropriate.
- The docs should clearly describe when to use `search`, `meta_search`, `get_content`, and `meta_catalog`.

## 对这些问题优化后相比于之前有哪些优势

- The provider now has fewer local configuration assumptions.
- Authentication follows LazyLLM tool auth conventions.
- Public APIs map more directly to official Sciverse capabilities.
- Field discovery is available at runtime through `meta_catalog`.

## 哪些可以沉淀为自己后续的编码规范

- New search tools should extend `SearchBase` when they belong to LazyLLM.
- Provider code should expose a small public surface and keep request helpers private.
- Tool docs should explain business-facing method selection in both Chinese and English.

