### PR TITLE
feat(tools): support list credentials in config injection

### DIFF
--- a/lazyllm/tools/tool_config_inject.py
+++ b/lazyllm/tools/tool_config_inject.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import lazyllm
 from lazyllm import LOG
@@ -43,15 +43,15 @@ TOOL_AUTH_REGISTRY: Dict[str, str] = {
 _DEFAULT_CONFIG_KEY = 'dynamic_tool_auth'
 
 
-def inject_tool_config(tool_config: Optional[Dict[str, str]]) -> None:
+def inject_tool_config(tool_config: Optional[Dict[str, Any]]) -> None:
     '''Inject per-request tool credentials into lazyllm globals.
 
-    tool_config maps tool names to credential tokens::
+    tool_config maps tool names to credential tokens or token lists::
 
         {
             "feishu": "u-xxx",    # OAuth2 access token (caller is responsible for freshness)
             "bing":   "sk-xxx",
-            "google": "AIza...",
+            "google": ["AIza...", "AIza..."],
         }
 
     The destination config key for each tool is determined by
@@ -67,22 +67,27 @@ def inject_tool_config(tool_config: Optional[Dict[str, str]]) -> None:
         return
 
     # Collect updates grouped by config key.
-    updates: Dict[str, Dict[str, str]] = {}
+    updates: Dict[str, Dict[str, Any]] = {}
     injected: list = []
 
     for tool_name, token in tool_config.items():
-        if not isinstance(token, str):
-            LOG.warning(f'[inject_tool_config] skipping {tool_name!r}: expected str token, '
+        if isinstance(token, str):
+            value = token.strip()
+        elif isinstance(token, (list, tuple)) and all(isinstance(k, str) for k in token):
+            keys = [k.strip() for k in token if k.strip()]
+            value = keys if len(keys) > 1 else (keys[0] if keys else '')
+        else:
+            LOG.warning(f'[inject_tool_config] skipping {tool_name!r}: expected str or list[str] token, '
                         f'got {type(token).__name__}')
             continue
-        token = token.strip()
-        if not token:
+        if not value:
             LOG.warning(f'[inject_tool_config] skipping {tool_name!r}: token is empty')
             continue
 
         canonical = tool_name.lower().strip()
         config_key = TOOL_AUTH_REGISTRY.get(canonical, _DEFAULT_CONFIG_KEY)
-        updates.setdefault(config_key, {})[canonical] = token
+
+        updates.setdefault(config_key, {})[canonical] = value
         injected.append(canonical)
 
     for config_key, new_entries in updates.items():


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Support injecting multiple credentials for a single tool through `list[str]` or `tuple[str]` values.
- Preserve existing single-token behavior while normalizing empty strings out of list values.

---

# 🎯 问题背景 / Problem Context

- Some tool integrations need multiple API keys or credentials instead of a single token.
- `inject_tool_config` previously accepted only `str`, so multi-key config values were skipped.

# 🔍 相关 Issue / Related Issue

* None

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `make lint-only-diff`
2. `git diff --cached --check`
3. Reviewed the staged diff for backward compatibility with string tokens.

---

# 📷 Demo (Optional)

* N/A

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
inject_tool_config({
    'google': ['AIza...', 'AIza...'],
    'bing': 'sk-xxx',
})
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
inject_tool_config({'google': 'AIza...'})
```

## After

```python
inject_tool_config({'google': ['AIza...', 'AIza...']})
```

# ⚠️ 注意事项 / Additional Notes

* Empty strings are filtered from credential lists.
* Lists with one non-empty token are stored as a single string to preserve the previous shape.

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
```text
将submodule的lazyllm暂存的py文件提交push到self并向main提交一个pr，遵守pr模版
```

## 一开始制定了什么方案

Inspect the lazyllm submodule, identify the staged Python file, run template-required checks, commit the staged change,
push it to the user's fork with the requested `dya/` branch prefix, and create a PR to upstream `main`.

## 方案实施后存在什么问题

The first push used the default `codex/` branch prefix before the user clarified that branches should use `dya/`.

## 我（用户）发现了哪些问题

The user pointed out that the branch prefix should be `dya/` and asked Codex to remember that preference.

## 对这些问题优化后相比于之前有哪些优势

The local branch was renamed to `dya/support-tool-config-list-tokens`, pushed to `self`, and the temporary remote
`codex/` branch was deleted. The PR now uses the requested branch naming convention.

## 哪些可以沉淀为自己后续的编码规范

Use `dya/` as the branch prefix for this user's LazyLLM work, and keep PR bodies aligned with the repository's default
PR template including AI involvement details.
