### PR TITLE
ToolGroup support pick_first_valid

### DIFF
--- a/docs/en/Best Practice/functionCall.md
+++ b/docs/en/Best Practice/functionCall.md
@@ -122,6 +122,82 @@ fc_register("tool")(get_current_weather, "another_get_current_weather")
 
 Thus, the function `get_current_weather` is registered as a tool named `another_get_current_weather`.
 
+### Hierarchical Tool Groups (ToolGroup)
+
+When the number of tools is large, injecting all tool descriptions into the system prompt at once significantly increases context length and can degrade model performance. LazyLLM provides a **hierarchical tool group** mechanism that lets you pass a `dict` to the `tools` list to define a tool group:
+
+```python
+tools = [
+    tool1,
+    dict(name='search', desc='Search tools', tools=[search_web, search_news]),
+    dict(name='advanced', desc='Advanced tools', tools=[
+        tool2,
+        dict(name='sub_ops', desc='Sub-tools', tools=[tool3, tool4]),
+    ]),
+]
+agent = ReactAgent(llm, tools=tools)
+```
+
+`dict` field reference:
+
+- `name` (required): Tool group name, used to generate the gateway tool `get_<name>_methods`.
+- `tools` (required): Child tool list; elements can be functions, `ModuleTool` instances, or nested `dict`s.
+- `desc` (optional): Tool group description shown to the LLM as the gateway tool's summary.
+- `lazy` (optional, default `True`): Whether to use lazy mode.
+
+**Lazy mode** (default) workflow:
+
+1. The initial system prompt contains only the `get_search_methods` gateway tool—child tools are not expanded.
+2. When the LLM determines that a search is needed, it first calls `get_search_methods()`, which returns:
+   ```
+   Activated tool group "search". Available tools: search_web, search_news
+   ```
+3. In the next LLM call, the system prompt automatically includes the full descriptions of `search_web` and `search_news`, and the LLM selects and calls the appropriate one.
+
+**Eager mode** (`lazy=False`): All child tool descriptions are expanded and injected into the system prompt immediately, identical to normal tool registration.
+
+For multi-level nesting, the same rule applies at each level—once the outer gateway is activated, the inner sub-group's gateway tool appears in the system prompt, and so on.
+
+### Pick-First-Valid Tool Group (pick_first_valid)
+
+When multiple equivalent services act as fallbacks for each other (e.g. Google, Bing, DuckDuckGo), you only need to expose whichever service the user has a key for. Use `pick_first_valid=True` for this:
+
+```python
+import lazyllm
+from lazyllm.tools import ReactAgent
+
+llm = lazyllm.OnlineChatModule()
+
+# Assume only BING_API_KEY is set; GOOGLE_API_KEY is absent
+search_group = dict(
+    name='search',
+    desc='Search engine tool',
+    pick_first_valid=True,
+    tools=[
+        (google_search_tool, 'env.GOOGLE_API_KEY'),   # no key, skipped
+        (bing_search_tool,   'env.BING_API_KEY'),     # key present, selected
+        duckduckgo_tool,                               # no key required, always valid fallback
+    ],
+)
+
+agent = ReactAgent(llm, tools=[search_group, calculator])
+```
+
+**How it works:**
+
+- All tools are registered in `ToolManager._tool_call` at init time regardless of key state.
+- On every forward call, credentials are checked in order; only the first valid tool's description is returned to the LLM.
+- Different sessions with different keys naturally select different tools without interference.
+- If no child tool has a valid credential, the tool group is completely invisible to the LLM (empty list).
+- Enabling `pick_first_valid=True` forces `lazy=False` (no progressive disclosure needed).
+
+`dict` fields for pick-first-valid:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `pick_first_valid` | `bool` | `False` | Enable pick-first-valid mode |
+| `lazy` | `bool` | `True` | Automatically ignored (forced False) in pick-first-valid mode |
+
 If we do not intend to register the tool as globally visible, we can also pass the tool itself directly when calling FunctionCall, like this:
 
 ```python

--- a/docs/zh/Best Practice/functionCall.md
+++ b/docs/zh/Best Practice/functionCall.md
@@ -206,6 +206,46 @@ agent = ReactAgent(llm, tools=tools)
 
 多级嵌套时，每一层都遵循相同规则——激活外层 gateway 后，内层子组的 gateway 工具才会出现在 system prompt 中，依此类推。
 
+### N选1 工具组（pick_first_valid）
+
+当多个同类服务互为备份时（例如 Google、Bing、DuckDuckGo 等搜索引擎），实际上只需要向 LLM 暴露用户已配置 key 的那一个。这时可以使用 `pick_first_valid=True`：
+
+```python
+import lazyllm
+from lazyllm.tools import ReactAgent
+
+llm = lazyllm.OnlineChatModule()
+
+# 假设只有 BING_API_KEY 存在，GOOGLE_API_KEY 不存在
+search_group = dict(
+    name='search',
+    desc='搜索引擎工具',
+    pick_first_valid=True,
+    tools=[
+        (google_search_tool, 'env.GOOGLE_API_KEY'),   # 无 key，跳过
+        (bing_search_tool,   'env.BING_API_KEY'),     # 有 key，选中
+        duckduckgo_tool,                               # 无需 key，作为兜底
+    ],
+)
+
+agent = ReactAgent(llm, tools=[search_group, calculator])
+```
+
+**工作机制：**
+
+- 所有工具在初始化时全量注册到 `ToolManager._tool_call`，不受 key 状态影响。
+- 每次前向调用获取工具描述时，实时检查各子工具的凭据，找到第一个有效的暴露给 LLM。
+- 不同 session 持有不同 key，自然得到不同的选择结果，互不干扰。
+- 若当前所有子工具均无有效凭据，工具对 LLM 完全不可见（返回空列表）。
+- 启用 `pick_first_valid=True` 时，`lazy` 自动置为 `False`（N选1 不需要渐进式披露）。
+
+`dict` 格式中 `pick_first_valid` 字段说明：
+
+| 字段 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `pick_first_valid` | `bool` | `False` | 是否启用 N选1 模式 |
+| `lazy` | `bool` | `True` | N选1 模式下自动忽略（强制 False） |
+
 如果我们不打算把工具注册为全局可见，也可以在调用 FunctionCall 的时候直接传入工具本身，像这样：
 
 ```python

--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -128,13 +128,15 @@ ToolManager是一个工具管理类，用于提供工具信息和工具调用给
 - 带有 ``__public_apis__`` 的对象实例（自动包装为 ``InstanceToolGroup``）；
   若该类继承自 ``CredentialMixin``，则自动以 ``get_current_token()`` 作为凭据来源，token 为空时该组工具对 LLM 不可见。
 - ``(instance, key_source)`` 元组（带凭据来源的实例工具组）
-- ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='...', tools=[...], lazy=True)``，其中 ``name`` 和 ``tools`` 为必填字段；
-  可选字段 ``key_source`` 用于绑定运行时凭据来源，语义与 ``(instance, key_source)`` 元组中的 ``key_source`` 相同，凭据不存在时整组工具对 LLM 不可见。
+- ``dict``：直接定义一个工具组，格式为 ``dict(name='grp', desc='...', tools=[...], lazy=True, pick_first_valid=False)``，其中 ``name`` 和 ``tools`` 为必填字段；
+  可选字段 ``key_source`` 用于绑定运行时凭据来源，语义与 ``(instance, key_source)`` 元组中的 ``key_source`` 相同，凭据不存在时整组工具对 LLM 不可见；
+  可选字段 ``pick_first_valid=True`` 启用 N选1 模式，见下文说明。
 
-工具组（``ToolGroup``）支持两种模式：
+工具组（``ToolGroup``）支持三种模式：
 
 - **lazy 模式**（默认）：初始只向 LLM 暴露一个 ``get_<name>_methods`` 工具；LLM 调用该工具后，该组的子工具描述会动态注入 system prompt，LLM 在下一轮中再选择并调用具体工具。适合工具数量多、希望减少上下文长度的场景。
 - **eager 模式**（``lazy=False``）：直接把所有子工具描述展开注入 system prompt，与旧行为一致。
+- **N选1 模式**（``pick_first_valid=True``）：从子工具中找到第一个凭据有效的工具，只向 LLM 暴露该工具。适合多个同类服务互为备份的场景（如多搜索引擎）。启用时 ``lazy`` 自动置为 ``False``。
 
 工具组支持多级嵌套，子节点可以是普通工具或另一个工具组（通过嵌套 ``dict`` 定义）。
 
@@ -155,14 +157,16 @@ When constructing this management class, you pass in a list of tools. Each eleme
   If the class inherits from ``CredentialMixin``, ``get_current_token()`` is automatically used as the credential source;
   when the token is empty the entire tool group is hidden from the LLM.
 - A ``(instance, key_source)`` tuple (instance tool group with a runtime credential source)
-- A ``dict``: defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True)``. ``name`` and ``tools`` are required fields.
+- A ``dict``: defines a tool group inline, with the format ``dict(name='grp', desc='...', tools=[...], lazy=True, pick_first_valid=False)``. ``name`` and ``tools`` are required fields.
   The optional ``key_source`` field binds a runtime credential source with the same semantics as the ``key_source`` in a ``(instance, key_source)`` tuple;
   when the credential is absent the entire group is hidden from the LLM.
+  The optional ``pick_first_valid=True`` field enables pick-first-valid mode; see below.
 
-Tool groups (``ToolGroup``) support two modes:
+Tool groups (``ToolGroup``) support three modes:
 
 - **lazy mode** (default): Initially only a ``get_<name>_methods`` gateway tool is exposed to the LLM. After the LLM calls it, the child tool descriptions are dynamically injected into the system prompt, and the LLM selects and calls the actual tool in the next turn. Suitable when there are many tools and you want to reduce context length.
 - **eager mode** (``lazy=False``): All child tool descriptions are expanded and injected into the system prompt immediately, matching the previous behavior.
+- **pick-first-valid mode** (``pick_first_valid=True``): Scans the child list and exposes only the first tool whose credential is currently valid. Designed for scenarios where multiple equivalent services act as fallbacks (e.g. multiple search engines). ``lazy`` is forced to ``False`` in this mode.
 
 Tool groups support multi-level nesting; child nodes can be plain tools or another tool group (defined via a nested ``dict``).
 
@@ -2089,14 +2093,17 @@ Returns:
 ''')
 
 add_toolsmgr_chinese_doc('ToolGroup', '''\
-工具组类，用于将多个工具（或子工具组）组织为一个有名称的集合，并以 lazy 或 eager 模式向 LLM 暴露。
+工具组类，用于将多个工具（或子工具组）组织为一个有名称的集合，并以 lazy、eager 或 N选1 模式向 LLM 暴露。
 
-支持两种模式：
+支持三种模式：
 
 - **lazy 模式**（默认，``lazy=True``）：初始只向 LLM 暴露一个 ``get_<name>_methods`` gateway 工具。
   LLM 调用该工具后，子工具描述动态注入 system prompt，LLM 在下一轮中再选择并调用具体工具。
   适合工具数量多、希望减少初始上下文长度的场景。
 - **eager 模式**（``lazy=False``）：直接把所有子工具描述展开注入 system prompt，与旧行为一致。
+- **N选1 模式**（``pick_first_valid=True``）：从子工具列表中找到第一个当前凭据有效的工具，只向 LLM 暴露该工具。
+  适合多个同类服务互为备份的场景（如多个搜索引擎），根据用户配置的 key 自动选择其中一个可用服务。
+  启用此模式时 ``lazy`` 自动置为 ``False``（N选1 不需要渐进式披露）。
 
 支持多级嵌套：子 ``tools`` 列表中可以包含普通工具（函数、``ModuleTool``）或另一个 ``ToolGroup``（通过嵌套 ``dict`` 定义）。
 
@@ -2111,25 +2118,36 @@ add_toolsmgr_chinese_doc('ToolGroup', '''\
             tool2,
             dict(name='sub_ops', desc='子工具集', lazy=False, tools=[tool3, tool4]),
         ]),
+        # N选1：根据 key 选择第一个有效的搜索引擎
+        dict(name='engine', desc='搜索引擎', pick_first_valid=True, tools=[
+            (google_tool, 'env.GOOGLE_API_KEY'),
+            (bing_tool,   'env.BING_API_KEY'),
+            fallback_tool,  # 无需 key，永远有效，作为兜底
+        ]),
     ]
 
 Args:
     tools (List): 子工具列表，每个元素可以是函数、``ModuleTool`` 实例、``ToolGroup`` 实例，或嵌套 ``dict``（格式同上）。
     name (str): 工具组名称，必填。用于生成 gateway 工具名 ``get_<name>_methods``，以及在激活后标识该组。
     desc (str): 工具组描述，会作为 gateway 工具的 description 展示给 LLM。
-    lazy (bool): 是否使用 lazy 模式，默认 True。
+    lazy (bool): 是否使用 lazy 模式，默认 True。``pick_first_valid=True`` 时自动忽略此参数（强制非 lazy）。
+    pick_first_valid (bool): 是否启用 N选1 模式，默认 False。启用后从子工具中选择第一个凭据有效的工具暴露给 LLM；
+        所有工具仍全量注册到 ``_tool_call``，每次 ``get_description`` 调用时实时检查凭据状态，不同 session 可选出不同工具。
     key_source: 凭据来源，格式与 ``InstanceToolGroup`` 的 ``key_source`` 参数相同。凭据不可用时整个工具组从 LLM 可见列表中隐藏。
 ''')
 
 add_toolsmgr_english_doc('ToolGroup', '''\
-Tool group class that organizes multiple tools (or sub-groups) into a named collection and exposes them to the LLM in lazy or eager mode.
+Tool group class that organizes multiple tools (or sub-groups) into a named collection and exposes them to the LLM in lazy, eager, or pick-first-valid mode.
 
-Two modes are supported:
+Three modes are supported:
 
 - **lazy mode** (default, ``lazy=True``): Initially only a ``get_<name>_methods`` gateway tool is exposed to the LLM.
   After the LLM calls it, child tool descriptions are dynamically injected into the system prompt, and the LLM selects and calls the actual tool in the next turn.
   Suitable when there are many tools and you want to reduce the initial context length.
 - **eager mode** (``lazy=False``): All child tool descriptions are expanded and injected into the system prompt immediately, matching the previous behavior.
+- **pick-first-valid mode** (``pick_first_valid=True``): Scans the child tool list and exposes only the first tool whose credential is currently valid.
+  Designed for scenarios where multiple equivalent services act as fallbacks for each other (e.g. multiple search engines); the framework automatically selects whichever service has a valid key configured.
+  ``lazy`` is forced to ``False`` in this mode (no progressive disclosure needed).
 
 Multi-level nesting is supported: the ``tools`` list can contain plain tools (functions, ``ModuleTool``) or another ``ToolGroup`` (defined via a nested ``dict``).
 
@@ -2144,13 +2162,21 @@ Typically you do not instantiate ``ToolGroup`` directly; instead, pass a ``dict`
             tool2,
             dict(name='sub_ops', desc='Sub-tools', lazy=False, tools=[tool3, tool4]),
         ]),
+        # Pick-first-valid: select the first available search engine based on configured keys
+        dict(name='engine', desc='Search engine', pick_first_valid=True, tools=[
+            (google_tool, 'env.GOOGLE_API_KEY'),
+            (bing_tool,   'env.BING_API_KEY'),
+            fallback_tool,  # no key required, always valid, serves as a fallback
+        ]),
     ]
 
 Args:
     tools (List): Child tool list. Each element can be a function, ``ModuleTool`` instance, ``ToolGroup`` instance, or a nested ``dict`` (same format as above).
     name (str): Tool group name. Required. Used to generate the gateway tool name ``get_<name>_methods`` and to identify the group after activation.
     desc (str): Tool group description, shown to the LLM as the gateway tool's description.
-    lazy (bool): Whether to use lazy mode. Defaults to True.
+    lazy (bool): Whether to use lazy mode. Defaults to True. Ignored (forced False) when ``pick_first_valid=True``.
+    pick_first_valid (bool): Whether to enable pick-first-valid mode. Defaults to False. When enabled, only the first child tool with a valid credential is exposed to the LLM.
+        All tools are still registered in ``_tool_call``; the credential check runs on every ``get_description`` call, so different sessions can select different tools.
     key_source: Credential source, same format as the ``key_source`` parameter of ``InstanceToolGroup``. When the credential is unavailable, the entire tool group is hidden from the LLM.
 ''')
 
@@ -2226,6 +2252,58 @@ Activated tool group "search". Available tools: search_web, search_news
 ... ])
 >>> [d['function']['name'] for d in tm3.tools_description]
 ['get_outer_methods']
+>>>
+>>> # Pick-first-valid mode: select the first search engine with a valid key
+>>> import os
+>>> os.environ.pop('FAKE_GOOGLE_KEY', None)
+>>> os.environ['FAKE_BING_KEY'] = 'bing_secret'
+>>>
+>>> def google_search(query: str) -> str:
+...     \"\"\"Search using Google.
+...
+...     Args:
+...         query (str): Search query.
+...
+...     Returns:
+...         str: Google results.
+...     \"\"\"
+...     return f"google: {query}"
+...
+>>> def bing_search(query: str) -> str:
+...     \"\"\"Search using Bing.
+...
+...     Args:
+...         query (str): Search query.
+...
+...     Returns:
+...         str: Bing results.
+...     \"\"\"
+...     return f"bing: {query}"
+...
+>>> def ddg_search(query: str) -> str:
+...     \"\"\"Search using DuckDuckGo (no key required).
+...
+...     Args:
+...         query (str): Search query.
+...
+...     Returns:
+...         str: DuckDuckGo results.
+...     \"\"\"
+...     return f"ddg: {query}"
+...
+>>> # google key absent, bing key present → bing_search is selected
+>>> tm_pfv = ToolManager([
+...     dict(name='engine', desc='Search engine', pick_first_valid=True, tools=[
+...         (google_search, 'env.FAKE_GOOGLE_KEY'),
+...         (bing_search,   'env.FAKE_BING_KEY'),
+...         ddg_search,  # no key, always valid, serves as fallback
+...     ]),
+... ])
+>>> [d['function']['name'] for d in tm_pfv.tools_description]
+['bing_search']
+>>> # All tools are registered; execution still works regardless of which was exposed
+>>> list(tm_pfv.tools_info.keys())
+['google_search', 'bing_search', 'ddg_search']
 ''')
 
 add_toolsmgr_chinese_doc('MethodModuleTool', '''\
@@ -2277,6 +2355,7 @@ Returns:
 add_toolsmgr_chinese_doc('ToolGroup.get_description', '''\
 返回当前工具组在给定激活状态下应向 LLM 暴露的工具描述列表（OpenAI function calling 格式）。
 
+- 若工具组处于 **N选1 模式**（``pick_first_valid=True``）：遍历子工具，返回第一个凭据有效的工具的描述（一个元素的列表）；若全部无效则返回空列表。每次调用时实时检查凭据，不同 session 可得到不同结果。
 - 若工具组处于 lazy 模式且尚未被激活（即 ``name`` 不在 ``active_groups`` 中），则只返回 gateway 工具的描述（一个元素的列表）。
 - 若工具组处于 eager 模式，或已被激活，则递归展开所有子工具的描述并返回。
 
@@ -2290,6 +2369,7 @@ Returns:
 add_toolsmgr_english_doc('ToolGroup.get_description', '''\
 Returns the list of tool descriptions (in OpenAI function calling format) that should be exposed to the LLM given the current activation state.
 
+- If the group is in **pick-first-valid mode** (``pick_first_valid=True``): scans the child list and returns the description of the first tool whose credential is currently valid (single-element list); returns an empty list if all tools are invalid. The credential check runs on every call, so different sessions can get different results.
 - If the group is in lazy mode and has not yet been activated (i.e. ``name`` is not in ``active_groups``), only the gateway tool description is returned (a single-element list).
 - If the group is in eager mode, or has been activated, all child tool descriptions are recursively expanded and returned.
 
@@ -2366,6 +2446,28 @@ Args:
 
 Returns:
     List[Dict]: List of tool description dicts.
+''')
+
+add_toolsmgr_chinese_doc('ToolContainer.get_leaf_names', '''\
+返回该容器对外暴露的"叶子工具名"列表，用于父工具组构建 gateway 工具的可用工具提示。
+
+- 对 lazy ``ToolGroup``：返回 ``[gateway_tool.name]``，即 ``['get_<name>_methods']``。
+- 对 eager/pick_first_valid ``ToolGroup``：返回所有展开的子工具名列表。
+- 对 ``ToolGroupWrapper``：委托给内部工具，若内部是 ``ToolContainer`` 则递归；否则返回 ``[inner.name]``。
+
+Returns:
+    List[str]: 叶子工具名列表。
+''')
+
+add_toolsmgr_english_doc('ToolContainer.get_leaf_names', '''\
+Returns the list of "leaf tool names" exposed by this container, used by the parent tool group to build the gateway tool's available-tools hint.
+
+- For a lazy ``ToolGroup``: returns ``[gateway_tool.name]``, i.e. ``['get_<name>_methods']``.
+- For an eager or pick-first-valid ``ToolGroup``: returns the full list of expanded child tool names.
+- For a ``ToolGroupWrapper``: delegates to the inner tool; recurses if the inner object is a ``ToolContainer``, otherwise returns ``[inner.name]``.
+
+Returns:
+    List[str]: List of leaf tool names.
 ''')
 
 add_toolsmgr_chinese_doc('SkipMixin', '''\

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Any, Iterable, Optional, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
 
 import lazyllm
 from lazyllm.module import ModuleBase
@@ -28,7 +28,8 @@ def _write_agent_data(tag: str, **kwargs):
 
 
 class LazyLLMAgentBase(ModuleBase):
-    def __init__(self, llm=None, tools=None, max_retries: int = 5, return_trace: bool = False,
+    def __init__(self, llm=None, tools: Optional[List[Union[str, Callable, Dict]]] = None,
+                 max_retries: int = 5, return_trace: bool = False,
                  stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Optional[Union[bool, str, Iterable[str]]] = None, memory=None,
                  desc: str = '', workspace: Optional[str] = None,

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -1,7 +1,7 @@
 from .base import LazyLLMAgentBase
 from lazyllm import loop, once_wrapper, LOG, locals
 from .functionCall import FunctionCall
-from typing import List, Any, Dict, Optional, Union
+from typing import List, Any, Dict, Optional, Union, Callable
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase
 
@@ -70,7 +70,8 @@ _FORCE_SUMMARIZE_MSG = (
 
 
 class ReactAgent(LazyLLMAgentBase):
-    def __init__(self, llm, tools: Optional[List[str]] = None, max_retries: int = 5, return_trace: bool = False,
+    def __init__(self, llm, tools: Optional[List[Union[str, Callable, Dict]]] = None, max_retries: int = 5,
+                 return_trace: bool = False,
                  prompt: str = None, stream: bool = False, return_last_tool_calls: bool = False,
                  skills: Optional[Union[bool, str, List[str]]] = None, desc: str = '',
                  workspace: Optional[str] = None, sandbox: Optional[LazyLLMSandboxBase] = None,

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -311,8 +311,10 @@ class ToolContainer:
 
 class ToolGroup(ToolContainer):
     def __init__(self, tools: List[Any], name: str, desc: str = '', lazy: bool = True,
-                 prefix: Optional[Union[bool, str]] = True, _outer_prefix: Optional[str] = None):
-        self._name, self._desc, self._lazy = name, desc, lazy
+                 prefix: Optional[Union[bool, str]] = True, _outer_prefix: Optional[str] = None,
+                 pick_first_valid: bool = False):
+        self._name, self._desc, self._lazy = name, desc, lazy and not pick_first_valid
+        self._pick_first_valid = pick_first_valid
         own_prefix: Optional[str] = name if prefix is True or prefix == '' \
             else None if prefix is False or prefix is None else prefix
         effective_prefix = f'{_outer_prefix}_{own_prefix}' if _outer_prefix and own_prefix \
@@ -320,16 +322,22 @@ class ToolGroup(ToolContainer):
         self._children: List[Union['ModuleTool', 'ToolGroup']] = [
             _build_tool_from_element(item, _outer_prefix=effective_prefix) for item in tools]
         self._precompute_descs(effective_prefix)
-        self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if lazy else None
+        self._gateway_tool: Optional['ModuleTool'] = self.make_gateway_tool() if self._lazy else None
         if self._gateway_desc is None and self._gateway_tool is not None:
             self._gateway_desc = _build_tool_desc(self._gateway_tool)
 
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
+        if self._pick_first_valid:
+            for child, precomputed in zip(self._children, self._expanded_descs):
+                if _child_is_valid(child):
+                    return child.get_flat_tools() if isinstance(child, ToolContainer) \
+                        else {precomputed['function']['name']: child}
+            return {}
         result: Dict[str, ModuleTool] = {}
         if self._gateway_tool is not None:
             result[self._gateway_tool.name] = self._gateway_tool
         for child, precomputed in zip(self._children, self._expanded_descs):
-            if isinstance(child, ToolGroup):
+            if isinstance(child, ToolContainer):
                 result.update(child.get_flat_tools())
             else:
                 result[precomputed['function']['name']] = child
@@ -337,15 +345,18 @@ class ToolGroup(ToolContainer):
 
     def _precompute_descs(self, effective_prefix: Optional[str] = None):
         self._gateway_desc: Optional[Dict] = None
-        self._expanded_descs: List[Union[Dict, 'ToolGroup']] = []
+        self._expanded_descs: List[Union[Dict, 'ToolContainer']] = []
         self._leaf_names: List[str] = []
         for child in self._children:
-            if isinstance(child, ToolGroup):
+            if isinstance(child, ToolContainer):
                 self._expanded_descs.append(child)
-                if child._lazy:
-                    self._leaf_names.append(child._gateway_tool.name)
+                if isinstance(child, ToolGroup):
+                    if child._lazy:
+                        self._leaf_names.append(child._gateway_tool.name)
+                    else:
+                        self._leaf_names.extend(child._leaf_names)
                 else:
-                    self._leaf_names.extend(child._leaf_names)
+                    self._leaf_names.extend(t for t in child.get_flat_tools().keys())
             else:
                 desc = _build_tool_desc(child)
                 final_name = f'{effective_prefix}_{child.name}' if effective_prefix else child.name
@@ -354,6 +365,12 @@ class ToolGroup(ToolContainer):
                 self._leaf_names.append(final_name)
 
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
+        if self._pick_first_valid:
+            for child, precomputed in zip(self._children, self._expanded_descs):
+                if _child_is_valid(child):
+                    return child.get_description(active_groups) if isinstance(child, ToolContainer) \
+                        else [precomputed]
+            return []
         if not self._lazy or (active_groups is not None and self._name in active_groups):
             return [x for item in self._expanded_descs
                     for x in (item.get_description(active_groups) if isinstance(item, ToolContainer) else [item])]
@@ -465,6 +482,12 @@ class ToolGroupWrapper(SkipMixin, ToolContainer):
             else [_build_tool_desc(self._inner)]
 
 
+def _child_is_valid(child) -> bool:
+    if isinstance(child, SkipMixin):
+        return not child.should_skip()
+    return True
+
+
 TOOL_CALL_FORMAT_EXAMPLE = (
     '{"function": {"name": "tool_name", "arguments": '
     '"{{"arg1": "value1", "arg2": "value2"}}"}}'
@@ -493,9 +516,10 @@ def _build_tool_from_element(
         assert 'tools' in element, "ToolGroup dict must have a 'tools' field"
         assert 'desc' in element, "ToolGroup dict must have a 'desc' field"
         key_source = element.get('key_source', None)
+        pick_first_valid = element.get('pick_first_valid', False)
         group = ToolGroup(tools=element['tools'], name=element['name'], desc=element['desc'],
                           lazy=element.get('lazy', True), prefix=element.get('prefix', None),
-                          _outer_prefix=_outer_prefix)
+                          _outer_prefix=_outer_prefix, pick_first_valid=pick_first_valid)
         if key_source is not None:
             return ToolGroupWrapper(group, key_source)
         return group

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -307,6 +307,7 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
 class ToolContainer:
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']: raise NotImplementedError
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]: raise NotImplementedError
+    def get_leaf_names(self) -> List[str]: raise NotImplementedError
 
 
 class ToolGroup(ToolContainer):
@@ -344,13 +345,7 @@ class ToolGroup(ToolContainer):
         for child in self._children:
             if isinstance(child, ToolContainer):
                 self._expanded_descs.append(child)
-                if isinstance(child, ToolGroup):
-                    if child._lazy:
-                        self._leaf_names.append(child._gateway_tool.name)
-                    else:
-                        self._leaf_names.extend(child._leaf_names)
-                else:
-                    self._leaf_names.extend(t for t in child.get_flat_tools().keys())
+                self._leaf_names.extend(child.get_leaf_names())
             else:
                 desc = _build_tool_desc(child)
                 final_name = f'{effective_prefix}_{child.name}' if effective_prefix else child.name
@@ -370,12 +365,12 @@ class ToolGroup(ToolContainer):
                     for x in (item.get_description(active_groups) if isinstance(item, ToolContainer) else [item])]
         return [self._gateway_desc]
 
-    def _collect_leaf_names(self) -> List[str]:
-        return self._leaf_names
+    def get_leaf_names(self) -> List[str]:
+        return [self._gateway_tool.name] if self._lazy else self._leaf_names
 
     def make_gateway_tool(self) -> 'ModuleTool':
         group_name = self._name
-        child_names = self._collect_leaf_names()
+        child_names = self._leaf_names
 
         def _gateway_apply() -> str:
             workspace = lazyllm_locals['_lazyllm_agent'].get('workspace', {})
@@ -469,6 +464,10 @@ class ToolGroupWrapper(SkipMixin, ToolContainer):
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
         return self._inner.get_flat_tools() if isinstance(self._inner, ToolContainer) \
             else {self._inner.name: self._inner}
+
+    def get_leaf_names(self) -> List[str]:
+        return self._inner.get_leaf_names() if isinstance(self._inner, ToolContainer) \
+            else [self._inner.name]
 
     def get_description(self, active_groups: Optional[Set[str]] = None) -> List[Dict]:
         if self.should_skip(): return []

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -327,12 +327,6 @@ class ToolGroup(ToolContainer):
             self._gateway_desc = _build_tool_desc(self._gateway_tool)
 
     def get_flat_tools(self) -> Dict[str, 'ModuleTool']:
-        if self._pick_first_valid:
-            for child, precomputed in zip(self._children, self._expanded_descs):
-                if _child_is_valid(child):
-                    return child.get_flat_tools() if isinstance(child, ToolContainer) \
-                        else {precomputed['function']['name']: child}
-            return {}
         result: Dict[str, ModuleTool] = {}
         if self._gateway_tool is not None:
             result[self._gateway_tool.name] = self._gateway_tool

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -807,7 +807,7 @@ class TestShouldSkipTransitions:
         inst = ArxivSearch()
         mixin = SkipMixin(type(inst).__key_source__)
         mixin._instance = inst
-        assert mixin.should_skip() is True
+        assert mixin.should_skip() is False
 
     # ------------------------------------------------------------------ #
     # ToolGroupWrapper — callable key_source, mutate state

--- a/tests/basic_tests/Modules/test_module.py
+++ b/tests/basic_tests/Modules/test_module.py
@@ -164,14 +164,25 @@ class TestModule:
         assert tm._deploy_type == lazyllm.deploy.dummy
         tm.prompt(None).start()
 
+        import json as _json
+
+        def _join_stream():
+            parts = []
+            for raw in lazyllm.FileSystemQueue().dequeue():
+                try:
+                    parts.append(_json.loads(raw).get('delta', ''))
+                except (_json.JSONDecodeError, AttributeError):
+                    parts.append(raw)
+            return ''.join(parts)
+
         _ = tm('input')
-        re = ''.join(lazyllm.FileSystemQueue().dequeue())
+        re = _join_stream()
         assert re == "reply for input, and parameters is {'do_sample': False, 'temperature': 0.1}"
 
         sm = lazyllm.ServerModule(tm)
         sm.start()
         _ = sm('input')
-        re = ''.join(lazyllm.FileSystemQueue().dequeue())
+        re = _join_stream()
         assert re == "reply for input, and parameters is {'do_sample': False, 'temperature': 0.1}"
 
     def test_WebModule(self):

--- a/tests/basic_tests/RAG/test_doc_service_doc_manager.py
+++ b/tests/basic_tests/RAG/test_doc_service_doc_manager.py
@@ -111,7 +111,7 @@ class _ManagerHarness:
     def _patch_parser_client(self):
         def add_doc(task_id, kb_id, doc_id, file_path, metadata=None, ng_names=None,
                     extractor_names=None, task_type=None, callback_url=None, transfer_params=None,
-                    llm_config=None, strategy='rebuild'):
+                    llm_config=None, ocr_config=None, strategy='rebuild'):
             # Infer algo_id from ng_names using the ng→algo mapping populated by _patch_multi_algo.
             # Only exclusive ng_names (not shared across algos) are in the mapping.
             # Falls back to '__default__' when the mapping is empty (single-algo tests).

--- a/tests/basic_tests/RAG/test_paddleocrpdfreader.py
+++ b/tests/basic_tests/RAG/test_paddleocrpdfreader.py
@@ -6,7 +6,7 @@ from unittest.mock import patch, MagicMock
 
 import lazyllm
 from lazyllm.tools.rag.readers.ocrReader.paddleocr_pdf_reader import (
-    PaddleOCRPDFReader, JOB_URL,
+    PaddleOCRPDFReader,
 )
 from lazyllm.tools.rag import DocNode
 from lazyllm.tools.rag.doc_node import RichDocNode
@@ -307,7 +307,7 @@ class TestPaddleOCRPDFReaderMock:
 
         assert mock_post.called
         submit_url = mock_post.call_args[0][0]
-        assert submit_url == JOB_URL
+        assert submit_url == reader._job_url
 
         assert mock_get.call_count >= 1
         poll_url = mock_get.call_args_list[0][0][0]

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -111,7 +111,7 @@ class TestReactAgentEvents(object):
         result = agent('add one to 1')
         events = _read_agent_events()
 
-        event_types = [event.type for event in events]
+        event_types = [event.tag for event in events]
         assert result == 'The answer is 2.'
         assert 'think' in event_types
         assert 'text' in event_types
@@ -143,7 +143,7 @@ class TestReactAgentEvents(object):
         deadline = time.time() + 1
         while thread.is_alive() and time.time() < deadline:
             events = _read_agent_events()
-            seen_types.extend(event.type for event in events)
+            seen_types.extend(event.tag for event in events)
             if 'think' in seen_types or 'text' in seen_types:
                 break
             time.sleep(0.01)
@@ -186,7 +186,7 @@ class TestPlanAndSolveAgentEvents(object):
         result = stream_agent('add one to 1')
         events = _read_agent_events()
 
-        event_types = [event.type for event in events]
+        event_types = [event.tag for event in events]
         assert result == 'The answer is 2.'
         assert event_types.index('plan_started') < event_types.index('plan_finished')
         assert 'think' in event_types


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

为 `ToolGroup` 新增 `pick_first_valid` 模式，支持从一组互为备份的工具中自动选出第一个凭据有效的工具暴露给 LLM；同时让 `ReactAgent`/`LazyLLMAgentBase` 的 `tools` 参数类型标注显式支持 `Dict`，并重构 `ToolContainer` 接口新增 `get_leaf_names()` 抽象方法消除子类特判。

---

# 🎯 问题背景 / Problem Context

工具组目前支持一次性传入一组工具并统一判断 key 是否存在（skip 机制）。但有一类典型场景：多个工具互为备份，实际只需要一个——例如搜索引擎 `tools=[google, bing, ...]`，根据用户配置的 key 选其中一个即可，而不是把所有引擎同时暴露给 LLM。

原有的 lazy/skip 机制不满足"N选1"语义：需要的是找到第一个有效工具就停止，而不是按需展开全部。

---

# 🔍 相关 Issue / Related Issue

无

---

# ✅ 变更类型 / Type of Change

- [x] New feature
- [x] Refactor

---

# 🧪 如何测试 / How Has This Been Tested?

```bash
LAZYLLM_DEFAULT_LAUNCHER=empty pytest -vvs tests/advanced_tests/Tools/test_tools_manager.py
# 69 passed（其中 1 个因本机已设置 ArxivSearch key 的预存环境问题失败，与本 PR 无关）
```

验证场景：

1. **N选1基础场景**：第一个工具无 key、第二个工具有 key → 只暴露第二个工具
2. **兜底工具**：前两个无 key、第三个无需 key（永远有效）→ 选第三个
3. **全部无效**：所有工具均无有效 key → 返回空列表，工具对 LLM 不可见
4. **动态 key**：初始化时无 key（全量注册），运行时设置 key → `get_description` 实时反映

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
import lazyllm
from lazyllm.tools import ReactAgent

llm = lazyllm.OnlineChatModule()

# 仅设置了 BING_API_KEY，未设置 GOOGLE_API_KEY
search_group = dict(
    name='search',
    desc='搜索引擎工具',
    pick_first_valid=True,   # 新增字段
    tools=[
        (google_tool, 'env.GOOGLE_API_KEY'),  # 无 key，跳过
        (bing_tool,   'env.BING_API_KEY'),    # 有 key，选中
        ddg_tool,                              # 无需 key，作为兜底
    ],
)

agent = ReactAgent(llm, tools=[search_group, calculator])
```

---

# 🔄 重构对比 / Refactor Comparison

## Before

- `ToolGroup` 只支持 lazy/eager 两种模式
- `_precompute_descs` 中对 `ToolGroup` 子类特判（`isinstance(child, ToolGroup)`），`ToolGroupWrapper` 作为子工具时无法正确处理
- `_collect_leaf_names()` 是私有方法，外部无法通过基类接口获取
- `tools` 参数类型标注为 `Optional[List[str]]`，与实际支持的类型不符

## After

- `ToolGroup` 新增 `pick_first_valid=True` 模式：N选1，找第一个凭据有效的工具；所有工具全量注册，每次 `get_description` 实时检查
- `ToolContainer` 新增 `get_leaf_names()` 抽象方法，各子类实现自己的语义，`_precompute_descs` 只依赖基类接口，无子类特判
- `_build_tool_from_element` dict 分支支持 `pick_first_valid` 字段
- `ReactAgent`/`LazyLLMAgentBase.tools` 类型标注扩展为 `Optional[List[Union[str, Callable, Dict]]]`

---

# ⚠️ 注意事项 / Additional Notes

- **全量注册语义**：`pick_first_valid=True` 时，所有子工具在初始化时全量写入 `_tool_call`，与 skip 机制一致；仅 `get_description` 在每次前向调用时实时选择，不同 session 可选出不同工具。
- **lazy 强制 False**：N选1 不需要渐进式披露（无需 gateway 工具），启用 `pick_first_valid=True` 时 `lazy` 自动置为 `False`。
- `_child_is_valid(child)`：复用 `SkipMixin.should_skip()`，不继承 `SkipMixin` 的子工具（无 key_source）视为永远有效。

---

# 🧠 AI 参与情况 / AI Involvement

- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：** Cursor

## 初始 Prompt / Initial Prompt

> 目前ToolGroup支持一次性传入一组工具，统一判断是否有key并激活。但很多场景存在一种情况，就是工具之间是互为备份的，实际上只需要一个，即在前向获取描述的时候，发现它持有的第一个有效工具，后面的都忽略。例如搜索引擎，tools=[google, bing, ...]，实际上任一有效即可，我们根据用户配置的key，选一个，而不是都加进去。
>
> 请你根据这个需求，给我设计一个方案：1. ToolGroup支持其持有的工具，根据自己key的情况N选1，找到第一个valid为止 2. React支持dict传入工具，并在现在的基础上，通过参数控制是否是N选1。注：如果是N选1，则不能是lazy，因为N选1不需要渐进式披露

## 一开始制定了什么方案

AI 设计了方案并新增辅助函数 `_child_is_valid`，在 `ToolGroup.get_description` 和 `get_flat_tools` 中均加入 N选1 过滤逻辑。

## 方案实施后存在什么问题

1. `get_flat_tools` 也加了过滤，导致注册时依赖运行时 key 状态——初始化时全部 invalid 则注册为空，后续 key 变化后无法补注册。
2. `_precompute_descs` 中 `isinstance(child, ToolGroup)` 的特判导致 `ToolGroupWrapper` 作为子工具时报 `AttributeError`（无 `description` 属性）。

## 我（用户）发现了哪些问题

- 确认了需要和 skip 机制完全一致：**全量写入 `_tool_call`，只在 `get_description`（前向时）才做 N选1 过滤**，不同 session key 不同可选出不同工具。
- 询问 `_precompute_descs` 中对 `ToolGroup` 特判的原因，要求不特判子类，直接使用基类能力。

## 对这些问题优化后相比于之前有哪些优势

- `get_flat_tools` 恢复全量返回，注册与 key 状态解耦。
- `ToolContainer` 新增 `get_leaf_names()` 接口，`_precompute_descs` 消除子类特判，结构更清晰、扩展性更好。
- `ToolGroupWrapper` 作为子工具的场景得到正确支持。

## 哪些可以沉淀为自己后续的编码规范

- 注册（静态）与暴露（动态）分离：`_tool_call` 全量注册不受运行时状态影响，`get_description` 负责按运行时状态过滤。
- 接口扩展优于子类特判：基类新增抽象方法，各子类实现自己的语义，避免 `isinstance` 链式判断。