### PR TITLE
fix(bug): support gb18030 encoding csv type

### DIFF
--- a/lazyllm/tools/rag/readers/pandasReader.py
+++ b/lazyllm/tools/rag/readers/pandasReader.py
@@ -15,6 +15,30 @@ _FILL_FUNC_MAP = {
     'bfill': lambda df: df.bfill(),
 }
 
+
+def _read_csv_auto(file, **kwargs):
+    user_encoding = kwargs.pop('encoding', None)
+
+    # Try user override first, then common CSV encodings (GB18030 covers GBK/GB2312).
+    encodings = []
+    for enc in (user_encoding, 'gb18030', 'utf-8', 'utf-8-sig'):
+        if enc and enc not in encodings:
+            encodings.append(enc)
+
+    last_error = None
+    for enc in encodings:
+        try:
+            # File-like objects must rewind between encoding attempts.
+            if hasattr(file, 'seek'):
+                file.seek(0)
+            return pd.read_csv(file, encoding=enc, **kwargs)
+        except UnicodeDecodeError as e:
+            last_error = e
+
+    file_repr = getattr(file, 'name', file)
+    raise ValueError(f'Cannot decode csv: {file_repr}') from last_error
+
+
 def _apply_fill(df: pd.DataFrame, fill_method: Optional[str]) -> pd.DataFrame:
     if fill_method not in _FILL_FUNC_MAP:
         LOG.warning(f'Unsupported fill method: {fill_method}, using fillna instead')
@@ -37,9 +61,9 @@ class PandasCSVReader(LazyLLMReaderBase):
 
         if fs:
             with fs.open(file) as f:
-                df = pd.read_csv(f, **self._pandas_config)
+                df = _read_csv_auto(f, **self._pandas_config)
         else:
-            df = pd.read_csv(file, **self._pandas_config)
+            df = _read_csv_auto(file, **self._pandas_config)
 
         df = _apply_fill(df, self._fill_method)
         text_list = df.apply(lambda row: (self._col_joiner).join(row.astype(str).tolist()), axis=1).tolist()

--- a/lazyllm/tools/rag/readers/pandasReader.py
+++ b/lazyllm/tools/rag/readers/pandasReader.py
@@ -5,7 +5,7 @@ import importlib
 from lazyllm.thirdparty import pandas as pd
 from lazyllm import LOG
 
-from .readerBase import LazyLLMReaderBase
+from .readerBase import LazyLLMReaderBase, get_default_fs
 from ..doc_node import DocNode
 
 
@@ -16,14 +16,17 @@ _FILL_FUNC_MAP = {
 }
 
 
-def _read_csv_auto(file, **kwargs):
+def _read_csv_auto(file, *, file_path: Optional[Path] = None,
+                   fs: Optional['fsspec.AbstractFileSystem'] = None, **kwargs):
     user_encoding = kwargs.pop('encoding', None)
 
-    # Try user override first, then common CSV encodings (GB18030 covers GBK/GB2312).
     encodings = []
-    for enc in (user_encoding, 'utf-8', 'utf-8-sig', 'gb18030'):
-        if enc and enc not in encodings:
-            encodings.append(enc)
+    if user_encoding:
+        encodings.append(user_encoding)
+    if file_path is not None:
+        detected = LazyLLMReaderBase.detect_encoding(file_path, fs or get_default_fs())
+        if detected and detected not in encodings:
+            encodings.append(detected)
 
     last_error = None
     for enc in encodings:
@@ -61,9 +64,9 @@ class PandasCSVReader(LazyLLMReaderBase):
 
         if fs:
             with fs.open(file) as f:
-                df = _read_csv_auto(f, **self._pandas_config)
+                df = _read_csv_auto(f, file_path=file, fs=fs, **self._pandas_config)
         else:
-            df = _read_csv_auto(file, **self._pandas_config)
+            df = _read_csv_auto(file, file_path=file, **self._pandas_config)
 
         df = _apply_fill(df, self._fill_method)
         text_list = df.apply(lambda row: (self._col_joiner).join(row.astype(str).tolist()), axis=1).tolist()

--- a/lazyllm/tools/rag/readers/pandasReader.py
+++ b/lazyllm/tools/rag/readers/pandasReader.py
@@ -21,7 +21,7 @@ def _read_csv_auto(file, **kwargs):
 
     # Try user override first, then common CSV encodings (GB18030 covers GBK/GB2312).
     encodings = []
-    for enc in (user_encoding, 'utf-8', 'gb18030', 'utf-8-sig'):
+    for enc in (user_encoding, 'utf-8', 'utf-8-sig', 'gb18030'):
         if enc and enc not in encodings:
             encodings.append(enc)
 

--- a/lazyllm/tools/rag/readers/pandasReader.py
+++ b/lazyllm/tools/rag/readers/pandasReader.py
@@ -21,7 +21,7 @@ def _read_csv_auto(file, **kwargs):
 
     # Try user override first, then common CSV encodings (GB18030 covers GBK/GB2312).
     encodings = []
-    for enc in (user_encoding, 'gb18030', 'utf-8', 'utf-8-sig'):
+    for enc in (user_encoding, 'utf-8', 'gb18030', 'utf-8-sig'):
         if enc and enc not in encodings:
             encodings.append(enc)
 

--- a/lazyllm/tools/rag/readers/readerBase.py
+++ b/lazyllm/tools/rag/readers/readerBase.py
@@ -77,22 +77,19 @@ class LazyLLMReaderBase(ModuleBase, metaclass=LazyLLMRegisterMetaClass):
         has_high_bytes = any(b > 127 for b in raw_data[:1000])
 
         if has_high_bytes:
-            chinese_encodings = ['gbk', 'gb2312', 'big5']
-            for encoding in chinese_encodings:
-                if cls._try_decode(raw_data, encoding):
-                    try:
-                        decoded = raw_data.decode(encoding)
-                        if any('\u4e00' <= c <= '\u9fff' for c in decoded[:100]):
-                            cls._cache_encoding(cache_key, encoding)
-                            return encoding
-                    except Exception:
-                        pass
-
+            chinese_encodings = ['gb18030', 'gbk', 'gb2312', 'big5']
+            # Prefer UTF-8 when valid; otherwise fall back to Chinese encodings.
+            # Do not require Chinese chars in the first N chars — CSV headers are often long ASCII.
             if cls._try_decode(raw_data, 'utf-8'):
                 cls._cache_encoding(cache_key, 'utf-8')
                 return 'utf-8'
+
+            for encoding in chinese_encodings:
+                if cls._try_decode(raw_data, encoding):
+                    cls._cache_encoding(cache_key, encoding)
+                    return encoding
         else:
-            primary_encodings = ['utf-8', 'gbk', 'gb2312', 'big5']
+            primary_encodings = ['utf-8', 'gb18030', 'gbk', 'gb2312', 'big5']
             for encoding in primary_encodings:
                 if cls._try_decode(raw_data, encoding):
                     cls._cache_encoding(cache_key, encoding)

--- a/tests/basic_tests/RAG/test_reader.py
+++ b/tests/basic_tests/RAG/test_reader.py
@@ -189,6 +189,23 @@ class TestRagReader(object):
         finally:
             shutil.rmtree(temp_dir)
 
+    def test_detect_encoding_gb_csv_long_ascii_header(self):
+        temp_dir = tempfile.mkdtemp()
+        try:
+            csv_file = os.path.join(temp_dir, 'gb_csv_header.csv')
+            header = (
+                'dataset_id,dataset_name,question,ground_truth,reference_context,'
+                'reference_doc,data_source,question_type,score_type,key_point,version,domain\n'
+            )
+            row = '1,test,q,a,ctx,doc,src,type,score,kp,v1,电影\n'
+            with open(csv_file, 'w', encoding='gb18030') as f:
+                f.write(header + row)
+
+            detected = TxtReader.detect_encoding(csv_file)
+            assert detected in ('gb18030', 'gbk'), f'Expected gb18030/gbk, got {detected}'
+        finally:
+            shutil.rmtree(temp_dir)
+
     def test_encoding_cache(self):
         temp_dir = tempfile.mkdtemp()
         try:


### PR DESCRIPTION
研究院公开数据集 使用 gb18030 为编码方式，导致 pandas load csv报错 (默认 utf-8)，现在增加 自动编码 再读取的逻辑。
====================================================================
修复（已改 readerBase.py）
加入 gb18030（排在 gbk 前面）
改掉「前 100 字符必须有中文」的启发式
新策略：
有高字节时：UTF-8 能解就用 UTF-8
UTF-8 失败 → 依次试 gb18030 → gbk → gb2312 → big5，能解码就用

==============
前后对比：
<img width="1245" height="151" alt="image" src="https://github.com/user-attachments/assets/fbee1443-72bf-4ab4-afc5-cf8516bf8c56" />
