### PR TITLE
fix(rag): skip DocServer auto-upgrade for embedded vector stores

### DIFF
--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -60,7 +60,7 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
             connect = isinstance(manager, DocServer)
             if (not spawn and not connect and not processor and is_persistent_store(store_conf)
                     and dataset_path and not os.path.isfile(dataset_path)
-                    and not list(iter_embedded_store_endpoints(store_conf))):
+                    and not any(iter_embedded_store_endpoints(store_conf))):
                 lazyllm.LOG.info(f'Persistent store detected (type={store_conf.get("type")}),'
                                  f' auto-enabling DocServer for production-grade file tracking and scan.')
                 spawn = True

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -59,7 +59,8 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
             spawn = bool(manager) and not isinstance(manager, DocServer)
             connect = isinstance(manager, DocServer)
             if (not spawn and not connect and not processor and is_persistent_store(store_conf)
-                    and dataset_path and not os.path.isfile(dataset_path)):
+                    and dataset_path and not os.path.isfile(dataset_path)
+                    and not list(iter_embedded_store_endpoints(store_conf))):
                 lazyllm.LOG.info(f'Persistent store detected (type={store_conf.get("type")}),'
                                  f' auto-enabling DocServer for production-grade file tracking and scan.')
                 spawn = True


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

`_decide_service_mode` auto-upgrades to DocServer when a persistent store and directory dataset are detected. However, it doesn't check whether the store is embedded (local file) or remote, causing `_reject_embedded_store_with_service_mode` to immediately raise `ValueError` for users with `manager=False` + local Milvus.

This fix skips the auto-upgrade when `iter_embedded_store_endpoints` finds any filesystem-bound backends.

Error:
<img width="1483" height="268" alt="image" src="https://github.com/user-attachments/assets/b294374b-20b3-4b5b-b7fc-ed0bdc4d5754" />


---


# ✅ 变更类型 / Type of Change

* [X] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization


---

# 📷 Demo (Optional)

<img width="1189" height="974" alt="image" src="https://github.com/user-attachments/assets/a48a100f-6ea7-4df6-82c8-f07ad8694009" />

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [X] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [ ] CodeX
- [X] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

