### PR TITLE
fix: harden relay payload and chroma metadata handling

### DIFF
--- a/lazyllm/components/deploy/relay/base.py
+++ b/lazyllm/components/deploy/relay/base.py
@@ -2,6 +2,9 @@ import os
 import random
 import inspect
 import sys
+import shlex
+import subprocess
+import tempfile
 
 from lazyllm import launchers, LazyLLMCMD, dump_obj, config
 from ..base import LazyLLMDeployBase, verify_fastapi_func, verify_ray_func
@@ -9,6 +12,42 @@ from ..utils import get_log_path, make_log_dir
 from typing import Optional
 
 config.add('use_ray', bool, False, 'USE_RAY', description='Whether to use Ray for ServerModule(relay server).')
+
+
+def _should_write_relay_arg_file():
+    return os.name == 'nt'
+
+
+def _can_use_relay_arg_files(launcher):
+    return _should_write_relay_arg_file() and isinstance(launcher, launchers.EmptyLauncher)
+
+
+def _quote_relay_cmd_arg(value):
+    if os.name == 'nt':
+        quoted = subprocess.list2cmdline([value])
+        if not (quoted.startswith('"') and quoted.endswith('"')):
+            quoted = f'"{quoted}"'
+        return quoted.replace('%', '%%')
+    return shlex.quote(value)
+
+
+def _relay_payload_arg(name, value, *, use_file=None):
+    if not value:
+        return ''
+    if use_file is None:
+        use_file = _should_write_relay_arg_file()
+    if use_file:
+        with tempfile.NamedTemporaryFile(
+            mode='w',
+            encoding='utf-8',
+            prefix=f'lazyllm-relay-{name}-',
+            suffix='.b64',
+            delete=False,
+        ) as handle:
+            handle.write(value)
+            file_path = handle.name
+        return f'--{name}_file={_quote_relay_cmd_arg(file_path)} '
+    return f'--{name}={_quote_relay_cmd_arg(value)} '
 
 
 class RelayServer(LazyLLMDeployBase):
@@ -39,25 +78,34 @@ class RelayServer(LazyLLMDeployBase):
 
         def impl():
             self._real_port = self._port if self._port else random.randint(30000, 40000)
-            cmd = f'{sys.executable} {run_file_path} --open_port={self._real_port} --function="{self._func}" '
+            use_arg_file = _can_use_relay_arg_files(self._launcher)
+            cmd = f'{_quote_relay_cmd_arg(sys.executable)} {_quote_relay_cmd_arg(run_file_path)} '
+            cmd += f'--open_port={self._real_port} '
+            cmd += _relay_payload_arg('function', self._func, use_file=use_arg_file)
             if self._pre:
-                cmd += f'--before_function="{self._pre}" '
+                cmd += _relay_payload_arg('before_function', self._pre, use_file=use_arg_file)
             if self._post:
-                cmd += f'--after_function="{self._post}" '
+                cmd += _relay_payload_arg('after_function', self._post, use_file=use_arg_file)
             if self._pythonpath:
-                cmd += f'--pythonpath="{self._pythonpath}" '
+                cmd += _relay_payload_arg('pythonpath', self._pythonpath, use_file=use_arg_file)
             if self._num_replicas > 1 and config['use_ray']:
-                cmd += f'--num_replicas={self._num_replicas}'
+                cmd += f'--num_replicas={self._num_replicas} '
             if self._security_key:
-                cmd += f'--security_key="{self._security_key}" '
+                cmd += _relay_payload_arg('security_key', self._security_key, use_file=use_arg_file)
             if self._defined_pos:
-                cmd += '--defined_pos="{}" '.format(dump_obj(self._defined_pos.replace('"', r'\"')))
-            if self.temp_folder: cmd += f' 2>&1 | tee {get_log_path(self.temp_folder)}'
+                cmd += _relay_payload_arg('defined_pos', dump_obj(self._defined_pos.replace('"', r'\"')),
+                                          use_file=use_arg_file)
+            if self.temp_folder: cmd += f' 2>&1 | tee {_quote_relay_cmd_arg(get_log_path(self.temp_folder))}'
             return cmd
 
         return LazyLLMCMD(cmd=impl, return_value=self.geturl,
                           checkf=verify_ray_func if config['use_ray'] else verify_fastapi_func,
-                          no_displays=['function', 'before_function', 'after_function', 'security_key', 'defined_pos'])
+                          no_displays=['function', 'function_file',
+                                       'before_function', 'before_function_file',
+                                       'after_function', 'after_function_file',
+                                       'defined_pos', 'defined_pos_file',
+                                       'pythonpath_file',
+                                       'security_key', 'security_key_file'])
 
     def geturl(self, job=None):
         if job is None:

--- a/lazyllm/components/deploy/relay/server.py
+++ b/lazyllm/components/deploy/relay/server.py
@@ -13,14 +13,32 @@ from types import GeneratorType
 from typing import Callable
 
 
+def _read_arg_file(file_path, *, remove=True):
+    try:
+        with open(file_path, encoding='utf-8') as file_obj:
+            return file_obj.read()
+    finally:
+        if remove:
+            try:
+                os.remove(file_path)
+            except FileNotFoundError:
+                pass
+
+
 def _inject_pythonpath(argv):
     pythonpath = None
     for index, arg in enumerate(argv):
         if arg == '--pythonpath' and index + 1 < len(argv):
             pythonpath = argv[index + 1]
             break
+        if arg == '--pythonpath_file' and index + 1 < len(argv):
+            pythonpath = _read_arg_file(argv[index + 1], remove=False)
+            break
         if arg.startswith('--pythonpath='):
             pythonpath = arg.split('=', 1)[1]
+            break
+        if arg.startswith('--pythonpath_file='):
+            pythonpath = _read_arg_file(arg.split('=', 1)[1], remove=False)
             break
     if pythonpath:
         pythonpath = os.path.abspath(pythonpath)
@@ -51,26 +69,52 @@ parser.add_argument('--open_ip', type=str, default='0.0.0.0',
                     help='IP: Receive for Client')
 parser.add_argument('--open_port', type=int, default=17782,
                     help='Port: Receive for Client')
-parser.add_argument('--function', required=True)
+parser.add_argument('--function')
 parser.add_argument('--before_function')
 parser.add_argument('--after_function')
 parser.add_argument('--pythonpath')
 parser.add_argument('--num_replicas', type=int, default=1, help='num of ray replicas')
 parser.add_argument('--security_key', type=str, default=None, help='security key')
 parser.add_argument('--defined_pos', type=str, default=None, help='user defined positional')
+parser.add_argument('--function_file')
+parser.add_argument('--before_function_file')
+parser.add_argument('--after_function_file')
+parser.add_argument('--defined_pos_file')
+parser.add_argument('--pythonpath_file')
+parser.add_argument('--security_key_file')
 args = parser.parse_args()
 
-func = load_obj(args.function)
-if args.before_function:
-    before_func = load_obj(args.before_function)
-if args.after_function:
-    after_func = load_obj(args.after_function)
+
+def _read_arg(name, value, file_path, *, required=False):
+    if value and file_path:
+        parser.error(f'Cannot specify both --{name} and --{name}_file')
+    if value:
+        return value
+    if file_path:
+        return _read_arg_file(file_path)
+    if required:
+        parser.error(f'`--{name}` or `--{name}_file` is required')
+    return None
+
+
+function_arg = _read_arg('function', args.function, args.function_file, required=True)
+before_function_arg = _read_arg('before_function', args.before_function, args.before_function_file)
+after_function_arg = _read_arg('after_function', args.after_function, args.after_function_file)
+defined_pos_arg = _read_arg('defined_pos', args.defined_pos, args.defined_pos_file)
+_read_arg('pythonpath', args.pythonpath, args.pythonpath_file)
+security_key_arg = _read_arg('security_key', args.security_key, args.security_key_file)
+
+func = load_obj(function_arg)
+if before_function_arg:
+    before_func = load_obj(before_function_arg)
+if after_function_arg:
+    after_func = load_obj(after_function_arg)
 
 
 _register_trim_module({'__main__': ['async_wrapper', 'impl']})
 _err_msg = ('service of ServerModule execuate failed.\n\nThe above exception was the direct cause '
             'of the following exception in service of ServerModule')
-_err_msg += (f' defined at `{load_obj(args.defined_pos)}`' if args.defined_pos else '') + ':\n'
+_err_msg += (f' defined at `{load_obj(defined_pos_arg)}`' if defined_pos_arg else '') + ':\n'
 
 
 app = fastapi.FastAPI()
@@ -89,7 +133,7 @@ async def async_wrapper(func, *args, **kwargs):
 def security_check(f: Callable):
     @functools.wraps(f)
     async def wrapper(request: fastapi.Request):
-        if args.security_key and args.security_key != request.headers.get('Security-Key'):
+        if security_key_arg and security_key_arg != request.headers.get('Security-Key'):
             return fastapi.responses.Response(content='Authentication failed', status_code=401)
         return (await f(request)) if inspect.iscoroutinefunction(f) else f(request)
     return wrapper
@@ -128,7 +172,7 @@ async def generate(request: fastapi.Request): # noqa C901
         globals._init_sid(request.headers.get('Session-ID'))
         globals.unpickle_and_update_data(request.headers.get('Global-Parameters'))
 
-        if args.before_function:
+        if before_function_arg:
             assert (callable(before_func)), 'before_func must be callable'
             r = inspect.getfullargspec(before_func)
             if isinstance(input, kwargs) or (
@@ -153,7 +197,7 @@ async def generate(request: fastapi.Request): # noqa C901
                 for o in output:
                     yield impl(o)
             return fastapi.responses.StreamingResponse(generate_stream(), media_type='text/plain')
-        elif args.after_function:
+        elif after_function_arg:
             assert (callable(after_func)), 'after_func must be callable'
             r = inspect.getfullargspec(after_func)
             assert len(r.args) > 0 and r.varargs is None and r.varkw is None

--- a/lazyllm/tools/rag/store/vector/chroma_store.py
+++ b/lazyllm/tools/rag/store/vector/chroma_store.py
@@ -24,6 +24,7 @@ DEFAULT_INDEX_CONFIG = {
         'ef_construction': 200,
     }
 }
+EMPTY_METADATA_SENTINEL = '__lazyllm_empty_metadata__'
 
 
 class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
@@ -37,6 +38,7 @@ class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
         assert uri or (dir), 'uri or dir must be provided'
         self._index_kwargs = index_kwargs or DEFAULT_INDEX_CONFIG
         self._client_kwargs = client_kwargs or {}
+        self._index_kwargs_compat_warning_sent = False
         if dir:
             self._dir = dir
         else:
@@ -103,25 +105,62 @@ class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
             self._client = chromadb.HttpClient(host=self._host, port=self._port, **self._client_kwargs)
             LOG.success(f'Initialzed chroma in host: {self._host}, port: {self._port}')
 
+    def _collection_kwargs(self, embed_key: str):
+        index_kwargs = self._index_kwargs
+        if isinstance(index_kwargs, list):
+            matched = next((item for item in index_kwargs
+                            if isinstance(item, dict) and item.get('embed_key') == embed_key), None)
+            fallback = next((item for item in index_kwargs
+                             if isinstance(item, dict) and item.get('embed_key') is None), None)
+            index_kwargs = matched or fallback
+        if not index_kwargs:
+            return {}
+        if isinstance(index_kwargs, dict):
+            index_kwargs = index_kwargs.copy()
+            index_kwargs.pop('embed_key', None)
+            if any(key.startswith('hnsw:') for key in index_kwargs):
+                index_kwargs = chromadb.api.collection_configuration\
+                    .create_collection_configuration_from_legacy_metadata_dict(index_kwargs)
+        if hasattr(index_kwargs, 'to_json') or isinstance(index_kwargs, dict):
+            return {'configuration': index_kwargs}
+        if not self._index_kwargs_compat_warning_sent:
+            LOG.warning(f'[Chroma Store] Unsupported index kwargs type: {type(index_kwargs)}')
+            self._index_kwargs_compat_warning_sent = True
+        return {}
+
     @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:
         try:
-            # NOTE chroma only support single embedding for each collection
             if not data:
                 LOG.warning(f'[Chroma Store - upsert] No data to upsert for collection {collection_name}')
-                return
-            data_embeddings = data[0].get('embedding', {})
-            if not data_embeddings: return
-            embed_keys = list(data_embeddings.keys())
+                return True
+
+            # NOTE chroma only support single embedding for each collection
+            embed_keys = []
+            seen_embed_keys = set()
+            for item in data:
+                for embed_key, embedding in item.get('embedding', {}).items():
+                    if embedding is None:
+                        continue
+                    if embed_key not in seen_embed_keys:
+                        seen_embed_keys.add(embed_key)
+                        embed_keys.append(embed_key)
+
+            if not embed_keys:
+                LOG.warning(f'[Chroma Store - upsert] No embedding payload for collection {collection_name}')
+                return True
+
             for embed_key in embed_keys:
+                rows = [item for item in data if item.get('embedding', {}).get(embed_key) is not None]
                 with self._ddl_lock:
                     self._resolve_missing_embed_specs({embed_key})
                 if embed_key not in self._embed_datatypes:
                     raise ValueError(f'Embed key {embed_key} not found in embed_datatypes')
                 collection = self._client.get_or_create_collection(
-                    name=self._gen_collection_name(collection_name, embed_key), configuration=self._index_kwargs)
-                for i in range(0, len(data), INSERT_BATCH_SIZE):
-                    collection.upsert(**self._serialize_data(data[i: i + INSERT_BATCH_SIZE], embed_key))
+                    name=self._gen_collection_name(collection_name, embed_key),
+                    **self._collection_kwargs(embed_key))
+                for i in range(0, len(rows), INSERT_BATCH_SIZE):
+                    collection.upsert(**self._serialize_data(rows[i: i + INSERT_BATCH_SIZE], embed_key))
             return True
         except Exception as e:
             LOG.error(f'[Chroma Store - upsert] Failed to create collection {collection_name}: {e}')
@@ -131,10 +170,15 @@ class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
     def _serialize_data(self, data: List[dict], embed_key: str) -> List[dict]:
         res = {'ids': [], 'embeddings': [], 'metadatas': []}
         for d in data:
+            global_meta = {
+                self._gen_global_meta_key(k): v for k, v in d.get('global_meta', {}).items()
+                if k in self._global_metadata_desc
+            }
+            if not global_meta:
+                global_meta = {EMPTY_METADATA_SENTINEL: True}
             res['ids'].append(d.get('uid'))
             res['embeddings'].append(d.get('embedding', {}).get(embed_key))
-            res['metadatas'].append({self._gen_global_meta_key(k): v for k, v in d.get('global_meta', {}).items()
-                                     if k in self._global_metadata_desc})
+            res['metadatas'].append(global_meta)
         return res
 
     @override
@@ -200,6 +244,7 @@ class ChromaStore(EmbedResolveMixin, LazyLLMStoreBase):
                         entry['global_meta'] = {
                             k[len(GLOBAL_META_KEY_PREFIX):]: v
                             for k, v in meta.items()
+                            if k.startswith(GLOBAL_META_KEY_PREFIX)
                         }
                     entry['embedding'][embed_key] = list(emb)
             return list(res.values())

--- a/tests/basic_tests/Deploy/test_relay_args.py
+++ b/tests/basic_tests/Deploy/test_relay_args.py
@@ -1,0 +1,185 @@
+import importlib.util
+import shlex
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+import lazyllm
+from lazyllm.components.deploy.relay import base as relay_base
+
+
+def _identity(value):
+    return value
+
+
+def _load_relay_server_module(monkeypatch, argv):
+    module_name = f'_lazyllm_relay_server_test_{uuid.uuid4().hex}'
+    server_path = relay_base.os.path.join(
+        relay_base.os.path.dirname(relay_base.os.path.abspath(relay_base.__file__)),
+        'server.py',
+    )
+    monkeypatch.setattr(sys, 'argv', [server_path] + argv)
+    old_sys_path = list(sys.path)
+    old_relay_services = None
+    has_relay_services = hasattr(lazyllm.FastapiApp, '__relay_services__')
+    if has_relay_services:
+        old_relay_services = lazyllm.FastapiApp.__relay_services__.copy()
+    spec = importlib.util.spec_from_file_location(module_name, server_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+        sys.path[:] = old_sys_path
+        if has_relay_services:
+            lazyllm.FastapiApp.__relay_services__ = old_relay_services
+    return module
+
+
+def _get_arg_value(tokens, name):
+    needle = f'--{name}='
+    for token in tokens:
+        if token.startswith(needle):
+            return token[len(needle):]
+    return None
+
+
+def _assert_file_payload(path, expected_payload):
+    assert relay_base.os.path.exists(path), f'{path} not exists'
+    with open(path, encoding='utf-8') as f:
+        assert f.read() == expected_payload
+
+
+def test_relay_cmd_writes_serialized_payloads_to_files(monkeypatch):
+    monkeypatch.setattr(relay_base, '_should_write_relay_arg_file', lambda: True)
+    server = relay_base.RelayServer(
+        port=32123,
+        func=_identity,
+        pre_func=_identity,
+        post_func=_identity,
+        pythonpath='C:\\path&with spaces',
+        security_key='token&with spaces',
+        defined_pos='file: "demo.py", line 7',
+    )
+
+    cmd = server.cmd().cmd()
+    cmd_parts = shlex.split(cmd)
+
+    function_file = _get_arg_value(cmd_parts, 'function_file')
+    before_file = _get_arg_value(cmd_parts, 'before_function_file')
+    after_file = _get_arg_value(cmd_parts, 'after_function_file')
+    pythonpath_file = _get_arg_value(cmd_parts, 'pythonpath_file')
+    security_key_file = _get_arg_value(cmd_parts, 'security_key_file')
+    defined_pos_file = _get_arg_value(cmd_parts, 'defined_pos_file')
+    try:
+        assert function_file is not None
+        assert before_file is not None
+        assert after_file is not None
+        assert pythonpath_file is not None
+        assert security_key_file is not None
+        assert defined_pos_file is not None
+        _assert_file_payload(function_file, lazyllm.dump_obj(_identity))
+        _assert_file_payload(before_file, lazyllm.dump_obj(_identity))
+        _assert_file_payload(after_file, lazyllm.dump_obj(_identity))
+        _assert_file_payload(pythonpath_file, 'C:\\path&with spaces')
+        _assert_file_payload(security_key_file, 'token&with spaces')
+        assert _get_arg_value(cmd_parts, 'function') is None
+        assert _get_arg_value(cmd_parts, 'before_function') is None
+        assert _get_arg_value(cmd_parts, 'after_function') is None
+        assert _get_arg_value(cmd_parts, 'pythonpath') is None
+        assert _get_arg_value(cmd_parts, 'security_key') is None
+        assert _get_arg_value(cmd_parts, 'defined_pos') is None
+        assert relay_base.os.path.exists(defined_pos_file)
+        with open(defined_pos_file, encoding='utf-8') as f:
+            assert f.read() in {
+                lazyllm.dump_obj('file: "demo.py", line 7'),
+                lazyllm.dump_obj('file: \\"demo.py\\", line 7'),
+            }
+    finally:
+        for path in (function_file, before_file, after_file, pythonpath_file, security_key_file, defined_pos_file):
+            if path:
+                try:
+                    relay_base.os.unlink(path)
+                except FileNotFoundError:
+                    pass
+
+
+def test_relay_payload_file_arg_uses_windows_quoting(monkeypatch, tmp_path):
+    temp_dir = tmp_path / 'relay payloads'
+    temp_dir.mkdir()
+    monkeypatch.setattr(relay_base.os, 'name', 'nt')
+    monkeypatch.setattr(relay_base.tempfile, 'tempdir', str(temp_dir))
+
+    arg = relay_base._relay_payload_arg('function', 'payload', use_file=True)
+    raw_path = arg.removeprefix('--function_file=').strip()
+    assert raw_path.startswith('"')
+    assert raw_path.endswith('"')
+    assert "'" not in raw_path
+    payload_file = raw_path.strip('"')
+    try:
+        assert raw_path == subprocess.list2cmdline([payload_file])
+        _assert_file_payload(payload_file, 'payload')
+    finally:
+        relay_base.os.unlink(payload_file)
+
+
+def test_relay_server_reads_payload_from_file(monkeypatch, tmp_path):
+    payload = lazyllm.dump_obj(_identity)
+    payload_file = tmp_path / 'function.b64'
+    payload_file.write_text(payload, encoding='utf-8')
+
+    module = _load_relay_server_module(
+        monkeypatch,
+        ['--open_port=32124', f'--function_file={payload_file}'],
+    )
+
+    assert module.func('ok') == 'ok'
+    assert not payload_file.exists()
+
+
+def test_relay_server_reads_security_key_from_file(monkeypatch, tmp_path):
+    payload = lazyllm.dump_obj(_identity)
+    payload_file = tmp_path / 'function.b64'
+    security_file = tmp_path / 'security.txt'
+    payload_file.write_text(payload, encoding='utf-8')
+    security_file.write_text('token&value', encoding='utf-8')
+
+    module = _load_relay_server_module(
+        monkeypatch,
+        ['--open_port=32128', f'--function_file={payload_file}', f'--security_key_file={security_file}'],
+    )
+
+    assert module.security_key_arg == 'token&value'
+    assert not payload_file.exists()
+    assert not security_file.exists()
+
+
+def test_relay_server_accepts_direct_payload(monkeypatch):
+    payload = lazyllm.dump_obj(_identity)
+
+    module = _load_relay_server_module(
+        monkeypatch,
+        ['--open_port=32125', f'--function={payload}'],
+    )
+
+    assert module.func('ok') == 'ok'
+
+
+def test_relay_server_rejects_missing_function_payload(monkeypatch):
+    with pytest.raises(SystemExit):
+        _load_relay_server_module(monkeypatch, ['--open_port=32126'])
+
+
+def test_relay_server_rejects_ambiguous_function_payload(monkeypatch, tmp_path):
+    payload = lazyllm.dump_obj(_identity)
+    payload_file = tmp_path / 'function.b64'
+    payload_file.write_text(payload, encoding='utf-8')
+
+    with pytest.raises(SystemExit):
+        _load_relay_server_module(
+            monkeypatch,
+            ['--open_port=32127', f'--function={payload}', f'--function_file={payload_file}'],
+        )

--- a/tests/basic_tests/RAG/test_store.py
+++ b/tests/basic_tests/RAG/test_store.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import time
+import threading
 import pytest
 import tempfile
 import unittest
@@ -349,6 +350,190 @@ class TestChromaStore(unittest.TestCase):
         res = self.store.search(collection_name=self.collections[1], query_embedding=[0.1, 0.2, 0.3],
                                 embed_key='vec_dense', topk=1, filters={RAG_KB_ID: ['kb1']})
         self.assertEqual(len(res), 0)
+
+
+class TestChromaStoreUnit(unittest.TestCase):
+    def setUp(self):
+        self.store_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.store_dir, ignore_errors=True)
+
+    def _store(self):
+        store = ChromaStore(uri=self.store_dir)
+        store._global_metadata_desc = BUILDIN_GLOBAL_META_DESC
+        store._embed_dims = {'vec_dense': 3}
+        store._embed_datatypes = {'vec_dense': DataType.FLOAT_VECTOR}
+        store._embed = {}
+        store._ddl_lock = threading.Lock()
+        return store
+
+    def test_upsert_empty_data_returns_true(self):
+        store = self._store()
+
+        self.assertTrue(store.upsert('col', []))
+
+    def test_upsert_missing_embedding_payload_returns_true(self):
+        store = self._store()
+
+        self.assertTrue(store.upsert('col', [{'uid': 'uid1'}]))
+
+    def test_upsert_with_empty_global_meta_uses_nonempty_metadata_payload(self):
+        store = self._store()
+
+        class FakeCollection:
+            def __init__(self):
+                self.upserts = []
+
+            def upsert(self, **kwargs):
+                self.upserts.append(kwargs)
+
+        class FakeClient:
+            def __init__(self):
+                self.collection = FakeCollection()
+
+            def get_or_create_collection(self, name, **kwargs):
+                return self.collection
+
+        fake_client = FakeClient()
+        store._client = fake_client
+
+        self.assertTrue(store.upsert('col', [{
+            'uid': 'uid1',
+            'embedding': {'vec_dense': [0.1, 0.2, 0.3]},
+            'global_meta': {},
+        }]))
+
+        self.assertEqual(len(fake_client.collection.upserts), 1)
+        metadatas = fake_client.collection.upserts[0]['metadatas']
+        self.assertEqual(len(metadatas), 1)
+        self.assertTrue(len(metadatas[0]) >= 1)
+        self.assertEqual(set(metadatas[0].keys()).intersection({RAG_DOC_ID, RAG_KB_ID}), set())
+
+    def test_get_filters_internal_and_non_global_metadata(self):
+        from lazyllm.tools.rag.store.store_base import GLOBAL_META_KEY_PREFIX
+
+        class FakeCollection:
+            def get(self, include, **filters):
+                return {
+                    'ids': ['uid1'],
+                    'metadatas': [{
+                        'internal_metadata': True,
+                        'foreign': 'value',
+                        GLOBAL_META_KEY_PREFIX + RAG_DOC_ID: 'doc1',
+                    }],
+                    'embeddings': [[0.1, 0.2, 0.3]],
+                }
+
+        class FakeClient:
+            def get_collection(self, name):
+                return FakeCollection()
+
+        store = self._store()
+        store._client = FakeClient()
+
+        res = store.get('col')
+
+        self.assertEqual(res[0]['global_meta'], {RAG_DOC_ID: 'doc1'})
+        self.assertEqual(res[0]['embedding']['vec_dense'], [0.1, 0.2, 0.3])
+        self.assertNotIn('foreign', res[0]['global_meta'])
+        self.assertNotIn('internal_metadata', res[0]['global_meta'])
+
+    def test_collection_kwargs_forwards_configuration_for_dict(self):
+        class FakeCollection:
+            def __init__(self):
+                self.kwargs = []
+
+            def upsert(self, **kwargs):
+                pass
+
+        class FakeClient:
+            def __init__(self):
+                self.collection = FakeCollection()
+                self.created = []
+
+            def get_or_create_collection(self, name, **kwargs):
+                self.created.append((name, kwargs))
+                return self.collection
+
+        fake_client = FakeClient()
+        store = self._store()
+        store._client = fake_client
+        store._index_kwargs = {'hnsw': {'space': 'cosine'}}
+
+        store.upsert('col', [{'uid': 'uid1', 'embedding': {'vec_dense': [0.1, 0.2, 0.3]}}])
+
+        self.assertEqual(len(fake_client.created), 1)
+        self.assertEqual(fake_client.created[0][1].get('configuration'), {'hnsw': {'space': 'cosine'}})
+
+    def test_collection_kwargs_selects_matching_list_entry(self):
+        class FakeCollection:
+            def upsert(self, **kwargs):
+                pass
+
+        class FakeClient:
+            def __init__(self):
+                self.collection = FakeCollection()
+                self.created = []
+
+            def get_or_create_collection(self, name, **kwargs):
+                self.created.append((name, kwargs))
+                return self.collection
+
+        fake_client = FakeClient()
+        store = self._store()
+        store._client = fake_client
+        store._index_kwargs = [
+            {'hnsw': {'space': 'ip'}},
+            {'embed_key': 'other', 'hnsw': {'space': 'l2'}},
+            {'embed_key': 'vec_dense', 'hnsw': {'space': 'cosine'}},
+        ]
+
+        store.upsert('col', [{'uid': 'uid1', 'embedding': {'vec_dense': [0.1, 0.2, 0.3]}}])
+
+        self.assertEqual(len(fake_client.created), 1)
+        self.assertEqual(fake_client.created[0][1].get('configuration'), {'hnsw': {'space': 'cosine'}})
+
+    def test_collection_kwargs_converts_legacy_hnsw_metadata(self):
+        store = self._store()
+        store._index_kwargs = {'hnsw:space': 'cosine', 'hnsw:construction_ef': 200}
+
+        kwargs = store._collection_kwargs('vec_dense')
+
+        self.assertEqual(kwargs['configuration']['hnsw']['space'], 'cosine')
+        self.assertEqual(kwargs['configuration']['hnsw']['ef_construction'], 200)
+
+    def test_collection_kwargs_forwards_configuration_for_to_json_object(self):
+        class Config:
+            def to_json(self):
+                return '{}'
+
+        class FakeCollection:
+            def __init__(self):
+                self.kwargs = []
+
+            def upsert(self, **kwargs):
+                pass
+
+        class FakeClient:
+            def __init__(self):
+                self.collection = FakeCollection()
+                self.created = []
+
+            def get_or_create_collection(self, name, **kwargs):
+                self.created.append((name, kwargs))
+                return self.collection
+
+        fake_client = FakeClient()
+        store = self._store()
+        store._client = fake_client
+
+        config = Config()
+        store._index_kwargs = config
+        store.upsert('col', [{'uid': 'uid1', 'embedding': {'vec_dense': [0.1, 0.2, 0.3]}}])
+
+        self.assertEqual(len(fake_client.created), 1)
+        self.assertEqual(fake_client.created[0][1].get('configuration'), config)
 
 
 @pytest.mark.skip_on_win


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Harden relay server startup argument passing for large serialized payloads and Windows local launch.
- Make ChromaStore upsert/get behavior more robust around empty batches, sparse embedding payloads, and metadata.
- Add focused regression tests for relay file-backed args and ChromaStore compatibility edge cases.

---

# 🎯 问题背景 / Problem Context

- Relay currently passes base64-serialized functions through command-line arguments, which is fragile for long payloads
  and local Windows shell parsing.
- Chroma requires non-empty metadata per row, while LazyLLM may legitimately upsert rows without global metadata.
- Chroma upsert should tolerate empty/no-op inputs and rows that only contain embeddings for a subset of embed keys.
- Chroma metadata returned to users should not expose internal sentinel or unrelated metadata keys.

# 🔍 相关 Issue / Related Issue

* None

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `python3 -m py_compile lazyllm/components/deploy/relay/base.py lazyllm/components/deploy/relay/server.py
   lazyllm/tools/rag/store/vector/chroma_store.py tests/basic_tests/Deploy/test_relay_args.py
   tests/basic_tests/RAG/test_store.py tests/basic_tests/Common/test_common.py`
2. `uv run --python 3.11 --with pytest --with chromadb --with pandas --with pypdf --with docx2txt
   --with ebooklib --with html2text --with olefile --with openpyxl --with python-pptx --with python-docx
   --with beautifulsoup4 --with 'tiktoken>=0.7.0,<0.8.0' --with 'spacy<=3.7.5'
   --with 'bm25s>=0.1.10,<0.2.0' --with pystemmer --with nltk --with jieba --with sentencepiece
   --with psycopg2-binary --with sqlalchemy --with json_repair pytest
   tests/basic_tests/Deploy/test_relay_args.py tests/basic_tests/RAG/test_store.py::TestChromaStoreUnit
   tests/basic_tests/Common/test_common.py::TestCommon::test_common_cmd -q`
3. `uv run --python 3.11 --with flake8 --with flake8-quotes --with flake8-bugbear make lint-only-diff`

---

# 📷 Demo (Optional)

* Not applicable

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
# Existing RelayServer and ChromaStore usage does not change.
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# Relay serialized payloads were always embedded directly in the command line.
# Chroma upsert could fail or return None for valid no-op inputs.
```

## After

```python
# Windows local relay launch passes serialized payloads and sensitive args via temporary files.
# Chroma upsert returns True for no-op batches and filters internal metadata on reads.
```

# ⚠️ 注意事项 / Additional Notes

* The relay file-backed path is limited to Windows local EmptyLauncher usage to avoid passing local temp paths to
  remote launchers.
* Chroma dict/list index kwargs remain supported; dicts are forwarded as collection configuration and list entries
  prefer exact embed_key matches.

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
~/Downloads/lazyllm.diff 是一份对 lazyllm 进行改进的 patch，先分析这个 diff 想要做什么，
然后保留那些确实能提高健壮性或者代码质量的改动，最终贡献给上游。
那些 cosmetic 的改动就不要引入了。一个 PR 处理这个 diff 里的所有改动。
```

## 一开始制定了什么方案

Keep functional hardening only: relay payload transport should avoid Windows command-line limits, and ChromaStore
should handle no-op upserts, empty metadata, mixed embedding keys, and metadata filtering without cosmetic churn.

## 方案实施后存在什么问题

Initial review found two issues: Windows relay quoting still had `cmd.exe` metacharacter risk for non-payload args,
and Chroma list index kwargs could select a fallback entry before an exact embed_key match.

## 我（用户）发现了哪些问题

The user requested one upstream PR, no cosmetic changes, and compliance with the upstream PR template and submission
requirements.

## 对这些问题优化后相比于之前有哪些优势

Relay now uses file-backed args for function payloads, pythonpath, security_key, and defined positions on Windows
local launches. Chroma index kwargs preserve dict/list compatibility and prefer exact embed_key matches.

## 哪些可以沉淀为自己后续的编码规范

When hardening shell command construction, avoid passing arbitrary serialized or sensitive data on the command line.
When adapting third-party API compatibility, preserve existing public input shapes unless intentionally documented as
a breaking change.
