### PR TITLE
feat(online): add SiliconFlow STT and extend RAG reader support

### DIFF
--- a/lazyllm/docs/module.py
+++ b/lazyllm/docs/module.py
@@ -2783,6 +2783,47 @@ Args:
     **kwargs: Other model parameters
 """)
 
+add_chinese_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowSTT', """\
+SiliconFlow 语音转文本模块，继承自 LazyLLMOnlineSTTModuleBase。
+
+通过 SiliconFlow ``/v1/audio/transcriptions`` 接口将本地音频文件转写为文本，默认模型为 ``FunAudioLLM/SenseVoiceSmall``。
+
+调用时传入本地音频路径（``input`` 为文件路径字符串）或通过 ``files`` 传入单文件路径列表；每次仅支持一个音频文件。
+
+Args:
+    api_key (str, optional): API 密钥，默认为配置中的 ``siliconflow_api_key``
+    model (str, optional): 模型名称，默认为 ``FunAudioLLM/SenseVoiceSmall``。也可使用别名 ``model_name``
+    base_url (str, optional): API 基础 URL，默认为 ``https://api.siliconflow.cn/v1/``
+    return_trace (bool, optional): 是否返回追踪信息，默认为 ``False``
+    **kwargs: 其他模型参数
+""")
+
+add_english_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowSTT', """\
+SiliconFlow Speech-to-Text module, inherits from LazyLLMOnlineSTTModuleBase.
+
+Transcribes local audio files to text via the SiliconFlow ``/v1/audio/transcriptions`` endpoint. The default model is ``FunAudioLLM/SenseVoiceSmall``.
+
+Pass a local audio file path as ``input``, or provide a single-file list via ``files``; only one audio file is supported per call.
+
+Args:
+    api_key (str, optional): API key, defaults to configured ``siliconflow_api_key``
+    model (str, optional): Model name, defaults to ``FunAudioLLM/SenseVoiceSmall``. Alias: ``model_name``
+    base_url (str, optional): Base API URL, defaults to ``https://api.siliconflow.cn/v1/``
+    return_trace (bool, optional): Whether to return trace information, defaults to ``False``
+    **kwargs: Other model parameters
+""")
+
+add_example('llms.onlinemodule.supplier.siliconflow.SiliconFlowSTT', """\
+>>> import lazyllm
+>>> stt = lazyllm.OnlineMultiModalModule(
+...     source='siliconflow',
+...     model='FunAudioLLM/SenseVoiceSmall',
+...     type='stt',
+... )
+>>> text = stt('/path/to/audio.mp3')
+>>> print(text)
+""")
+
 add_chinese_doc('llms.onlinemodule.supplier.siliconflow.SiliconFlowTTS', """\
 SiliconFlow文本转语音模块，继承自OnlineMultiModalBase。
 

--- a/lazyllm/module/llms/onlinemodule/map_model_type.py
+++ b/lazyllm/module/llms/onlinemodule/map_model_type.py
@@ -444,6 +444,8 @@ MODEL_MAPPING = {
     'deepseek-v4-pro': 'llm',
 
     # ===== SiliconFlow =====
+    # free speech2text model
+    'FunAudioLLM/SenseVoiceSmall': 'stt',
     'qwen/qwen3-vl-embedding-8b': 'cross_modal_embed',
     'qwen/qwen-image-edit': 'image_editing',
     'qwen/qwen-image-edit-2509': 'image_editing',

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -253,7 +253,7 @@ class SiliconFlowSTT(LazyLLMOnlineSTTModuleBase):
         response.raise_for_status()
         return response.json().get('text', '')
 
-    def _forward(self, input: str = None, files: List[str] = [], url: str = None, model: str = None, **kwargs):
+    def _forward(self, input: str = None, files: List[str] = None, url: str = None, model: str = None, **kwargs):
         file_path = self._resolve_audio_path(input=input, files=files)
         return self._transcribe(file_path, model or self._model_name, base_url=url)
 

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -5,7 +5,8 @@ from urllib.parse import urljoin
 from lazyllm.components.utils.downloader.model_downloader import LLMType
 from ..base import (
     OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineMultimodalEmbedModuleBase,
-    LazyLLMOnlineRerankModuleBase, LazyLLMOnlineText2ImageModuleBase, LazyLLMOnlineTTSModuleBase
+    LazyLLMOnlineRerankModuleBase, LazyLLMOnlineSTTModuleBase, LazyLLMOnlineText2ImageModuleBase,
+    LazyLLMOnlineTTSModuleBase,
 )
 from lazyllm.components.formatter import encode_query_with_filepaths
 from lazyllm.components.utils.file_operate import bytes_to_file, _image_to_base64
@@ -215,6 +216,46 @@ class SiliconFlowText2Image(LazyLLMOnlineText2ImageModuleBase):
         ai_img_path = os.path.join(config['temp_dir'], 'ai_img')
         file_paths = bytes_to_file(image_bytes, target_dir=ai_img_path)
         return encode_query_with_filepaths(None, file_paths)
+
+
+class SiliconFlowSTT(LazyLLMOnlineSTTModuleBase):
+    MODEL_NAME = 'FunAudioLLM/SenseVoiceSmall'
+
+    def __init__(self, api_key: str = None, model: str = None, model_name: str = None,
+                 base_url: Optional[str] = None,
+                 return_trace: bool = False, **kwargs):
+        base_url = base_url or 'https://api.siliconflow.cn/v1/'
+        resolved_model = model or model_name or SiliconFlowSTT.MODEL_NAME
+        super().__init__(api_key=api_key or self._default_api_key(),
+                         model=resolved_model, return_trace=return_trace, url=base_url, **kwargs)
+        self._endpoint = 'audio/transcriptions'
+
+    def _resolve_audio_path(self, input: str = None, files: List[str] = None) -> str:
+        if files and len(files) > 1:
+            raise ValueError('SiliconFlowSTT only supports one audio file at a time')
+        if files and len(files) == 1:
+            return files[0]
+        if input and os.path.isfile(input):
+            return input
+        raise ValueError('SiliconFlowSTT requires a local audio file path')
+
+    def _transcribe(self, file_path: str, model: str, base_url: Optional[str] = None) -> str:
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f'File {file_path} not found')
+        url = urljoin(base_url or self._base_url, self._endpoint)
+        filename = os.path.basename(file_path)
+        with open(file_path, 'rb') as audio_file:
+            multipart = {
+                'file': (filename, audio_file),
+                'model': (None, model),
+            }
+            response = requests.post(url, headers=self._get_empty_header(), files=multipart, timeout=180)
+        response.raise_for_status()
+        return response.json().get('text', '')
+
+    def _forward(self, input: str = None, files: List[str] = [], url: str = None, model: str = None, **kwargs):
+        file_path = self._resolve_audio_path(input=input, files=files)
+        return self._transcribe(file_path, model or self._model_name, base_url=url)
 
 
 class SiliconFlowTTS(LazyLLMOnlineTTSModuleBase):

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -72,6 +72,7 @@ class EmbedPlaceholder:
 class NodeGroupType(str, Enum):
     ORIGINAL = 'Original Source'
     CHUNK = 'Chunk'
+    CODE = 'Code'
     SUMMARY = 'Summary'
     IMAGE_INFO = 'Image Info'
     QUESTION_ANSWER = 'Question Answer'

--- a/lazyllm/tools/rag/readers/ipynbReader.py
+++ b/lazyllm/tools/rag/readers/ipynbReader.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 from typing import Dict, List, Optional
 from lazyllm.thirdparty import fsspec
@@ -17,20 +16,30 @@ class IPYNBReader(LazyLLMReaderBase):
 
         if file.name.endswith('.ipynb'):
             try:
-                import nbconvert
+                import nbformat
             except ImportError:
-                raise ImportError('Please install nbconvert `pip install nbconvert`')
+                raise ImportError('Please install nbformat: pip install nbformat')
 
         if fs:
-            with fs.open(file, encoding='utf-8') as f:
-                doc_str = nbconvert.exporters.ScriptExporter().from_file(f)[0]
+            with fs.open(file, 'r', encoding='utf-8') as f:
+                notebook = nbformat.read(f, as_version=4)
         else:
-            doc_str = nbconvert.exporters.ScriptExporter().from_file(file)[0]
+            with open(file, 'r', encoding='utf-8') as f:
+                notebook = nbformat.read(f, as_version=4)
 
-        splits = re.split(r'In\[\d+\]:', doc_str)
-        splits.pop(0)
+        cell_texts = []
+        for idx, cell in enumerate(notebook.cells):
+            source = getattr(cell, 'source', '')
+            if isinstance(source, list):
+                source = ''.join(source)
+            if not source or not source.strip():
+                continue
 
-        if self._concatenate: docs = [DocNode(text='\n\n'.join(splits))]
-        else: docs = [DocNode(text=s) for s in splits]
+            cell_texts.append(source)
 
-        return docs
+        if not cell_texts:
+            return []
+
+        if self._concatenate:
+            return [DocNode(text=('\n\n' + '-' * 80 + '\n\n').join(cell_texts))]
+        return [DocNode(text=text) for text in cell_texts]

--- a/lazyllm/tools/rag/readers/ipynbReader.py
+++ b/lazyllm/tools/rag/readers/ipynbReader.py
@@ -14,11 +14,10 @@ class IPYNBReader(LazyLLMReaderBase):
     def _load_data(self, file: Path, fs: Optional['fsspec.AbstractFileSystem'] = None) -> List[DocNode]:
         if not isinstance(file, Path): file = Path(file)
 
-        if file.name.endswith('.ipynb'):
-            try:
-                import nbformat
-            except ImportError:
-                raise ImportError('Please install nbformat: pip install nbformat')
+        try:
+            import nbformat
+        except ImportError:
+            raise ImportError('Please install nbformat: pip install nbformat')
 
         if fs:
             with fs.open(file, 'r', encoding='utf-8') as f:
@@ -28,7 +27,7 @@ class IPYNBReader(LazyLLMReaderBase):
                 notebook = nbformat.read(f, as_version=4)
 
         cell_texts = []
-        for idx, cell in enumerate(notebook.cells):
+        for cell in notebook.cells:
             source = getattr(cell, 'source', '')
             if isinstance(source, list):
                 source = ''.join(source)

--- a/tests/charge_tests/Models/automodel_stt_config.yaml
+++ b/tests/charge_tests/Models/automodel_stt_config.yaml
@@ -1,0 +1,5 @@
+speech_to_text:
+  - source: siliconflow
+    type: stt
+    name: FunAudioLLM/SenseVoiceSmall
+    api_key: ${LAZYLLM_SILICONFLOW_API_KEY}

--- a/tests/charge_tests/Models/test_siliconflow_stt.py
+++ b/tests/charge_tests/Models/test_siliconflow_stt.py
@@ -7,8 +7,14 @@ import lazyllm
 from lazyllm import AutoModel
 from lazyllm.module.llms.onlinemodule.supplier.siliconflow import SiliconFlowSTT
 
+from ...utils import get_api_key
+
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'automodel_stt_config.yaml')
-AUDIO_PATH = '/mnt/c/Users/cuishaoting/Downloads/test_content/speech.mp3'
+AUDIO_PATH = os.path.join(lazyllm.config['data_path'], 'ci_data/shuidiaogetou.mp3')
+
+
+def _live_stt_ready() -> bool:
+    return os.path.exists(AUDIO_PATH) and bool(get_api_key('siliconflow'))
 
 
 class TestSiliconFlowSTT:
@@ -47,15 +53,17 @@ class TestSiliconFlowSTT:
 
         assert result == 'path input'
 
+    def test_forward_rejects_multiple_files(self):
+        module = SiliconFlowSTT(api_key='test-key')
+        files = [AUDIO_PATH, AUDIO_PATH]
+        with pytest.raises(ValueError, match='only supports one audio file'):
+            module(files=files)
 
-@pytest.mark.skipif(
-    not os.environ.get('LAZYLLM_SILICONFLOW_API_KEY'),
-    reason='LAZYLLM_SILICONFLOW_API_KEY is required for live STT test',
-)
-@pytest.mark.skipif(not os.path.exists(AUDIO_PATH), reason=f'audio file not found: {AUDIO_PATH}')
+
+@pytest.mark.skipif(not _live_stt_ready(), reason='ci_data/shuidiaogetou.mp3 or siliconflow api key unavailable')
 class TestSiliconFlowSTTLive:
     def test_siliconflow_stt_live(self):
-        module = SiliconFlowSTT(api_key=os.environ['LAZYLLM_SILICONFLOW_API_KEY'])
+        module = SiliconFlowSTT(api_key=get_api_key('siliconflow'))
         result = module(AUDIO_PATH)
         assert isinstance(result, str)
         assert result.strip()

--- a/tests/charge_tests/Models/test_siliconflow_stt.py
+++ b/tests/charge_tests/Models/test_siliconflow_stt.py
@@ -1,0 +1,68 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import lazyllm
+from lazyllm import AutoModel
+from lazyllm.module.llms.onlinemodule.supplier.siliconflow import SiliconFlowSTT
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'automodel_stt_config.yaml')
+AUDIO_PATH = '/mnt/c/Users/cuishaoting/Downloads/test_content/speech.mp3'
+
+
+class TestSiliconFlowSTT:
+    def test_forward_posts_multipart_and_returns_text(self, tmp_path):
+        audio_file = tmp_path / 'audio.mp3'
+        audio_file.write_bytes(b'fake-audio')
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'text': 'hello world'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('lazyllm.module.llms.onlinemodule.supplier.siliconflow.requests.post',
+                   return_value=mock_response) as mock_post:
+            module = SiliconFlowSTT(api_key='test-key')
+            result = module(files=[str(audio_file)])
+
+        assert result == 'hello world'
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs['headers'] == {'Authorization': 'Bearer test-key'}
+        assert 'file' in call_kwargs['files']
+        assert call_kwargs['files']['model'] == (None, 'FunAudioLLM/SenseVoiceSmall')
+
+    def test_forward_accepts_audio_path_as_input(self, tmp_path):
+        audio_file = tmp_path / 'speech.mp3'
+        audio_file.write_bytes(b'fake-audio')
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {'text': 'path input'}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch('lazyllm.module.llms.onlinemodule.supplier.siliconflow.requests.post',
+                   return_value=mock_response):
+            module = SiliconFlowSTT(api_key='test-key')
+            result = module(str(audio_file))
+
+        assert result == 'path input'
+
+
+@pytest.mark.skipif(
+    not os.environ.get('LAZYLLM_SILICONFLOW_API_KEY'),
+    reason='LAZYLLM_SILICONFLOW_API_KEY is required for live STT test',
+)
+@pytest.mark.skipif(not os.path.exists(AUDIO_PATH), reason=f'audio file not found: {AUDIO_PATH}')
+class TestSiliconFlowSTTLive:
+    def test_siliconflow_stt_live(self):
+        module = SiliconFlowSTT(api_key=os.environ['LAZYLLM_SILICONFLOW_API_KEY'])
+        result = module(AUDIO_PATH)
+        assert isinstance(result, str)
+        assert result.strip()
+
+    def test_automodel_speech_to_text_live(self, monkeypatch):
+        monkeypatch.setitem(lazyllm.config._impl, 'auto_model_config_map_path', CONFIG_PATH)
+        module = AutoModel(model='speech_to_text')
+        result = module(AUDIO_PATH)
+        assert isinstance(result, str)
+        assert result.strip()


### PR DESCRIPTION
1.

给 硅基 加了一个 stt 接口；
用的是免费的 sensevoice

2.

修复旧代码导致ipynb无法解析内容的bug

3.

增加代码块节点组

<img width="480" height="507" alt="img_v3_0212i_ca855be8-4cad-4057-ad90-fa6dca75c6cg" src="https://github.com/user-attachments/assets/a1fc31ba-c4d8-4143-b54b-9f1fd717b02f" />

为 代码文件后缀服务 在lazymind中 与CodeSplitter联合使用

<img width="1012" height="110" alt="image" src="https://github.com/user-attachments/assets/94bda8c6-dc33-495c-a1af-82dc2f5d2f65" />


<img width="903" height="58" alt="image" src="https://github.com/user-attachments/assets/7063ed45-c90c-4c52-b97d-16fe1f808957" />
