### PR TITLE
fix(llm): forward stream param in AutoModel and remove redundant stream setting in suppliers

### DIFF
--- a/lazyllm/module/llms/automodel.py
+++ b/lazyllm/module/llms/automodel.py
@@ -49,7 +49,7 @@ class AutoModel:
         # 2) second: try OnlineModule with online config if found
         if online_entry is not None:
             online_args = process_online_args(model=model, source=source, type=type, entry=online_entry,
-                                               stream=stream)
+                                              stream=stream)
             if online_args: return OnlineModule(**online_args, **kwargs)
 
         # 3) finally: fallback (no config or config unusable)

--- a/lazyllm/module/llms/automodel.py
+++ b/lazyllm/module/llms/automodel.py
@@ -9,14 +9,14 @@ from .utils import get_candidate_entries, process_trainable_args, process_online
 class AutoModel:
 
     def __new__(cls, model: Optional[str] = None, *, config_id: Optional[str] = None, source: Optional[str] = None,  # noqa C901
-                type: Optional[str] = None, config: Union[str, bool] = True, **kwargs: Any):
+                type: Optional[str] = None, config: Union[str, bool] = True, stream=True, **kwargs: Any):
         # check and accomodate user params
         model = model or kwargs.pop('base_model', kwargs.pop('embed_model_name', kwargs.pop('model_name', None)))
 
         if source == 'dynamic':
             from .onlinemodule import OnlineChatModule
             dynamic_auth = kwargs.pop('dynamic_auth', False)
-            return OnlineChatModule(source='dynamic', dynamic_auth=dynamic_auth, type=type, **kwargs)
+            return OnlineChatModule(source='dynamic', dynamic_auth=dynamic_auth, type=type, stream=stream, **kwargs)
 
         if model in lazyllm.online.chat:
             if source is not None:
@@ -27,7 +27,7 @@ class AutoModel:
 
         if not model:
             try:
-                return lazyllm.OnlineModule(source=source, type=type)
+                return lazyllm.OnlineModule(source=source, type=type, stream=stream, **kwargs)
             except Exception as e:
                 raise RuntimeError(f'`model` is not provided in AutoModel, and {e}') from None
 
@@ -39,7 +39,7 @@ class AutoModel:
                 model=model, type=type, source=source, config=config, entry=trainable_entry
             )
             try:
-                module = TrainableModule(**trainable_args)
+                module = TrainableModule(**trainable_args, **kwargs, stream=stream)
                 if module._url or module._impl._get_deploy_tasks.flag: return module
             except Exception as e:
                 LOG.warning('Fail to create `TrainableModule`, will try to '
@@ -48,12 +48,12 @@ class AutoModel:
         # 2) second: try OnlineModule with online config if found
         if online_entry is not None:
             online_args = process_online_args(model=model, source=source, type=type, entry=online_entry)
-            if online_args: return OnlineModule(**online_args)
+            if online_args: return OnlineModule(**online_args, **kwargs, stream=stream)
 
         # 3) finally: fallback (no config or config unusable)
         try:
-            return OnlineModule(model=model, source=source, type=type)
+            return OnlineModule(model=model, source=source, type=type, stream=stream, **kwargs)
         except Exception as e:
             LOG.warning('`OnlineModule` creation failed, and will try to '
                         f'load model {model} with local `TrainableModule`. Since the error: {e}')
-            return TrainableModule(model, type=type)
+            return TrainableModule(model, type=type, stream=stream, **kwargs)

--- a/lazyllm/module/llms/automodel.py
+++ b/lazyllm/module/llms/automodel.py
@@ -36,10 +36,11 @@ class AutoModel:
         # 1) first: try TrainableModule with trainable config (for directly connecting deployed endpoint)
         if trainable_entry is not None:
             trainable_args = process_trainable_args(
-                model=model, type=type, source=source, config=config, entry=trainable_entry
+                model=model, type=type, source=source, config=config, entry=trainable_entry,
+                stream=stream,
             )
             try:
-                module = TrainableModule(**trainable_args, **kwargs, stream=stream)
+                module = TrainableModule(**trainable_args, **kwargs)
                 if module._url or module._impl._get_deploy_tasks.flag: return module
             except Exception as e:
                 LOG.warning('Fail to create `TrainableModule`, will try to '
@@ -47,8 +48,9 @@ class AutoModel:
 
         # 2) second: try OnlineModule with online config if found
         if online_entry is not None:
-            online_args = process_online_args(model=model, source=source, type=type, entry=online_entry)
-            if online_args: return OnlineModule(**online_args, **kwargs, stream=stream)
+            online_args = process_online_args(model=model, source=source, type=type, entry=online_entry,
+                                               stream=stream)
+            if online_args: return OnlineModule(**online_args, **kwargs)
 
         # 3) finally: fallback (no config or config unusable)
         try:

--- a/lazyllm/module/llms/onlinemodule/supplier/aiping.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/aiping.py
@@ -26,8 +26,6 @@ class AipingChat(OnlineChatModuleBase, FileHandlerBase):
         super().__init__(api_key=api_key or self._default_api_key(), base_url=base_url, model_name=model,
                          stream=stream, return_trace=return_trace, **kwargs)
         FileHandlerBase.__init__(self)
-        if stream:
-            self._model_optional_params['stream'] = True
 
     def _get_system_prompt(self):
         return 'You are an intelligent assistant developed by AIPing. You are a helpful assistant.'

--- a/lazyllm/module/llms/onlinemodule/supplier/minimax.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/minimax.py
@@ -20,8 +20,6 @@ class MinimaxChat(OnlineChatModuleBase, FileHandlerBase):
         super().__init__(api_key=api_key or self._default_api_key(), base_url=base_url, model_name=model,
                          stream=stream, return_trace=return_trace, **kwargs)
         FileHandlerBase.__init__(self)
-        if stream:
-            self._model_optional_params['stream'] = True
 
     def _get_system_prompt(self):
         return 'You are an intelligent assistant provided by Minimax. You are a helpful assistant.'

--- a/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/siliconflow.py
@@ -23,8 +23,6 @@ class SiliconFlowChat(OnlineChatModuleBase, FileHandlerBase):
         super().__init__(api_key=api_key or self._default_api_key(), base_url=base_url, model_name=model,
                          stream=stream, return_trace=return_trace, **kwargs)
         FileHandlerBase.__init__(self)
-        if stream:
-            self._model_optional_params['stream'] = True
 
     def _get_system_prompt(self):
         return 'You are an intelligent assistant provided by SiliconFlow. You are a helpful assistant.'

--- a/lazyllm/module/llms/utils.py
+++ b/lazyllm/module/llms/utils.py
@@ -332,12 +332,13 @@ def resolve_model_name(model: Optional[str], entry: Optional[Dict[str, Any]]) ->
 
 def process_trainable_args(model: str, type: str, source: str,
                            config: Union[str, bool],
-                           entry: Optional[Dict[str, Any]]) -> dict:
+                           entry: Optional[Dict[str, Any]],
+                           stream: bool = False) -> dict:
     entry = entry or {}
     return {
         'base_model': resolve_model_name(model=model, entry=entry),
         'target_path': entry.get('target_path', ''),
-        'stream': entry.get('stream', False),
+        'stream': stream or entry.get('stream', False),
         'return_trace': entry.get('return_trace', False),
         'trust_remote_code': entry.get('trust_remote_code', True),
         'type': type or entry.get('type', entry.get('task', None)),
@@ -346,7 +347,8 @@ def process_trainable_args(model: str, type: str, source: str,
     }
 
 def process_online_args(model: str, source: str, type: str,
-                        entry: Optional[Dict[str, Any]]) -> dict:
+                        entry: Optional[Dict[str, Any]],
+                        stream: bool = False) -> dict:
     entry = entry or {}
     entry['model'] = resolve_model_name(model=model, entry=entry)
     if source:
@@ -358,4 +360,5 @@ def process_online_args(model: str, source: str, type: str,
     # ConfigsDict look up per-role dynamic configs by name rather than
     # falling back to 'default' for every module of the same slot type.
     entry.setdefault('name', model)
+    entry['stream'] = stream or entry.get('stream', False)
     return entry

--- a/lazyllm/module/llms/utils.py
+++ b/lazyllm/module/llms/utils.py
@@ -333,12 +333,12 @@ def resolve_model_name(model: Optional[str], entry: Optional[Dict[str, Any]]) ->
 def process_trainable_args(model: str, type: str, source: str,
                            config: Union[str, bool],
                            entry: Optional[Dict[str, Any]],
-                           stream: bool = False) -> dict:
+                           stream) -> dict:
     entry = entry or {}
     return {
         'base_model': resolve_model_name(model=model, entry=entry),
         'target_path': entry.get('target_path', ''),
-        'stream': stream or entry.get('stream', False),
+        'stream': stream,
         'return_trace': entry.get('return_trace', False),
         'trust_remote_code': entry.get('trust_remote_code', True),
         'type': type or entry.get('type', entry.get('task', None)),
@@ -348,7 +348,7 @@ def process_trainable_args(model: str, type: str, source: str,
 
 def process_online_args(model: str, source: str, type: str,
                         entry: Optional[Dict[str, Any]],
-                        stream: bool = False) -> dict:
+                        stream) -> dict:
     entry = entry or {}
     entry['model'] = resolve_model_name(model=model, entry=entry)
     if source:
@@ -360,5 +360,5 @@ def process_online_args(model: str, source: str, type: str,
     # ConfigsDict look up per-role dynamic configs by name rather than
     # falling back to 'default' for every module of the same slot type.
     entry.setdefault('name', model)
-    entry['stream'] = stream or entry.get('stream', False)
+    entry['stream'] = stream
     return entry


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- `AutoModel.__new__` 添加 `stream=True` 默认参数，并透传到 `OnlineChatModule`、`OnlineModule`、`TrainableModule`
- 补充 `**kwargs` 透传到各模块构造函数，保持一致性
- 移除 `AipingChat`、`MinimaxChat`、`SiliconFlowChat` 中冗余的 `stream` 设置（基类已处理）

---

# 🎯 问题背景 / Problem Context

- `AutoModel` 创建模块时未透传 `stream` 参数，导致无法在 AutoModel 层面控制流式输出
- 三个 supplier 类在 `__init__` 中重复设置 `stream` 参数，但基类 `OnlineChatModuleBase.__init__` 已经处理了该参数

---

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1.
2.
3.

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
# AutoModel now supports stream parameter
model = AutoModel("gpt-4", stream=False)
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# aiping.py / minimax.py / siliconflow.py __init__
if stream:
    self._model_optional_params['stream'] = True
```

## After

```python
# 基类 OnlineChatModuleBase.__init__ 已处理 stream，子类无需重复设置
```

# ⚠️ 注意事项 / Additional Notes

*

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [ ] CodeX
- [x] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
```text
将 AutoModel 的 stream 参数透传到各个子模块
```

## 一开始制定了什么方案

## 方案实施后存在什么问题

## 我（用户）发现了哪些问题

## 对这些问题优化后相比于之前有哪些优势

## 哪些可以沉淀为自己后续的编码规范
