### PR TITLE
fix: AutoModel should not unconditionally inject stream param, causing embed type signature mismatch

### DIFF
--- a/lazyllm/module/llms/automodel.py
+++ b/lazyllm/module/llms/automodel.py
@@ -27,7 +27,7 @@ class AutoModel:
 
         if not model:
             try:
-                return lazyllm.OnlineModule(source=source, type=type, **kwargs)
+                return lazyllm.OnlineModule(source=source, type=type)
             except Exception as e:
                 raise RuntimeError(f'`model` is not provided in AutoModel, and {e}') from None
 
@@ -39,7 +39,7 @@ class AutoModel:
                 model=model, type=type, source=source, config=config, entry=trainable_entry
             )
             try:
-                module = TrainableModule(**trainable_args, **kwargs)
+                module = TrainableModule(**trainable_args)
                 if module._url or module._impl._get_deploy_tasks.flag: return module
             except Exception as e:
                 LOG.warning('Fail to create `TrainableModule`, will try to '
@@ -48,12 +48,12 @@ class AutoModel:
         # 2) second: try OnlineModule with online config if found
         if online_entry is not None:
             online_args = process_online_args(model=model, source=source, type=type, entry=online_entry)
-            if online_args: return OnlineModule(**online_args, **kwargs)
+            if online_args: return OnlineModule(**online_args)
 
         # 3) finally: fallback (no config or config unusable)
         try:
-            return OnlineModule(model=model, source=source, type=type, **kwargs)
+            return OnlineModule(model=model, source=source, type=type)
         except Exception as e:
             LOG.warning('`OnlineModule` creation failed, and will try to '
                         f'load model {model} with local `TrainableModule`. Since the error: {e}')
-            return TrainableModule(model, type=type, **kwargs)
+            return TrainableModule(model, type=type)

--- a/lazyllm/module/llms/automodel.py
+++ b/lazyllm/module/llms/automodel.py
@@ -9,14 +9,14 @@ from .utils import get_candidate_entries, process_trainable_args, process_online
 class AutoModel:
 
     def __new__(cls, model: Optional[str] = None, *, config_id: Optional[str] = None, source: Optional[str] = None,  # noqa C901
-                type: Optional[str] = None, config: Union[str, bool] = True, stream=True, **kwargs: Any):
+                type: Optional[str] = None, config: Union[str, bool] = True, **kwargs: Any):
         # check and accomodate user params
         model = model or kwargs.pop('base_model', kwargs.pop('embed_model_name', kwargs.pop('model_name', None)))
 
         if source == 'dynamic':
             from .onlinemodule import OnlineChatModule
             dynamic_auth = kwargs.pop('dynamic_auth', False)
-            return OnlineChatModule(source='dynamic', dynamic_auth=dynamic_auth, type=type, stream=stream, **kwargs)
+            return OnlineChatModule(source='dynamic', dynamic_auth=dynamic_auth, type=type, **kwargs)
 
         if model in lazyllm.online.chat:
             if source is not None:
@@ -27,7 +27,7 @@ class AutoModel:
 
         if not model:
             try:
-                return lazyllm.OnlineModule(source=source, type=type, stream=stream, **kwargs)
+                return lazyllm.OnlineModule(source=source, type=type, **kwargs)
             except Exception as e:
                 raise RuntimeError(f'`model` is not provided in AutoModel, and {e}') from None
 
@@ -36,8 +36,7 @@ class AutoModel:
         # 1) first: try TrainableModule with trainable config (for directly connecting deployed endpoint)
         if trainable_entry is not None:
             trainable_args = process_trainable_args(
-                model=model, type=type, source=source, config=config, entry=trainable_entry,
-                stream=stream,
+                model=model, type=type, source=source, config=config, entry=trainable_entry
             )
             try:
                 module = TrainableModule(**trainable_args, **kwargs)
@@ -48,14 +47,13 @@ class AutoModel:
 
         # 2) second: try OnlineModule with online config if found
         if online_entry is not None:
-            online_args = process_online_args(model=model, source=source, type=type, entry=online_entry,
-                                              stream=stream)
+            online_args = process_online_args(model=model, source=source, type=type, entry=online_entry)
             if online_args: return OnlineModule(**online_args, **kwargs)
 
         # 3) finally: fallback (no config or config unusable)
         try:
-            return OnlineModule(model=model, source=source, type=type, stream=stream, **kwargs)
+            return OnlineModule(model=model, source=source, type=type, **kwargs)
         except Exception as e:
             LOG.warning('`OnlineModule` creation failed, and will try to '
                         f'load model {model} with local `TrainableModule`. Since the error: {e}')
-            return TrainableModule(model, type=type, stream=stream, **kwargs)
+            return TrainableModule(model, type=type, **kwargs)

--- a/lazyllm/module/llms/utils.py
+++ b/lazyllm/module/llms/utils.py
@@ -1,5 +1,6 @@
 import os
 import json
+from httpx import stream
 import yaml
 import functools
 from datetime import datetime
@@ -332,13 +333,12 @@ def resolve_model_name(model: Optional[str], entry: Optional[Dict[str, Any]]) ->
 
 def process_trainable_args(model: str, type: str, source: str,
                            config: Union[str, bool],
-                           entry: Optional[Dict[str, Any]],
-                           stream) -> dict:
+                           entry: Optional[Dict[str, Any]]) -> dict:
     entry = entry or {}
     return {
         'base_model': resolve_model_name(model=model, entry=entry),
         'target_path': entry.get('target_path', ''),
-        'stream': stream,
+        'stream': entry.get('stream', False),
         'return_trace': entry.get('return_trace', False),
         'trust_remote_code': entry.get('trust_remote_code', True),
         'type': type or entry.get('type', entry.get('task', None)),
@@ -347,8 +347,7 @@ def process_trainable_args(model: str, type: str, source: str,
     }
 
 def process_online_args(model: str, source: str, type: str,
-                        entry: Optional[Dict[str, Any]],
-                        stream) -> dict:
+                        entry: Optional[Dict[str, Any]]) -> dict:
     entry = entry or {}
     entry['model'] = resolve_model_name(model=model, entry=entry)
     if source:
@@ -360,5 +359,4 @@ def process_online_args(model: str, source: str, type: str,
     # ConfigsDict look up per-role dynamic configs by name rather than
     # falling back to 'default' for every module of the same slot type.
     entry.setdefault('name', model)
-    entry['stream'] = stream
     return entry

--- a/lazyllm/module/llms/utils.py
+++ b/lazyllm/module/llms/utils.py
@@ -1,6 +1,5 @@
 import os
 import json
-from httpx import stream
 import yaml
 import functools
 from datetime import datetime


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- `AutoModel.__new__` 移除 `stream` 参数，不再无条件透传 `stream=True` 给下游模块
- `process_online_args` 不再强制注入 `entry['stream'] = stream`，改为由 config entry 自身决定
- `process_trainable_args` 中 `stream` 从 entry 读取，默认 `False`

---

# 🎯 问题背景 / Problem Context

当 `type='embed'` 时，`AutoModel.__new__` 会将 `stream=True` 透传给 `OnlineModule`：

```python
# Before: AutoModel.__new__ 无条件传递 stream
return OnlineModule(source=source, type=type, stream=stream, **kwargs)
```

`OnlineModule` 根据 `type='embed'` 最终返回 `OnlineEmbed` 实例，但 `OnlineEmbed.__init__` 不接受 `stream` 参数，导致签名不符报错。

```
TypeError: OnlineEmbed.__init__() got an unexpected keyword argument 'stream'
```

根本原因：`stream` 是 chat 场景特有的参数，不应由 `AutoModel` 统一注入给所有类型的模块。

修复方案：`stream` 改为从 config entry 中按需获取：
- `OnlineModule` 路径：entry 中有 stream 就透传，没有就不传（embed 的 entry 本来就没有）
- `TrainableModule` 路径：从 entry 读取，默认 `False`

---

# 🔍 相关 Issue / Related Issue

*

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. 现有单测通过
2. 验证 `type='embed'` 时 `AutoModel` 创建 `OnlineEmbed` 不再报签名错误
3. 验证 chat 类型模块 stream 功能仍正常（从 config entry 读取）

---

# 🔄 变更对比 / Change Comparison

## Before

```python
class AutoModel:
    def __new__(cls, ..., stream=True, **kwargs):  # stream 硬编码默认 True
        ...
        return OnlineModule(source=source, type=type, stream=stream, **kwargs)  # 无条件注入
        trainable_args = process_trainable_args(..., stream=stream)              # 层层传递
        online_args = process_online_args(..., stream=stream)
        ...

def process_online_args(..., stream):
    entry['stream'] = stream  # 强制注入，与 OnlineEmbed 签名冲突
    return entry
```

## After

```python
class AutoModel:
    def __new__(cls, ..., **kwargs):  # 不再接管 stream
        ...
        return OnlineModule(source=source, type=type, **kwargs)  # 不注入 stream
        trainable_args = process_trainable_args(...)              # 从 entry 读取
        online_args = process_online_args(...)                    # entry 自身控制
        ...

def process_online_args(...):
    # 不再设置 entry['stream']，由 entry 自身决定
    return entry
```

---

# ⚠️ 注意事项 / Additional Notes

* `stream` 现在完全由 config entry 的 `stream` 字段控制。chat 类模块的 entry 中若配置了 `stream: true` 仍会正常生效
* 对 embed 等不需要 stream 的模块类型，entry 中本就没有 stream 字段，不再被强制注入，签名冲突消除