### PR TITLE
Add keyword_search for document-scoped keyword matching across segment stores

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -1286,6 +1286,42 @@ add_example('Document.get_window_nodes', '''\
 >>> window_nodes = doc.get_window_nodes(node, span=(-2, 2), merge=False)
 ''')
 
+add_chinese_doc('Document.keyword_search', '''\
+在指定文档内做关键词精准匹配，与全库检索的 :meth:`find` 互补。
+
+需提供 ``doc_id`` 定位目标文档，支持精确短语匹配或单词级匹配，可控制排序方式与返回数量。
+
+Args:
+    group (str): 节点组名（如 ``"block"`` 或 ``"line"``）。
+    keyword (str): 待匹配的关键词或短语。
+    doc_id (str): 目标文档 ID。
+    kb_id (Optional[str]): 知识库过滤条件（可选）。
+    phrase (bool): True 为精确子串匹配，False 要求所有单词均出现。
+    sort_by (str): ``"score"`` 按相关性排序，``"number"`` 按文档原始顺序排序。
+    size (int): 最大返回条数。
+
+Returns:
+    List[dict]: 命中的切片列表。
+''')
+
+add_english_doc('Document.keyword_search', '''\
+Perform exact keyword matching within a specific document, complementing the collection-wide retrieval of :meth:`find`.
+
+Requires ``doc_id`` to locate the target document. Supports exact phrase or word-level matching, with configurable sort order and result count.
+
+Args:
+    group (str): Node group name (e.g., ``"block"`` or ``"line"``).
+    keyword (str): Keyword or phrase to match.
+    doc_id (str): Target document ID.
+    kb_id (Optional[str]): Optional knowledge-base filter.
+    phrase (bool): True for exact substring match; False requires every word to appear.
+    sort_by (str): ``"score"`` sorts by relevance, ``"number"`` sorts by document order.
+    size (int): Maximum number of hits.
+
+Returns:
+    List[dict]: Matched segment list.
+''')
+
 
 
 # rag/graph_document.py
@@ -7720,6 +7756,38 @@ Returns:
         - Second element: mapping from embed key to ``DataType``.
 ''')
 
+add_chinese_doc('rag.LazyLLMStoreBase.keyword_search', '''\
+在指定文档内做关键词精准匹配，与全库相关性检索的 :meth:`search` 互补。
+
+Args:
+    collection_name (str): 表名或索引名。
+    keyword (str): 待匹配的关键词或短语。
+    doc_id (str): 限定在此文档内搜索。
+    kb_id (Optional[str]): 知识库过滤条件（可选）。
+    phrase (bool): True 为精确子串匹配，False 要求所有单词均出现（不要求顺序）。
+    sort_by (str): ``"score"`` 按关键词出现次数排序，``"number"`` 按文档原始顺序排序。
+    size (int): 最大返回条数。
+
+Returns:
+    List[dict]: 命中的切片列表。
+''')
+
+add_english_doc('rag.LazyLLMStoreBase.keyword_search', '''\
+Perform exact keyword matching within a specific document, complementing the collection-wide relevance retrieval of :meth:`search`.
+
+Args:
+    collection_name (str): Table or index name.
+    keyword (str): Keyword or phrase to match.
+    doc_id (str): Limit search to this document.
+    kb_id (Optional[str]): Optional knowledge-base filter.
+    phrase (bool): True for exact substring match; False requires every word to appear (any order).
+    sort_by (str): ``"score"`` sorts by keyword occurrence count, ``"number"`` sorts by original document order.
+    size (int): Maximum number of hits.
+
+Returns:
+    List[dict]: Matched segment list.
+''')
+
 add_chinese_doc('rag.doc_impl.DocImpl', '''\
 文档实现类，用于管理文档处理、存储和检索的核心功能。
 
@@ -8372,6 +8440,42 @@ Args:
 
 **Returns:**\n
 - List[dict]: 返回匹配结果列表及相似度 'score'。
+""")
+
+add_chinese_doc('rag.store.segment.OpenSearchStore.keyword_search', """\
+在单文档内做关键词精准匹配，直接拼 OpenSearch DSL（match_phrase / match + filter + highlight）。
+
+与 :meth:`search` 的全库检索不同，本方法限定 ``doc_id``，并通过 ``phrase`` 控制精确短语或单词级匹配，返回带高亮片段的切片列表。
+
+Args:
+    collection_name (str): 索引名。
+    keyword (str): 待匹配的关键词或短语。
+    doc_id (str): 目标文档 ID。
+    kb_id (Optional[str]): 知识库过滤条件（可选）。
+    phrase (bool): True 使用 match_phrase，False 使用 match。
+    sort_by (str): ``"score"`` 按 BM25 相关性排序，``"number"`` 按文档原始顺序排序。
+    size (int): 最大返回条数。
+
+Returns:
+    List[dict]: 命中的切片列表，可含 ``highlights`` 高亮片段。
+""")
+
+add_english_doc('rag.store.segment.OpenSearchStore.keyword_search', """\
+Exact keyword matching within a single document, building an OpenSearch DSL query (match_phrase / match + filter + highlight).
+
+Unlike :meth:`search` which does collection-wide retrieval, this method scopes to a single ``doc_id``, controls phrase vs word-level matching via ``phrase``, and returns segments with highlight snippets.
+
+Args:
+    collection_name (str): Index name.
+    keyword (str): Keyword or phrase to match.
+    doc_id (str): Target document ID.
+    kb_id (Optional[str]): Optional knowledge-base filter.
+    phrase (bool): True uses match_phrase; False uses match.
+    sort_by (str): ``"score"`` sorts by BM25 relevance; ``"number"`` sorts by document order.
+    size (int): Maximum number of hits.
+
+Returns:
+    List[dict]: Matched segment list, may contain ``highlights`` snippets.
 """)
 
 add_chinese_doc('services.ServerBase', """\
@@ -9042,6 +9146,42 @@ Args:
 
 Returns:
     List[dict]: Segment list with ``score`` field (negated FTS5 rank, higher = more relevant).
+""")
+
+add_chinese_doc('rag.store.segment.SQLiteStore.keyword_search', """\
+在单文档内做关键词精准匹配，先通过 :meth:`get` 取全文档切片再在内存中过滤排序。
+
+与 :meth:`search` 的全库 FTS5 检索不同，本方法限定 ``doc_id``，按 ``phrase`` 模式筛选后根据 ``sort_by`` 排序并截断。
+
+Args:
+    collection_name (str): 集合名称（表名）。
+    keyword (str): 待匹配的关键词或短语。
+    doc_id (str): 目标文档 ID。
+    kb_id (Optional[str]): 知识库过滤条件（可选）。
+    phrase (bool): True 为精确子串匹配，False 要求所有单词均出现。
+    sort_by (str): ``"score"`` 按关键词出现次数排序，``"number"`` 按文档原始顺序排序。
+    size (int): 最大返回条数。
+
+Returns:
+    List[dict]: 命中的切片列表。
+""")
+
+add_english_doc('rag.store.segment.SQLiteStore.keyword_search', """\
+Exact keyword matching within a single document — fetches all segments via :meth:`get`, then filters and sorts in memory.
+
+Unlike :meth:`search` which does collection-wide FTS5 retrieval, this method scopes to a single ``doc_id``, filters by ``phrase`` mode, then sorts by ``sort_by`` and truncates.
+
+Args:
+    collection_name (str): Collection name (table name).
+    keyword (str): Keyword or phrase to match.
+    doc_id (str): Target document ID.
+    kb_id (Optional[str]): Optional knowledge-base filter.
+    phrase (bool): True for exact substring match; False requires every word to appear.
+    sort_by (str): ``"score"`` sorts by keyword occurrence count, ``"number"`` sorts by document order.
+    size (int): Maximum number of hits.
+
+Returns:
+    List[dict]: Matched segment list.
 """)
 
 

--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -3911,6 +3911,42 @@ Args:
 - Union[List[DocNode], DocNode]: Window nodes list or a merged node.
 ''')
 
+add_chinese_doc('rag.document.UrlDocument.keyword_search', '''\
+在远程文档中执行关键词精准匹配。
+
+与 :meth:`Document.keyword_search` 接口一致，通过 RPC 代理到远端 Document 服务。
+
+Args:
+    group (str): 节点组名。
+    keyword (str): 待匹配的关键词。
+    doc_id (str): 目标文档 ID。
+    kb_id (Optional[str]): 知识库过滤条件。
+    phrase (bool): True 为精确子串匹配，False 为单词级匹配。
+    sort_by (str): ``"score"`` 按相关性排序，``"number"`` 按文档顺序排序。
+    size (int): 最大返回条数。
+
+Returns:
+    List[dict]: 命中的切片列表。
+''')
+
+add_english_doc('rag.document.UrlDocument.keyword_search', '''\
+Perform exact keyword matching in a remote document.
+
+Same interface as :meth:`Document.keyword_search`, proxied via RPC to the remote Document service.
+
+Args:
+    group (str): Node group name.
+    keyword (str): Keyword to match.
+    doc_id (str): Target document ID.
+    kb_id (Optional[str]): Knowledge-base filter.
+    phrase (bool): True for exact substring match, False for word-level match.
+    sort_by (str): ``"score"`` sorts by relevance, ``"number"`` sorts by document order.
+    size (int): Maximum number of hits.
+
+Returns:
+    List[dict]: Matched segment list.
+''')
+
 add_english_doc('rag.doc_node.DocNode', '''
 Execute assigned tasks on the specified document.
 

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -603,6 +603,14 @@ class DocImpl:
             sort_by_number=sort_by_number, display=True,
         )
 
+    def _keyword_search(self, group, keyword, doc_id, kb_id=None,
+                        phrase=True, sort_by='score', size=10):
+        self._lazy_init()
+        return self._store.keyword_search(
+            group=group, keyword=keyword, doc_id=doc_id, kb_id=kb_id,
+            phrase=phrase, sort_by=sort_by, size=size,
+        )
+
     def _get_window_nodes(self, node: DocNode, span: tuple[int, int] = (-5, 5),
                           merge: bool = False) -> Union[List[DocNode], DocNode]:
         if node is None:

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -528,6 +528,10 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
                          merge: bool = False) -> Union[List[DocNode], DocNode]:
         return self._forward('_get_window_nodes', node, span, merge)
 
+    def keyword_search(self, group, keyword, doc_id, kb_id=None,
+                       phrase=True, sort_by='score', size=10):
+        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size)
+
     def _get_post_process_tasks(self):
         return lazyllm.pipeline(lambda *a: self._forward('_lazy_init'))
 
@@ -563,6 +567,10 @@ class UrlDocument(ModuleBase):
     def get_window_nodes(self, node: DocNode, span: tuple[int, int] = (-5, 5),
                          merge: bool = False) -> Union[List[DocNode], DocNode]:
         return self._forward('_get_window_nodes', node, span, merge)
+
+    def keyword_search(self, group, keyword, doc_id, kb_id=None,
+                       phrase=True, sort_by='score', size=10):
+        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size)
 
     @cached_property
     def active_node_groups(self):

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -457,6 +457,7 @@ class _DocumentStore(object):
 
     def keyword_search(self, group, keyword, doc_id, kb_id=None,
                        phrase=True, sort_by='score', size=10):
+        self._seg_init()
         store = getattr(self._impl, 'segment_store', self._impl)
         return store.keyword_search(
             collection_name=self._gen_collection_name(group),

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -455,6 +455,15 @@ class _DocumentStore(object):
                 topk=topk, filters=filters, **kwargs))
         return [self._deserialize_node(segment, segment.get('score', 0)) for segment in segments]
 
+    def keyword_search(self, group, keyword, doc_id, kb_id=None,
+                       phrase=True, sort_by='score', size=10):
+        store = getattr(self._impl, 'segment_store', self._impl)
+        return store.keyword_search(
+            collection_name=self._gen_collection_name(group),
+            keyword=keyword, doc_id=doc_id, kb_id=kb_id,
+            phrase=phrase, sort_by=sort_by, size=size,
+        )
+
     def _validate_query_params(self, group_name: str, similarity: str,
                                embed_keys: Optional[List[str]] = None, **kwargs):
         assert self.is_group_active(group_name), f'[_DocumentStore] Group {group_name} is not active'

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -285,7 +285,8 @@ class OpenSearchStore(LazyLLMStoreBase):
                         'global_meta', 'type', 'number', 'parent'],
             'query': {'bool': {
                 'filter': filters,
-                'must': [{'match_phrase' if phrase else 'match': {'content': keyword}}],
+                'must': [{'match_phrase': {'content': keyword}} if phrase
+                         else {'match': {'content': {'query': keyword, 'operator': 'and'}}}],
             }},
             'sort': [{'number': {'order': 'asc'}}] if sort_by == 'number' else [
                 {'_score': {'order': 'desc'}}, {'number': {'order': 'asc'}}],

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -270,6 +270,41 @@ class OpenSearchStore(LazyLLMStoreBase):
             LOG.error(f'[OpenSearchStore - search] Error searching data from OpenSearch: {e}')
             return []
 
+    @override
+    def keyword_search(self, collection_name, keyword, doc_id, kb_id=None,
+                       phrase=True, sort_by='score', size=10, **kwargs):
+        LOG.info(f'[OpenSearchStore.keyword_search] collection={collection_name!r} keyword={keyword!r} '
+                 f'doc_id={doc_id!r} kb_id={kb_id!r} phrase={phrase} sort_by={sort_by!r}')
+        self._ensure_index(collection_name)
+        filters = [{'term': {'doc_id': doc_id}}]
+        if kb_id:
+            filters.append({'term': {'kb_id': kb_id}})
+        body = {
+            'size': size,
+            '_source': ['uid', 'doc_id', 'kb_id', 'group', 'content', 'meta',
+                        'global_meta', 'type', 'number', 'parent'],
+            'query': {'bool': {
+                'filter': filters,
+                'must': [{'match_phrase' if phrase else 'match': {'content': keyword}}],
+            }},
+            'sort': [{'number': {'order': 'asc'}}] if sort_by == 'number' else [
+                {'_score': {'order': 'desc'}}, {'number': {'order': 'asc'}}],
+            'highlight': {
+                'fields': {'content': {'fragment_size': 180, 'number_of_fragments': 3}},
+            },
+        }
+        resp = self._client.search(index=collection_name, body=body)
+        res = []
+        for hit in resp['hits']['hits']:
+            seg = self._transform_segment(hit)
+            if seg:
+                seg['score'] = hit.get('_score', 0.0)
+                highlights = hit.get('highlight', {}).get('content', [])
+                if highlights:
+                    seg['highlights'] = highlights
+                res.append(seg)
+        return res
+
     def _serialize_node(self, segment: dict):
         seg = dict(segment)
         seg.pop('embedding', None)

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -276,9 +276,9 @@ class OpenSearchStore(LazyLLMStoreBase):
         LOG.info(f'[OpenSearchStore.keyword_search] collection={collection_name!r} keyword={keyword!r} '
                  f'doc_id={doc_id!r} kb_id={kb_id!r} phrase={phrase} sort_by={sort_by!r}')
         self._ensure_index(collection_name)
-        filters = [{'term': {'doc_id': doc_id}}]
+        filters = [{'term': {'doc_id.keyword': doc_id}}]
         if kb_id:
-            filters.append({'term': {'kb_id': kb_id}})
+            filters.append({'term': {'kb_id.keyword': kb_id}})
         body = {
             'size': size,
             '_source': ['uid', 'doc_id', 'kb_id', 'group', 'content', 'meta',

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -169,6 +169,33 @@ class SQLiteStore(LazyLLMStoreBase):
             return ([], 0) if kwargs.get('return_total') else []
 
     @override
+    def keyword_search(self, collection_name, keyword, doc_id, kb_id=None,
+                       phrase=True, sort_by='score', size=10, **kwargs):
+        LOG.info(f'[SQLiteStore.keyword_search] collection={collection_name!r} keyword={keyword!r} '
+                 f'doc_id={doc_id!r} kb_id={kb_id!r} phrase={phrase} sort_by={sort_by!r}')
+        criteria = {RAG_DOC_ID: doc_id}
+        if kb_id:
+            criteria[RAG_KB_ID] = kb_id
+        nodes = self.get(collection_name, criteria=criteria)
+
+        kw_lower = keyword.lower()
+        matched = []
+        for n in nodes:
+            text = (n.get('content') or '').lower()
+            if phrase:
+                if kw_lower in text:
+                    matched.append(n)
+            elif all(w.lower() in text for w in keyword.split()):
+                matched.append(n)
+
+        if sort_by == 'number':
+            matched.sort(key=lambda n: (n.get('number', 0) or 0, (n.get('uid', '') or '')))
+        else:
+            matched.sort(key=lambda n: ((n.get('content') or '').lower().count(kw_lower)), reverse=True)
+
+        return matched[:size]
+
+    @override
     def search(self, collection_name, query=None, topk=10, filters=None, **kwargs):
         if not query: return []
         try:

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -179,19 +179,22 @@ class SQLiteStore(LazyLLMStoreBase):
         nodes = self.get(collection_name, criteria=criteria)
 
         kw_lower = keyword.lower()
+        words = kw_lower.split()
         matched = []
         for n in nodes:
             text = (n.get('content') or '').lower()
             if phrase:
                 if kw_lower in text:
                     matched.append(n)
-            elif all(w.lower() in text for w in keyword.split()):
+            elif all(w in text for w in words):
                 matched.append(n)
 
         if sort_by == 'number':
             matched.sort(key=lambda n: (n.get('number', 0) or 0, (n.get('uid', '') or '')))
-        else:
+        elif phrase:
             matched.sort(key=lambda n: ((n.get('content') or '').lower().count(kw_lower)), reverse=True)
+        else:
+            matched.sort(key=lambda n: sum(((n.get('content') or '').lower().count(w) for w in words)), reverse=True)
 
         return matched[:size]
 

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -123,6 +123,13 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
                embed_key: Optional[str] = None, **kwargs) -> List[dict]:
         raise NotImplementedError
 
+    def keyword_search(
+        self, collection_name: str, keyword: str, doc_id: str,
+        kb_id: Optional[str] = None, phrase: bool = True,
+        sort_by: str = 'score', size: int = 10, **kwargs
+    ) -> List[dict]:
+        raise NotImplementedError
+
     def seg_connect(self, *args, **kwargs):
         # For pure SEGMENT stores: seg_connect == connect.
         # For pure VECTOR stores: seg_connect is a no-op.


### PR DESCRIPTION
# PR Description

Add `keyword_search` method to the Store abstraction for exact keyword matching within a single document, replacing the backend-specific branches in the business layer with a unified interface.

# Design

Originally, `kb_keyword_search` in the Agent tool layer contained two separate code paths: direct OpenSearch HTTP DSL queries and Python-level string matching for SQLite. Both bypassed the Store abstraction. This PR introduces `keyword_search` as a Store-layer method, allowing each backend to implement its own matching logic while the business layer calls a single interface.

# Changes

- **`LazyLLMStoreBase`**: add optional `keyword_search` interface with default `NotImplementedError`
- **`SQLiteStore`**: fetch segments via `get`, then filter/sort in Python (substring or all-words match)
- **`OpenSearchStore`**: build DSL query with `match_phrase`/`match` + `doc_id`/`kb_id` filters + highlight + custom sort
- **`_DocumentStore`**: route `keyword_search(group, ...)` to segment store with collection name generation
- **`Document` / `UrlDocument`**: proxy `keyword_search` via `_forward(_keyword_search, ...)` RPC
- **`DocImpl`**: server-side handler `_keyword_search` that calls `self._store.keyword_search()`
- **`docs/tools/tool_rag.py`**: bilingual API docs for all four public methods

# Type of Change

* [ ] Bug fix
* [X] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

# 📷 Demo
<img width="613" height="441" alt="企业微信截图_1781242637184" src="https://github.com/user-attachments/assets/b3c8400f-958e-4101-b079-79ba359be404" />
<img width="634" height="447" alt="企业微信截图_17812417129687" src="https://github.com/user-attachments/assets/14e5295d-b83d-49ed-bf77-c03405b2a84c" />


# How Has This Been Tested?

1. Deployed with SQLiteStore backend — `kb_keyword_search` returns matched segments correctly
2. Deployed with OpenSearch backend — verified `match_phrase` and `match` DSL queries return correct results
3. Existing `test_store.py` SQLiteStore tests all pass

# AI Involvement

- [x] AI-assisted (partial code)
- **Tools Used**: ClaudeCode