### PR TITLE
feat(tools): use full docstring description instead of short_description for LLM tool schema

### DIFF
--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -298,7 +298,7 @@ def _build_tool_desc(tool: 'ModuleTool') -> Dict:
         'type': 'function',
         'function': {
             'name': tool.name,
-            'description': parsed_docstring.short_description,
+            'description': parsed_docstring.description,
             'parameters': {'type': 'object', 'properties': args, 'required': required_arg_list},
         }
     }
@@ -380,7 +380,7 @@ class ToolGroup(ToolContainer):
             return (f'Activated tool group "{group_name}". '
                     f'Available tools: {", ".join(child_names)}')
 
-        short_desc = docstring_parser.parse(self._desc).short_description if self._desc else ''
+        short_desc = docstring_parser.parse(self._desc).description if self._desc else ''
         desc = f'Get available methods of {group_name}. {short_desc or ""}'
         _gateway_apply.__doc__ = (f'{desc}\n\nReturns:\n    str: List of available tool names in this group.')
         _gateway_apply.__name__ = f'get_{group_name}_methods'

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -380,8 +380,8 @@ class ToolGroup(ToolContainer):
             return (f'Activated tool group "{group_name}". '
                     f'Available tools: {", ".join(child_names)}')
 
-        short_desc = docstring_parser.parse(self._desc).description if self._desc else ''
-        desc = f'Get available methods of {group_name}. {short_desc or ""}'
+        group_desc = docstring_parser.parse(self._desc).description if self._desc else ''
+        desc = f'Get available methods of {group_name}. {group_desc or ""}'
         _gateway_apply.__doc__ = (f'{desc}\n\nReturns:\n    str: List of available tool names in this group.')
         _gateway_apply.__name__ = f'get_{group_name}_methods'
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

`_build_tool_desc` 现在使用 `parsed_docstring.description`（short + long 完整描述）替代 `parsed_docstring.short_description`（仅第一句话），使 LLM 收到工具 docstring 中完整的使用指导。

`ToolGroup.make_gateway_tool` 同步更新为 `.description` 以保持一致。

---

# 🎯 问题背景 / Problem Context

当前 `_build_tool_desc` 只提取 docstring 的 `short_description`（第一句话）作为发送给 LLM 的工具描述。例如 `url_fetch` 的完整 docstring 包含详细的使用指导，但 LLM 只能看到第一句话，丢失了行为指引。

`docstring_parser` 的 `.description` 属性返回 short + long 完整描述，LLM 能获取工具的完整使用指导。

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. 现有单测通过
2. 检查 `_build_tool_desc` 输出的 description 字段包含完整 docstring 正文

---

# 🧠 AI 参与情况 / AI Involvement

* [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)

**使用工具 / Tools Used：**
* [x] ClaudeCode
