### PR TITLE
Supported file_name in KeyWord Search of OpenSearch and SQLite

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -1297,16 +1297,17 @@ add_example('Document.get_window_nodes', '''\
 add_chinese_doc('Document.keyword_search', '''\
 在指定文档内做关键词精准匹配，与全库检索的 :meth:`find` 互补。
 
-需提供 ``doc_id`` 定位目标文档，支持精确短语匹配或单词级匹配，可控制排序方式与返回数量。
+通过 ``doc_id`` 或 ``file_name`` 定位目标文档（二选一，``file_name`` 优先），支持精确短语匹配或单词级匹配，可控制排序方式与返回数量。
 
 Args:
     group (str): 节点组名（如 ``"block"`` 或 ``"line"``）。
     keyword (str): 待匹配的关键词或短语。
-    doc_id (str): 目标文档 ID。
+    doc_id (str): 目标文档 ID，默认为空字符串。与 ``file_name`` 二选一，若同时提供则 ``file_name`` 优先。
     kb_id (Optional[str]): 知识库过滤条件（可选）。
     phrase (bool): True 为精确子串匹配，False 要求所有单词均出现。
     sort_by (str): ``"score"`` 按相关性排序，``"number"`` 按文档原始顺序排序。
     size (int): 最大返回条数。
+    file_name (Optional[str]): 按文件名过滤，与 ``doc_id`` 二选一。提供此参数时 ``doc_id`` 被忽略。
 
 Returns:
     List[dict]: 命中的切片列表。
@@ -1315,16 +1316,17 @@ Returns:
 add_english_doc('Document.keyword_search', '''\
 Perform exact keyword matching within a specific document, complementing the collection-wide retrieval of :meth:`find`.
 
-Requires ``doc_id`` to locate the target document. Supports exact phrase or word-level matching, with configurable sort order and result count.
+Locate the target document via ``doc_id`` or ``file_name`` (mutually exclusive; ``file_name`` takes precedence). Supports exact phrase or word-level matching, with configurable sort order and result count.
 
 Args:
     group (str): Node group name (e.g., ``"block"`` or ``"line"``).
     keyword (str): Keyword or phrase to match.
-    doc_id (str): Target document ID.
+    doc_id (str): Target document ID, defaults to empty string. Mutually exclusive with ``file_name``; if both are given, ``file_name`` takes priority.
     kb_id (Optional[str]): Optional knowledge-base filter.
     phrase (bool): True for exact substring match; False requires every word to appear.
     sort_by (str): ``"score"`` sorts by relevance, ``"number"`` sorts by document order.
     size (int): Maximum number of hits.
+    file_name (Optional[str]): Filter by file name. Mutually exclusive with ``doc_id``; when set, ``doc_id`` is ignored.
 
 Returns:
     List[dict]: Matched segment list.
@@ -3991,11 +3993,12 @@ add_chinese_doc('rag.document.UrlDocument.keyword_search', '''\
 Args:
     group (str): 节点组名。
     keyword (str): 待匹配的关键词。
-    doc_id (str): 目标文档 ID。
+    doc_id (str): 目标文档 ID，默认为空字符串。与 ``file_name`` 二选一，若同时提供则 ``file_name`` 优先。
     kb_id (Optional[str]): 知识库过滤条件。
     phrase (bool): True 为精确子串匹配，False 为单词级匹配。
     sort_by (str): ``"score"`` 按相关性排序，``"number"`` 按文档顺序排序。
     size (int): 最大返回条数。
+    file_name (Optional[str]): 按文件名过滤，与 ``doc_id`` 二选一。提供此参数时 ``doc_id`` 被忽略。
 
 Returns:
     List[dict]: 命中的切片列表。
@@ -4009,11 +4012,12 @@ Same interface as :meth:`Document.keyword_search`, proxied via RPC to the remote
 Args:
     group (str): Node group name.
     keyword (str): Keyword to match.
-    doc_id (str): Target document ID.
+    doc_id (str): Target document ID, defaults to empty string. Mutually exclusive with ``file_name``; if both are given, ``file_name`` takes priority.
     kb_id (Optional[str]): Knowledge-base filter.
     phrase (bool): True for exact substring match, False for word-level match.
     sort_by (str): ``"score"`` sorts by relevance, ``"number"`` sorts by document order.
     size (int): Maximum number of hits.
+    file_name (Optional[str]): Filter by file name. Mutually exclusive with ``doc_id``; when set, ``doc_id`` is ignored.
 
 Returns:
     List[dict]: Matched segment list.
@@ -7867,14 +7871,17 @@ Returns:
 add_chinese_doc('rag.LazyLLMStoreBase.keyword_search', '''\
 在指定文档内做关键词精准匹配，与全库相关性检索的 :meth:`search` 互补。
 
+通过 ``doc_id`` 或 ``file_name`` 定位目标文档（二选一，``file_name`` 优先）。
+
 Args:
     collection_name (str): 表名或索引名。
     keyword (str): 待匹配的关键词或短语。
-    doc_id (str): 限定在此文档内搜索。
+    doc_id (str): 限定在此文档内搜索，默认为空字符串。与 ``file_name`` 二选一，若同时提供则 ``file_name`` 优先。
     kb_id (Optional[str]): 知识库过滤条件（可选）。
     phrase (bool): True 为精确子串匹配，False 要求所有单词均出现（不要求顺序）。
     sort_by (str): ``"score"`` 按关键词出现次数排序，``"number"`` 按文档原始顺序排序。
     size (int): 最大返回条数。
+    file_name (Optional[str]): 按文件名过滤，与 ``doc_id`` 二选一。提供此参数时 ``doc_id`` 被忽略。
 
 Returns:
     List[dict]: 命中的切片列表。
@@ -7883,14 +7890,17 @@ Returns:
 add_english_doc('rag.LazyLLMStoreBase.keyword_search', '''\
 Perform exact keyword matching within a specific document, complementing the collection-wide relevance retrieval of :meth:`search`.
 
+Locate the target document via ``doc_id`` or ``file_name`` (mutually exclusive; ``file_name`` takes precedence).
+
 Args:
     collection_name (str): Table or index name.
     keyword (str): Keyword or phrase to match.
-    doc_id (str): Limit search to this document.
+    doc_id (str): Limit search to this document, defaults to empty string. Mutually exclusive with ``file_name``; if both are given, ``file_name`` takes priority.
     kb_id (Optional[str]): Optional knowledge-base filter.
     phrase (bool): True for exact substring match; False requires every word to appear (any order).
     sort_by (str): ``"score"`` sorts by keyword occurrence count, ``"number"`` sorts by original document order.
     size (int): Maximum number of hits.
+    file_name (Optional[str]): Filter by file name. Mutually exclusive with ``doc_id``; when set, ``doc_id`` is ignored.
 
 Returns:
     List[dict]: Matched segment list.
@@ -8553,16 +8563,17 @@ Args:
 add_chinese_doc('rag.store.segment.OpenSearchStore.keyword_search', """\
 在单文档内做关键词精准匹配，直接拼 OpenSearch DSL（match_phrase / match + filter + highlight）。
 
-与 :meth:`search` 的全库检索不同，本方法限定 ``doc_id``，并通过 ``phrase`` 控制精确短语或单词级匹配，返回带高亮片段的切片列表。
+与 :meth:`search` 的全库检索不同，本方法通过 ``doc_id`` 或 ``file_name`` 限定目标文档（二选一，``file_name`` 优先），并通过 ``phrase`` 控制精确短语或单词级匹配，返回带高亮片段的切片列表。
 
 Args:
     collection_name (str): 索引名。
     keyword (str): 待匹配的关键词或短语。
-    doc_id (str): 目标文档 ID。
+    doc_id (str): 目标文档 ID，默认为空字符串。与 ``file_name`` 二选一，若同时提供则 ``file_name`` 优先。
     kb_id (Optional[str]): 知识库过滤条件（可选）。
     phrase (bool): True 使用 match_phrase，False 使用 match。
     sort_by (str): ``"score"`` 按 BM25 相关性排序，``"number"`` 按文档原始顺序排序。
     size (int): 最大返回条数。
+    file_name (Optional[str]): 按文件名过滤，与 ``doc_id`` 二选一。提供此参数时 ``doc_id`` 被忽略。
 
 Returns:
     List[dict]: 命中的切片列表，可含 ``highlights`` 高亮片段。
@@ -8571,16 +8582,17 @@ Returns:
 add_english_doc('rag.store.segment.OpenSearchStore.keyword_search', """\
 Exact keyword matching within a single document, building an OpenSearch DSL query (match_phrase / match + filter + highlight).
 
-Unlike :meth:`search` which does collection-wide retrieval, this method scopes to a single ``doc_id``, controls phrase vs word-level matching via ``phrase``, and returns segments with highlight snippets.
+Unlike :meth:`search` which does collection-wide retrieval, this method scopes to a single document via ``doc_id`` or ``file_name`` (mutually exclusive; ``file_name`` takes precedence), controls phrase vs word-level matching via ``phrase``, and returns segments with highlight snippets.
 
 Args:
     collection_name (str): Index name.
     keyword (str): Keyword or phrase to match.
-    doc_id (str): Target document ID.
+    doc_id (str): Target document ID, defaults to empty string. Mutually exclusive with ``file_name``; if both are given, ``file_name`` takes priority.
     kb_id (Optional[str]): Optional knowledge-base filter.
     phrase (bool): True uses match_phrase; False uses match.
     sort_by (str): ``"score"`` sorts by BM25 relevance; ``"number"`` sorts by document order.
     size (int): Maximum number of hits.
+    file_name (Optional[str]): Filter by file name. Mutually exclusive with ``doc_id``; when set, ``doc_id`` is ignored.
 
 Returns:
     List[dict]: Matched segment list, may contain ``highlights`` snippets.
@@ -9259,16 +9271,17 @@ Returns:
 add_chinese_doc('rag.store.segment.SQLiteStore.keyword_search', """\
 在单文档内做关键词精准匹配，先通过 :meth:`get` 取全文档切片再在内存中过滤排序。
 
-与 :meth:`search` 的全库 FTS5 检索不同，本方法限定 ``doc_id``，按 ``phrase`` 模式筛选后根据 ``sort_by`` 排序并截断。
+与 :meth:`search` 的全库 FTS5 检索不同，本方法通过 ``doc_id`` 或 ``file_name`` 限定目标文档（二选一，``file_name`` 优先），按 ``phrase`` 模式筛选后根据 ``sort_by`` 排序并截断。
 
 Args:
     collection_name (str): 集合名称（表名）。
     keyword (str): 待匹配的关键词或短语。
-    doc_id (str): 目标文档 ID。
+    doc_id (str): 目标文档 ID，默认为空字符串。与 ``file_name`` 二选一，若同时提供则 ``file_name`` 优先。
     kb_id (Optional[str]): 知识库过滤条件（可选）。
     phrase (bool): True 为精确子串匹配，False 要求所有单词均出现。
     sort_by (str): ``"score"`` 按关键词出现次数排序，``"number"`` 按文档原始顺序排序。
     size (int): 最大返回条数。
+    file_name (Optional[str]): 按文件名过滤，与 ``doc_id`` 二选一。提供此参数时 ``doc_id`` 被忽略。
 
 Returns:
     List[dict]: 命中的切片列表。
@@ -9277,16 +9290,17 @@ Returns:
 add_english_doc('rag.store.segment.SQLiteStore.keyword_search', """\
 Exact keyword matching within a single document — fetches all segments via :meth:`get`, then filters and sorts in memory.
 
-Unlike :meth:`search` which does collection-wide FTS5 retrieval, this method scopes to a single ``doc_id``, filters by ``phrase`` mode, then sorts by ``sort_by`` and truncates.
+Unlike :meth:`search` which does collection-wide FTS5 retrieval, this method scopes to a single document via ``doc_id`` or ``file_name`` (mutually exclusive; ``file_name`` takes precedence), filters by ``phrase`` mode, then sorts by ``sort_by`` and truncates.
 
 Args:
     collection_name (str): Collection name (table name).
     keyword (str): Keyword or phrase to match.
-    doc_id (str): Target document ID.
+    doc_id (str): Target document ID, defaults to empty string. Mutually exclusive with ``file_name``; if both are given, ``file_name`` takes priority.
     kb_id (Optional[str]): Optional knowledge-base filter.
     phrase (bool): True for exact substring match; False requires every word to appear.
     sort_by (str): ``"score"`` sorts by keyword occurrence count, ``"number"`` sorts by document order.
     size (int): Maximum number of hits.
+    file_name (Optional[str]): Filter by file name. Mutually exclusive with ``doc_id``; when set, ``doc_id`` is ignored.
 
 Returns:
     List[dict]: Matched segment list.

--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -604,12 +604,12 @@ class DocImpl:
             sort_by_number=sort_by_number, display=True,
         )
 
-    def _keyword_search(self, group, keyword, doc_id, kb_id=None,
-                        phrase=True, sort_by='score', size=10):
+    def _keyword_search(self, group, keyword, doc_id='', kb_id=None,
+                        phrase=True, sort_by='score', size=10, file_name=None):
         self._lazy_init()
         return self._store.keyword_search(
             group=group, keyword=keyword, doc_id=doc_id, kb_id=kb_id,
-            phrase=phrase, sort_by=sort_by, size=size,
+            phrase=phrase, sort_by=sort_by, size=size, file_name=file_name,
         )
 
     def _get_window_nodes(self, node: DocNode, span: tuple[int, int] = (-5, 5),

--- a/lazyllm/tools/rag/document.py
+++ b/lazyllm/tools/rag/document.py
@@ -528,9 +528,9 @@ class Document(ModuleBase, BuiltinGroups, metaclass=_MetaDocument):
                          merge: bool = False) -> Union[List[DocNode], DocNode]:
         return self._forward('_get_window_nodes', node, span, merge)
 
-    def keyword_search(self, group, keyword, doc_id, kb_id=None,
-                       phrase=True, sort_by='score', size=10):
-        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size)
+    def keyword_search(self, group, keyword, doc_id='', kb_id=None,
+                       phrase=True, sort_by='score', size=10, file_name=None):
+        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size, file_name)
 
     def _get_post_process_tasks(self):
         return lazyllm.pipeline(lambda *a: self._forward('_lazy_init'))
@@ -568,9 +568,9 @@ class UrlDocument(ModuleBase):
                          merge: bool = False) -> Union[List[DocNode], DocNode]:
         return self._forward('_get_window_nodes', node, span, merge)
 
-    def keyword_search(self, group, keyword, doc_id, kb_id=None,
-                       phrase=True, sort_by='score', size=10):
-        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size)
+    def keyword_search(self, group, keyword, doc_id='', kb_id=None,
+                       phrase=True, sort_by='score', size=10, file_name=None):
+        return self._forward('_keyword_search', group, keyword, doc_id, kb_id, phrase, sort_by, size, file_name)
 
     @cached_property
     def active_node_groups(self):

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -455,14 +455,15 @@ class _DocumentStore(object):
                 topk=topk, filters=filters, **kwargs))
         return [self._deserialize_node(segment, segment.get('score', 0)) for segment in segments]
 
-    def keyword_search(self, group, keyword, doc_id, kb_id=None,
-                       phrase=True, sort_by='score', size=10):
+    def keyword_search(self, group, keyword, doc_id='', kb_id=None,
+                       phrase=True, sort_by='score', size=10, file_name=None):
         self._seg_init()
         store = getattr(self._impl, 'segment_store', self._impl)
         return store.keyword_search(
             collection_name=self._gen_collection_name(group),
             keyword=keyword, doc_id=doc_id, kb_id=kb_id,
             phrase=phrase, sort_by=sort_by, size=size,
+            file_name=file_name,
         )
 
     def _validate_query_params(self, group_name: str, similarity: str,

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -271,12 +271,16 @@ class OpenSearchStore(LazyLLMStoreBase):
             return []
 
     @override
-    def keyword_search(self, collection_name, keyword, doc_id, kb_id=None,
-                       phrase=True, sort_by='score', size=10, **kwargs):
+    def keyword_search(self, collection_name, keyword, doc_id='', kb_id=None,
+                       phrase=True, sort_by='score', size=10, file_name=None, **kwargs):
         LOG.info(f'[OpenSearchStore.keyword_search] collection={collection_name!r} keyword={keyword!r} '
-                 f'doc_id={doc_id!r} kb_id={kb_id!r} phrase={phrase} sort_by={sort_by!r}')
+                 f'doc_id={doc_id!r} kb_id={kb_id!r} file_name={file_name!r} phrase={phrase} sort_by={sort_by!r}')
         self._ensure_index(collection_name)
-        filters = [{'term': {'doc_id.keyword': doc_id}}]
+        filters = []
+        if file_name:
+            filters.append({'term': {'global_meta.file_name.keyword': file_name}})
+        elif doc_id:
+            filters.append({'term': {'doc_id.keyword': doc_id}})
         if kb_id:
             filters.append({'term': {'kb_id.keyword': kb_id}})
         body = {

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -169,19 +169,29 @@ class SQLiteStore(LazyLLMStoreBase):
             return ([], 0) if kwargs.get('return_total') else []
 
     @override
-    def keyword_search(self, collection_name, keyword, doc_id, kb_id=None,
-                       phrase=True, sort_by='score', size=10, **kwargs):
+    def keyword_search(self, collection_name, keyword, doc_id='', kb_id=None,
+                       phrase=True, sort_by='score', size=10, file_name=None, **kwargs):
         LOG.info(f'[SQLiteStore.keyword_search] collection={collection_name!r} keyword={keyword!r} '
-                 f'doc_id={doc_id!r} kb_id={kb_id!r} phrase={phrase} sort_by={sort_by!r}')
-        criteria = {RAG_DOC_ID: doc_id}
+                 f'doc_id={doc_id!r} kb_id={kb_id!r} file_name={file_name!r} phrase={phrase} sort_by={sort_by!r}')
+        criteria = {}
+        if file_name:
+            # file_name is stored inside global_meta JSON; filter in Python after fetch
+            pass  # handled below
+        elif doc_id:
+            criteria[RAG_DOC_ID] = doc_id
         if kb_id:
             criteria[RAG_KB_ID] = kb_id
-        nodes = self.get(collection_name, criteria=criteria)
+        nodes = self.get(collection_name, criteria=criteria if criteria else None)
 
         kw_lower = keyword.lower()
         words = kw_lower.split()
         matched = []
         for n in nodes:
+            if file_name:
+                gm_raw = n.get('global_meta') or '{}'
+                gm = json.loads(gm_raw) if isinstance(gm_raw, str) else (gm_raw or {})
+                if gm.get('file_name') != file_name:
+                    continue
             text = (n.get('content') or '').lower()
             if phrase:
                 if kw_lower in text:

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -7,7 +7,7 @@ from lazyllm import LOG
 from lazyllm.common import override
 
 from ..store_base import LazyLLMStoreBase, StoreCapability, INSERT_BATCH_SIZE, DEFAULT_KB_ID
-from ...global_metadata import RAG_DOC_ID, RAG_KB_ID
+from ...global_metadata import RAG_DOC_ID, RAG_KB_ID, RAG_DOC_FILE_NAME
 
 
 class SQLiteStore(LazyLLMStoreBase):
@@ -175,8 +175,7 @@ class SQLiteStore(LazyLLMStoreBase):
                  f'doc_id={doc_id!r} kb_id={kb_id!r} file_name={file_name!r} phrase={phrase} sort_by={sort_by!r}')
         criteria = {}
         if file_name:
-            # file_name is stored inside global_meta JSON; filter in Python after fetch
-            pass  # handled below
+            criteria[RAG_DOC_FILE_NAME] = file_name
         elif doc_id:
             criteria[RAG_DOC_ID] = doc_id
         if kb_id:
@@ -187,11 +186,6 @@ class SQLiteStore(LazyLLMStoreBase):
         words = kw_lower.split()
         matched = []
         for n in nodes:
-            if file_name:
-                gm_raw = n.get('global_meta') or '{}'
-                gm = json.loads(gm_raw) if isinstance(gm_raw, str) else (gm_raw or {})
-                if gm.get('file_name') != file_name:
-                    continue
             text = (n.get('content') or '').lower()
             if phrase:
                 if kw_lower in text:

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -124,9 +124,10 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
         raise NotImplementedError
 
     def keyword_search(
-        self, collection_name: str, keyword: str, doc_id: str,
+        self, collection_name: str, keyword: str, doc_id: str = '',
         kb_id: Optional[str] = None, phrase: bool = True,
-        sort_by: str = 'score', size: int = 10, **kwargs
+        sort_by: str = 'score', size: int = 10,
+        file_name: Optional[str] = None, **kwargs
     ) -> List[dict]:
         raise NotImplementedError
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

Supported file_name in KeyWord Search of OpenSearch and SQLite

---

# 🎯 问题背景 / Problem Context

Keyword Search originally only supported searching with doc_id and keywords, which caused the AI-Agent to increase the call chain by searching the vector library to obtain the doc_id. Now, by adding the file_name field to Keyword Search, the call chain has been greatly reduced and the hit rate has been improved.

---

# ✅ 变更类型 / Type of Change

* [ ] Bug fix
* [X] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 📷 Demo (Optional)
<img width="585" height="412" alt="企业微信截图_17817493453322" src="https://github.com/user-attachments/assets/655f5cb1-351f-4408-9c84-6833d89d8787" />
<img width="642" height="415" alt="企业微信截图_17817502467770" src="https://github.com/user-attachments/assets/5dd0c106-acc7-4f23-b502-5cab3577db1e" />
---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [X] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [ ] CodeX
- [X] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：
