### PR TITLE
add get_doc_ng_status for DocServer

### DIFF
--- a/lazyllm/tools/rag/doc_service/doc_manager.py
+++ b/lazyllm/tools/rag/doc_service/doc_manager.py
@@ -1493,7 +1493,7 @@ class DocManager:
         raise DocServiceError('E_INVALID_PARAM', f'group {group!r} not found in any algo bound to kb {kb_id}',
                               {'kb_id': kb_id, 'group': group})
 
-    def list_doc_node_groups(self, kb_id: str, doc_id: str):
+    def get_doc_ng_status(self, kb_id: str, doc_id: str):
         for name, val in [('kb_id', kb_id), ('doc_id', doc_id)]:
             if not val:
                 raise DocServiceError('E_INVALID_PARAM', f'{name} is required', {name: val})
@@ -1502,39 +1502,36 @@ class DocManager:
             raise DocServiceError('E_NOT_FOUND', f'doc not found in kb: {doc_id}', {'kb_id': kb_id, 'doc_id': doc_id})
         algo_ids = self._get_kb_algorithms(kb_id)
         id_to_meta = self._build_ng_id_to_meta(algo_ids)
-        default_algo_id = algo_ids[0] if len(algo_ids) == 1 else None
         with self._db_manager.get_session() as session:
             NgStatus = self._db_manager.get_table_orm_class(DOC_NODE_GROUP_STATUS_TABLE_INFO['name'])
             rows = session.query(NgStatus).filter(
                 NgStatus.kb_id == kb_id, NgStatus.doc_id == doc_id,
             ).order_by(NgStatus.created_at.asc()).all()
-        groups: List[str] = []
+        items = []
         seen: Set[str] = set()
         for row in rows:
             meta = id_to_meta.get(row.node_group_id, {})
             name = meta.get('name') or row.node_group_id
             if name in seen:
                 continue
-            algo_id = meta.get('algo_id') or default_algo_id
-            try:
-                resp = self._parser_client.list_doc_chunks(
-                    algo_id=algo_id,
-                    kb_id=kb_id,
-                    doc_id=doc_id,
-                    group=name,
-                    offset=0,
-                    page_size=1,
-                )
-            except Exception as e:
-                LOG.warning(f'[DocManager] Failed to check chunk existence for group {name}: {e}')
-                continue
-            if resp.code != 200:
-                continue
-            total = int((resp.data or {}).get('total') or 0)
-            if total <= 0:
-                continue
             seen.add(name)
-            groups.append(name)
+            items.append({
+                'node_group_id': row.node_group_id,
+                'name': name,
+                'display_name': meta.get('display_name') or name,
+                'status': row.status,
+                'error_msg': row.error_msg,
+                'updated_at': row.updated_at.isoformat() if row.updated_at else None,
+            })
+        return {'items': items}
+
+    def list_doc_node_groups(self, kb_id: str, doc_id: str):
+        result = self.get_doc_ng_status(kb_id, doc_id)
+        groups = [
+            item['name']
+            for item in result['items']
+            if item['status'] == NodeGroupParseStatus.SUCCESS.value
+        ]
         return {'groups': groups}
 
     def list_chunks(self, kb_id: str, doc_id: str, group: str, algo_id: Optional[str] = None,

--- a/lazyllm/tools/rag/doc_service/doc_server.py
+++ b/lazyllm/tools/rag/doc_service/doc_server.py
@@ -832,6 +832,11 @@ class DocServer(ModuleBase):
             self._lazy_init()
             return self._run(lambda: self._manager.list_doc_node_groups(kb_id=kb_id, doc_id=doc_id))
 
+        @app.get('/v1/docs/{doc_id}/ng-status')
+        def get_doc_ng_status(self, doc_id: str, kb_id: str):
+            self._lazy_init()
+            return self._run(lambda: self._manager.get_doc_ng_status(kb_id=kb_id, doc_id=doc_id))
+
         @app.get('/v1/docs/{doc_id}')
         def get_doc(self, doc_id: str):
             self._lazy_init()
@@ -1305,6 +1310,9 @@ class DocServer(ModuleBase):
 
     def list_doc_node_groups(self, kb_id: str, doc_id: str):
         return self._dispatch('list_doc_node_groups', kb_id=kb_id, doc_id=doc_id)
+
+    def get_doc_ng_status(self, kb_id: str, doc_id: str):
+        return self._dispatch('get_doc_ng_status', kb_id=kb_id, doc_id=doc_id)
 
     def list_algorithms(self):
         return self._dispatch('list_algorithms_impl')


### PR DESCRIPTION
接口整理（cursor）：

高优先级 — 直接重复，可以删

GET /v1/algo/list 和 GET /v1/algorithms 做完全相同的事，只是返回格式不同（裸 list vs {items:[]}）。根源是 DocManager.list_algorithms_compat() 这个方法不应存在于 Manager 层——格式转换应该在 HTTP handler 里做。建议废弃 /v1/algorithms，删掉 list_algorithms_compat。

POST /v1/tasks/info 和 GET /v1/tasks/{task_id} 功能完全相同。DocServer 外层还有两个方法 get_task 和 get_task_info 都落到同一个 manager.get_task。建议废弃 POST 接口，删掉 get_task_info / get_task_info_impl。

中优先级 — 结构性冗余

_impl 后缀方法系列（list_algorithms_impl、get_algorithm_info_impl、get_tasks_batch_impl、get_task_info_impl、delete_kbs_impl）是结构性的重复——因为 HTTP handler 签名接收 Request 对象，proxy dispatch 无法复用，所以造了一批平行的 _impl 方法。这是设计上的系统性问题，短期可以接受，但长期维护成本高。

GET /v1/docs/{doc_id}/ng-status 和 GET /v1/docs/node_groups 高度重叠——前者是后者的超集，后者完全可以用前者加 ?status=SUCCESS 参数代替，或者干脆在业务层过滤。不过考虑到 node_groups 接口有现有调用方，建议暂时保留，但新代码不应再依赖它。

POST /v1/kbs/{kb_id}/update 语义混乱，应为 PATCH /v1/kbs/{kb_id}。

低优先级 — 清理

废弃的 algo_id 参数散落在 list_docs、upload 等多处，handler 里是 LOG.warning('deprecated and ignored')，建议用 Pydantic deprecated=True 统一标注，避免新调用方误用。

遗留的 5 个接口（/upload_files、/add_files_to_group、/list_kb_groups 等）确认调用方已迁移后可以删。