### PR TITLE
feat(OnlineChatModule): Supports setting the `timeout` parameter for `onelinechatmodule`  

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -25,7 +25,8 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
 
     def __init__(self, api_key: Union[str, List[str]], base_url: str, model_name: str,
                  stream: Union[bool, Dict[str, str]], return_trace: bool = False, skip_auth: bool = False,
-                 static_params: Optional[StaticParams] = None, type: Optional[str] = None, **kwargs):
+                 static_params: Optional[StaticParams] = None, type: Optional[str] = None,
+                 timeout: Optional[Union[int, Tuple[int, int]]] = 180, **kwargs):
         if any([model_name.startswith(prefix) for prefix in self.VLM_MODEL_PREFIX]):
             if type is None: type = LLMType.VLM
             else: assert type == LLMType.VLM, f'model_name {model_name} is a VLM model, but type is {type}'
@@ -37,6 +38,7 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
         self._is_trained = False
         self._model_optional_params = {}
         self._vlm_force_format_input_with_files = False
+        self._timeout = timeout
 
     def prompt(self, prompt: Optional[str] = None, history: Optional[List[List[str]]] = None):
         super().prompt('' if prompt is None else prompt, history=history)
@@ -138,8 +140,8 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
             return ''
 
     def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
-                      proxies: Optional[Dict]) -> List[Dict[str, Any]]:
-        request_timeout = self._request_timeout(data)
+                      proxies: Optional[Dict], request_timeout: Optional[Union[float, Tuple[float, float]]]
+                      ) -> List[Dict[str, Any]]:
         with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
                            proxies=proxies, timeout=request_timeout) as r:
             if r.status_code != 200:
@@ -155,8 +157,12 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
                 )))
         return msg_json
 
-    def _request_timeout(self, data: Dict[str, Any]) -> Optional[Union[float, Tuple[float, float]]]:
+    def _request_timeout(self, data: Dict[str, Any],
+                         default_timeout: Optional[Union[int, float, Tuple[int, int], Tuple[float, float]]] = None,
+                         ) -> Optional[Union[float, Tuple[float, float]]]:
         raw_timeout = data.get('timeout')
+        if raw_timeout is None:
+            raw_timeout = default_timeout
         if raw_timeout is None:
             return None
         try:
@@ -170,7 +176,8 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
             return None
 
     def _forward_with_retry(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
-                            proxies: Optional[Dict], max_retries: int) -> List[Dict[str, Any]]:
+                            proxies: Optional[Dict], max_retries: int,
+                            request_timeout: Optional[Union[float, Tuple[float, float]]]) -> List[Dict[str, Any]]:
         _RETRY_DELAYS = [3, 10, 30]
         _CONTINUATION_PROMPT = (
             'Your previous response was interrupted. '
@@ -201,7 +208,8 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
                 partial_content = ''
             try:
                 msg_json = self._forward_impl(data, runtime_url=runtime_url,
-                                              stream_output=stream_output, proxies=proxies)
+                                              stream_output=stream_output, proxies=proxies,
+                                              request_timeout=request_timeout)
             except (requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError):
                 if attempt < max_retries - 1:
                     partial_content = self._extract_partial_content(msg_json)
@@ -221,6 +229,7 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
     def forward(self, __input: Union[Dict, str] = None, *, llm_chat_history: List[List[str]] = None,
                 tools: List[Dict[str, Any]] = None, stream_output: bool = None, stream: bool = None,
                 lazyllm_files=None, url: str = None, model: str = None, max_retries: int = 3, **kw):
+        request_timeout = self._request_timeout(kw, default_timeout=self._timeout)
         stream_output = stream_output if stream_output is not None else stream
         stream_output = stream_output if stream_output is not None else self._stream
         __input, files = self._get_files(__input, lazyllm_files)
@@ -247,7 +256,8 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
         data = self._prepare_request_data(data)
         proxies = {'http': None, 'https': None} if self.NO_PROXY else None
         msg_json = self._forward_with_retry(data, runtime_url=runtime_url, stream_output=stream_output,
-                                            proxies=proxies, max_retries=max_retries)
+                                            proxies=proxies, max_retries=max_retries,
+                                            request_timeout=request_timeout)
 
         usage = {'prompt_tokens': -1, 'completion_tokens': -1}
         if len(msg_json) > 0 and 'usage' in msg_json[-1] and isinstance(msg_json[-1]['usage'], dict):

--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -140,7 +140,6 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
     def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
                       proxies: Optional[Dict]) -> List[Dict[str, Any]]:
         request_timeout = self._request_timeout(data)
-        data.pop('timeout', None)
         with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
                            proxies=proxies, timeout=request_timeout) as r:
             if r.status_code != 200:

--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -139,8 +139,10 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
 
     def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
                       proxies: Optional[Dict]) -> List[Dict[str, Any]]:
+        request_timeout = self._request_timeout(data)
+        data.pop('timeout', None)
         with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
-                           proxies=proxies) as r:
+                           proxies=proxies, timeout=request_timeout) as r:
             if r.status_code != 200:
                 err_msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)]) \
                     if stream_output else r.text
@@ -153,6 +155,20 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
                     else [self._str_to_json(r.text, stream_output)]
                 )))
         return msg_json
+
+    def _request_timeout(self, data: Dict[str, Any]) -> Optional[Union[float, Tuple[float, float]]]:
+        raw_timeout = data.get('timeout')
+        if raw_timeout is None:
+            return None
+        try:
+            if isinstance(raw_timeout, (tuple, list)):
+                if len(raw_timeout) != 2:
+                    raise ValueError('timeout tuple/list must contain exactly two values')
+                return float(raw_timeout[0]), float(raw_timeout[1])
+            return float(raw_timeout)
+        except (TypeError, ValueError) as exc:
+            lazyllm.LOG.warning(f'Invalid request timeout {raw_timeout}: {exc}; using default None.')
+            return None
 
     def _forward_with_retry(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
                             proxies: Optional[Dict], max_retries: int) -> List[Dict[str, Any]]:

--- a/lazyllm/module/llms/onlinemodule/chat.py
+++ b/lazyllm/module/llms/onlinemodule/chat.py
@@ -1,6 +1,6 @@
 import lazyllm
 from lazyllm.components.utils.downloader.model_downloader import LLMType
-from typing import Any, ContextManager, List, Optional, Union
+from typing import Any, ContextManager, List, Optional, Tuple, Union
 from lazyllm.common.bind import _MetaBind
 
 from ...servermodule import LLMBase, StaticParams
@@ -35,7 +35,8 @@ class OnlineChatModule(_DynamicSourceRouterMixin, LLMBase, metaclass=_ChatModule
     def __new__(cls, model: str = None, source: str = None, url: str = None, stream: bool = True,
                 return_trace: bool = False, skip_auth: bool = False, type: Optional[str] = None,
                 api_key: str = None, static_params: Optional[StaticParams] = None, id: Optional[str] = None,
-                name: Optional[str] = None, group_id: Optional[str] = None, dynamic_auth: bool = False, **kwargs):
+                name: Optional[str] = None, group_id: Optional[str] = None, dynamic_auth: bool = False,
+                timeout: Optional[Union[int, Tuple[int, int]]] = 180, **kwargs):
         model, source, url, kwargs = resolve_online_params(
             model, source, url, kwargs, url_aliases='base_url', source_registry=lazyllm.online.chat)
         if cls._should_use_dynamic(source, dynamic_auth, skip_auth):
@@ -51,12 +52,13 @@ class OnlineChatModule(_DynamicSourceRouterMixin, LLMBase, metaclass=_ChatModule
         type = cls._resolve_type_name(type, model, options=[LLMType.LLM, LLMType.CHAT, LLMType.VLM])
         return getattr(lazyllm.online.chat, source)(
             base_url=url, model=model, stream=stream, return_trace=return_trace,
-            api_key=api_key, skip_auth=skip_auth, type=type, **kwargs)
+            api_key=api_key, skip_auth=skip_auth, type=type, timeout=timeout, **kwargs)
 
     def __init__(self, model: str = None, source: str = None, url: str = None, stream: bool = True,
                  return_trace: bool = False, skip_auth: bool = False, type: Optional[str] = None,
                  api_key: str = None, static_params: Optional[StaticParams] = None, id: Optional[str] = None,
-                 name: Optional[str] = None, group_id: Optional[str] = None, dynamic_auth: bool = False, **kwargs):
+                 name: Optional[str] = None, group_id: Optional[str] = None, dynamic_auth: bool = False,
+                 timeout: Optional[Union[int, Tuple[int, int]]] = 180, **kwargs):
         model, source, url, kwargs = resolve_online_params(
             model, source, url, kwargs, url_aliases='base_url', source_registry=lazyllm.online.chat)
         normalized_type = self._resolve_type_name(type, model, options=[LLMType.LLM, LLMType.CHAT, LLMType.VLM])
@@ -66,13 +68,14 @@ class OnlineChatModule(_DynamicSourceRouterMixin, LLMBase, metaclass=_ChatModule
         self._base_url = url
         self._model_name = model
         self._skip_auth = skip_auth
+        self._timeout = timeout
         self._init_dynamic_auth(api_key, dynamic_auth)
 
     def _build_supplier(self, source: str, skip_auth: bool):
         params = {
             'base_url': self._base_url, 'model': self._model_name, 'stream': self._stream, 'type': self._type,
             'static_params': self._static_params, 'skip_auth': skip_auth, 'api_key': self._api_key,
-            'return_trace': self._return_trace, **self._kwargs}
+            'return_trace': self._return_trace, 'timeout': self._timeout, **self._kwargs}
         supplier = getattr(lazyllm.online.chat, source)(**params)
         supplier.prompt(getattr(self, '_prompt', None))
         supplier.formatter(getattr(self, '_formatter', None))


### PR DESCRIPTION
# 🎯 问题背景 / Problem Context

修复 OnlineChatModule 未将 `timeout` 参数透传到 `requests.post` 的问题。

本次改动同时为 `OnlineChatModule` 增加初始化级别的 `timeout` 配置，默认值为 `180`。
调用时如果显式传入 `timeout`，优先使用调用参数；否则使用初始化时指定的 timeout。

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [x] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

# ⚡ 更新后的用法示例 / Usage After Update

```python
# 使用默认 HTTP request timeout: 180s
llm = lazyllm.OnlineChatModule(source='openai', model='xxx')

# 初始化时指定默认 timeout
llm = lazyllm.OnlineChatModule(source='openai', model='xxx', timeout=60)
llm(prompt)

# 调用时指定 timeout，优先级高于初始化 timeout
llm(prompt, timeout=180)

# 支持 requests 原生二元 timeout: (connect_timeout, read_timeout)
llm(prompt, timeout=(10, 180))
```

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

