### PR TITLE
bug fix: Set online mineru bbox to [0, 0, 0, 0]

### DIFF
--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -38,6 +38,8 @@ _IMAGE_REF_PATTERN = re.compile(
     r'images/[^\s\)"\'\]<]+\.(?:jpg|jpeg|png|gif|bmp|webp|tiff|tif)',
     re.IGNORECASE,
 )
+# Official MinerU API returns unreliable bbox values; keep page_idx only.
+_DEFAULT_BBOX = [0, 0, 0, 0]
 
 
 class MineruPDFReader(_OcrReaderBase):
@@ -443,7 +445,9 @@ class MineruPDFReader(_OcrReaderBase):
             LOG.warning(f'[MineruPDFReader] content item missing page_idx field, skipped: {item}')
             return None
         bbox = item.get('bbox')
-        if bbox is None:
+        if self._variant == OcrServiceVariant.ONLINE:
+            bbox = _DEFAULT_BBOX
+        elif bbox is None:
             LOG.warning(f'[MineruPDFReader] content item missing bbox field, skipped: {item}')
             return None
         page = PageRef(index=page_idx, bbox=BBox.from_list(bbox))

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -430,7 +430,7 @@ class MineruPDFReader(_OcrReaderBase):
             return result
         raise TypeError(f'Not supported type: {type(content)}.')
 
-    def _adapt_one(self, item: dict) -> Optional[Block]:
+    def _adapt_one(self, item: dict) -> Optional[Block]:  # noqa: C901
         ty = item.get('type')
         if ty is None:
             LOG.warning(f'[MineruPDFReader] content item missing type field, skipped: {item}')

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -39,7 +39,7 @@ _IMAGE_REF_PATTERN = re.compile(
     re.IGNORECASE,
 )
 # Official MinerU API returns unreliable bbox values; keep page_idx only.
-_DEFAULT_BBOX = [0, 0, 0, 0]
+DEFAULT_BBOX = [0, 0, 0, 0]
 
 
 class MineruPDFReader(_OcrReaderBase):
@@ -446,7 +446,7 @@ class MineruPDFReader(_OcrReaderBase):
             return None
         bbox = item.get('bbox')
         if self._variant == OcrServiceVariant.ONLINE:
-            bbox = _DEFAULT_BBOX
+            bbox = DEFAULT_BBOX
         elif bbox is None:
             LOG.warning(f'[MineruPDFReader] content item missing bbox field, skipped: {item}')
             return None

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_ppt_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_ppt_reader.py
@@ -3,12 +3,10 @@ from typing import List, Optional, Tuple
 
 from typing_extensions import override
 
-from .mineru_pdf_reader import MineruPDFReader
+from .mineru_pdf_reader import MineruPDFReader, _DEFAULT_BBOX
 from .ocr_ir import Block
 
 _PPT_SUFFIXES = frozenset({'.ppt', '.pptx', '.pptm'})
-# Mineru online API does not return bbox for office files.
-_DEFAULT_BBOX = [0, 0, 0, 0]
 
 
 class MineruPPTReader(MineruPDFReader):

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_ppt_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_ppt_reader.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Tuple
 
 from typing_extensions import override
 
-from .mineru_pdf_reader import MineruPDFReader, _DEFAULT_BBOX
+from .mineru_pdf_reader import MineruPDFReader, DEFAULT_BBOX
 from .ocr_ir import Block
 
 _PPT_SUFFIXES = frozenset({'.ppt', '.pptx', '.pptm'})
@@ -28,5 +28,5 @@ class MineruPPTReader(MineruPDFReader):
     @override
     def _adapt_one(self, item: dict) -> Optional[Block]:
         if item.get('bbox') is None:
-            item = {**item, 'bbox': _DEFAULT_BBOX}
+            item = {**item, 'bbox': DEFAULT_BBOX}
         return super()._adapt_one(item)

--- a/tests/basic_tests/RAG/test_dynamicpdfreader.py
+++ b/tests/basic_tests/RAG/test_dynamicpdfreader.py
@@ -214,6 +214,25 @@ class TestDynamicPDFReader:
         assert isinstance(image_block, FigureBlock)
         assert image_block.page.bbox.to_list() == [0, 0, 0, 0]
 
-    def test_pdf_missing_bbox_still_skipped(self):
+    def test_pdf_official_missing_bbox_uses_zero_bbox(self):
         reader = MineruPDFReader(url='https://mineru.net')
+        block = reader._adapt_one({'type': 'text', 'text': 'hello', 'page_idx': 0})
+        assert isinstance(block, ParagraphBlock)
+        assert block.page.index == 0
+        assert block.page.bbox.to_list() == [0, 0, 0, 0]
+
+    def test_pdf_official_ignores_returned_bbox(self):
+        reader = MineruPDFReader(url='https://mineru.net')
+        block = reader._adapt_one({
+            'type': 'text',
+            'text': 'hello',
+            'page_idx': 2,
+            'bbox': [10.0, 20.0, 100.0, 50.0],
+        })
+        assert isinstance(block, ParagraphBlock)
+        assert block.page.index == 2
+        assert block.page.bbox.to_list() == [0, 0, 0, 0]
+
+    def test_pdf_offline_missing_bbox_still_skipped(self):
+        reader = MineruPDFReader(url='http://local-mineru:8000/api/v1/pdf_parse')
         assert reader._adapt_one({'type': 'text', 'text': 'hello', 'page_idx': 0}) is None


### PR DESCRIPTION
判定为官方api时 将bbox设置为0,0,0,0

修改前：bbox 为官方给出的 为归一化的四个数字

<img width="729" height="204" alt="image" src="https://github.com/user-attachments/assets/2c003ddf-fe45-4292-a647-2f5efb9c53b5" />


修改后: bbox全部被设置为 0

<img width="739" height="68" alt="image" src="https://github.com/user-attachments/assets/c2bec60c-e123-4c8d-8896-e74f6648fb33" />

=======================
跳转测试：（没有多余的 bbox， 会跳转到页码上， 并且长文档 跳转没问题）

<img width="1663" height="909" alt="image" src="https://github.com/user-attachments/assets/8766b526-bdeb-4d9f-82c0-e184d6334b00" />
