### PR TITLE
fix: use _add_clause helper for parent and number filter in opensearch_store

### DIFF
--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -364,9 +364,9 @@ class OpenSearchStore(LazyLLMStoreBase):
             val = criteria.pop(RAG_KB_ID)
             _add_clause('kb_id', val)
         if 'parent' in criteria:
-            must_clauses.append({'term': {'parent': criteria.pop('parent')}})
+            _add_clause('parent', criteria.pop('parent'))
         if 'number' in criteria:
-            must_clauses.append({'term': {'number': criteria.pop('number')}})
+            _add_clause('number', criteria.pop('number'))
 
         for k, v in criteria.items():
             field_key = k


### PR DESCRIPTION
## 改动

- 在 opensearch_store 中使用 `_add_clause` helper 处理 parent 和 number 过滤器，统一查询构建逻辑

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)