### PR TITLE
fix(tools): remove active tool allowlist guard

### DIFF
--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -547,13 +547,6 @@ def _load_tool_by_name(name: str) -> 'ModuleTool':
     return target()
 
 
-# Register the per-session active-tool allowlist in the lazyllm session config system.
-# Upper layers write via: lazyllm.globals.config['active_tool_names'] = <set>
-# _safe_call reads via the same key.  Using globals.config keeps the framework
-# decoupled from hard-coded key strings in business code.
-lazyllm.globals.config.add('active_tool_names', set, None)
-
-
 class ToolManager(ModuleBase):
 
     def __init__(self, tools: List[Union[str, Callable]], return_trace: bool = False, sandbox=None):
@@ -707,13 +700,6 @@ class ToolManager(ModuleBase):
                 def _safe_call(args, _tool=tool):
                     tool_name = _tool.name
                     try:
-                        # Guard: raise PermissionError if tool is not active in this session.
-                        active_tool_names = lazyllm.globals.config['active_tool_names']
-                        if isinstance(active_tool_names, set) and tool_name not in active_tool_names:
-                            raise PermissionError(
-                                f'{tool_name} is not registered or active in current session. '
-                                'Please enable this tool in model/tool config, then retry.'
-                            )
                         return {'ok': True, 'value': _tool(args)}
                     except Exception as e:
                         lazyllm.LOG.warning(f'[ToolCall] tool={tool_name!r} raised: {type(e).__name__}: {e}')


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Remove the per-session `active_tool_names` guard from `ToolManager._safe_call`.
- Keep missing-tool validation in `ToolManager._parse_tool_call`, which returns the existing
  `Tool [x] is not available. Please choose from the available tools.` error.

---

# 🎯 问题背景 / Problem Context

- The extra `active_tool_names` allowlist can reject tools that are actually registered in the
  current `ToolManager`, especially dynamically expanded or gateway-derived tools.
- `ToolManager` already owns the authoritative callable registry through `_tool_call`, so the
  second session-global check is redundant and can produce false negatives.

# 🔍 相关 Issue / Related Issue

* None

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `python -m py_compile lazyllm/tools/agent/toolsManager.py`
2. `make lint-only-diff`

---

# 📷 Demo (Optional)

* None

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
manager = ToolManager([echo], sandbox=None)
manager.forward({'function': {'name': 'echo', 'arguments': '{"text": "hello"}'}})
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
active_tool_names = lazyllm.globals.config['active_tool_names']
if isinstance(active_tool_names, set) and tool_name not in active_tool_names:
    raise PermissionError(...)
```

## After

```python
return {'ok': True, 'value': _tool(args)}
```

# ⚠️ 注意事项 / Additional Notes

* Tools that are not present in `ToolManager._tool_call` still return the existing not-available
  error before execution.
* No base-class abstraction is needed because this change removes redundant global-state behavior
  rather than introducing a reusable workflow.

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
排查工具已经注册但报 “is not registered or active in current session” 的原因，
并整理去除 ToolManager active_tool_names 二次检查的完善方案。
```

## 一开始制定了什么方案

Initially considered mapping gateway and expanded tool names to permission scopes, but that would
add another permission model on top of the actual `ToolManager` registry.

## 方案实施后存在什么问题

The mapping approach still had edge cases for dynamic tools such as `get_skill` and lazy group
expansion, where visible names and executable names can differ over time.

## 我（用户）发现了哪些问题

The user pointed out that `active_tool_names` should not duplicate `ToolManager._tool_call`, and that
missing tools already have a clear not-available path.

## 对这些问题优化后相比于之前有哪些优势

The final change removes the redundant global allowlist and keeps a single source of truth:
`ToolManager._tool_call`. Registered tools execute, while unregistered tools are rejected by the
existing missing-tool branch.

## 哪些可以沉淀为自己后续的编码规范

Avoid duplicating runtime authorization state when the execution registry already defines what is
callable. Prefer one authoritative source of truth for dynamic tool availability.
