### PR TITLE
fix: reduce embedding num_worker default to avoid rate limiting

### DIFF
--- a/lazyllm/module/llms/onlinemodule/embedding.py
+++ b/lazyllm/module/llms/onlinemodule/embedding.py
@@ -138,6 +138,18 @@ class OnlineEmbeddingModule(_DynamicSourceRouterMixin, metaclass=__EmbedModuleMe
         self._batch_size = batch_size
         self._init_dynamic_auth(api_key, dynamic_auth)
 
+    # Expose batch_size on the dynamic router (which subclasses ModuleBase, not
+    # OnlineEmbeddingModuleBase). Without it, parallel_do_embedding's _check_batch
+    # cannot detect batch capability and falls back to one concurrent request per
+    # node, flooding the provider and triggering rate limits.
+    @property
+    def batch_size(self):
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, value: int):
+        self._batch_size = value
+
     def _build_supplier(self, source: str, skip_auth: bool):
         params = {'embed_url': self._embed_url, 'embed_model_name': self._embed_model_name,
                   'return_trace': self._return_trace, 'batch_size': self._batch_size,


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

Add batch_size for Dynamic-OnlineEmbding

---

# 🎯 问题背景 / Problem Context

OnlineEmbeddingModule(source='dynamic') routes through _DynamicSourceRouterMixin → ModuleBase, which does not expose a batch_size attribute. _check_batch() calls getattr(router, 'batch_size', None), which hits ModuleBase.__getattr__ (only handles builder_keys), raises AttributeError, and is swallowed — returning None and disabling the batch path.

This forces per-node embedding via ThreadPoolExecutor(max_workers=32): each node fires a separate API call, up to 32 concurrent. Even a small ~3000-char txt, split across multiple node groups (FineChunk/MediumChunk/CoarseChunk etc.), saturates the rate limit immediately.

---

# ✅ 变更类型 / Type of Change

* [X] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---


# 📷 Demo (Optional)

<img width="1644" height="413" alt="image" src="https://github.com/user-attachments/assets/94600cf9-48af-4e30-aa3a-d5ef1a315d13" />

---



# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [X] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [X] Cursor
- [ ] CodeX
- [X] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：
