### PR TITLE
online mineru skip ssl

### DIFF
--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -34,6 +34,10 @@ lazyllm.config.add(
     'mineru_backend', str, 'hybrid-auto-engine', 'MINERU_BACKEND',
     description='The MinerU backend used by local MinerU service.',
 )
+lazyllm.config.add(
+    'mineru_ssl_verify', bool, True, 'MINERU_SSL_VERIFY',
+    description='Verify SSL for official MinerU online API. Set false when mineru.net certificate is mismatched.',
+)
 _IMAGE_REF_PATTERN = re.compile(
     r'images/[^\s\)"\'\]<]+\.(?:jpg|jpeg|png|gif|bmp|webp|tiff|tif)',
     re.IGNORECASE,
@@ -79,6 +83,18 @@ class MineruPDFReader(_OcrReaderBase):
         self._variant = resolve_ocr_variant('mineru', self._url)
         self._offline_mode = self._variant == OcrServiceVariant.OFFLINE
         self._upload_mode = upload_mode if upload_mode is not None else self._offline_mode
+        if self._variant == OcrServiceVariant.ONLINE and not lazyllm.config['mineru_ssl_verify']:
+            LOG.warning(
+                '[MineruPDFReader] SSL verification disabled for official MinerU API; '
+                'set MINERU_SSL_VERIFY=true after mineru.net certificate is fixed.'
+            )
+
+    def _online_request_kwargs(self) -> Dict:
+        return {'verify': lazyllm.config['mineru_ssl_verify']}
+
+    def _http_execute(self, method: str, url: str, **kwargs):
+        kwargs.setdefault('verify', lazyllm.config['mineru_ssl_verify'])
+        return super()._http_execute(method, url, **kwargs)
 
     @property
     def appendix_hash_key(self):
@@ -346,7 +362,8 @@ class MineruPDFReader(_OcrReaderBase):
         # Step 2: Upload file to OSS
         _t2 = time.time()
         with open(file_path, 'rb') as f:
-            upload_resp = requests.put(file_url, data=f, timeout=self._timeout or 300)
+            upload_resp = requests.put(
+                file_url, data=f, timeout=self._timeout or 300, **self._online_request_kwargs())
             upload_resp.raise_for_status()
         _t_upload = time.time() - _t2
         LOG.info(f'[BENCHMARK] file={fname} phase=upload elapsed={_t_upload:.3f}s')
@@ -367,7 +384,8 @@ class MineruPDFReader(_OcrReaderBase):
                 state = extract_result[0].get('state')
                 if state == 'done':
                     full_zip_url = extract_result[0].get('full_zip_url')
-                    zip_resp = requests.get(full_zip_url, timeout=self._timeout or 120)
+                    zip_resp = requests.get(
+                        full_zip_url, timeout=self._timeout or 120, **self._online_request_kwargs())
                     zip_resp.raise_for_status()
                     _t_wait = time.time() - _t3
                     LOG.info(f'[BENCHMARK] file={fname} phase=wait elapsed={_t_wait:.3f}s')

--- a/tests/basic_tests/RAG/test_dynamicpdfreader.py
+++ b/tests/basic_tests/RAG/test_dynamicpdfreader.py
@@ -259,3 +259,8 @@ class TestDynamicPDFReader:
     def test_pdf_offline_missing_bbox_still_skipped(self):
         reader = MineruPDFReader(url='http://local-mineru:8000/api/v1/pdf_parse')
         assert reader._adapt_one({'type': 'text', 'text': 'hello', 'page_idx': 0}) is None
+
+    def test_online_ssl_verify_respects_config(self, monkeypatch):
+        monkeypatch.setenv('LAZYLLM_MINERU_SSL_VERIFY', 'false')
+        reader = MineruPDFReader(url='https://mineru.net')
+        assert reader._online_request_kwargs() == {'verify': False}


### PR DESCRIPTION
通过变量 LAZYLLM_MINERU_SSL_VERIFY 跳过 mineru 官方的 ssl 检测

<img width="2514" height="292" alt="image" src="https://github.com/user-attachments/assets/fc536850-d956-407d-89ad-403a1cd68c68" />

