### PR TITLE
fix(retriever): Preserve child retrieval scores during target parent aggregation

### DIFF
--- a/lazyllm/tools/rag/doc_impl.py
+++ b/lazyllm/tools/rag/doc_impl.py
@@ -531,28 +531,46 @@ class DocImpl:
         return result
 
     def _find_parent_with_node(self, nodes: list[DocNode], group: str):
-        result = set()
+        result = {}
+        score_by_parent = {}
 
-        def recurse_parents(node: DocNode, visited: Set[DocNode]) -> None:
+        def update_parent(parent: DocNode, score) -> None:
+            uid = parent.uid
+            result[uid] = parent
+            if score is not None:
+                score_by_parent[uid] = max(score_by_parent.get(uid, score), score)
+
+        def recurse_parents(node: DocNode, score) -> None:
             if node.parent:
                 if node.parent._group == group:
-                    visited.add(node.parent)
+                    update_parent(node.parent, score)
                 else:
-                    recurse_parents(node.parent, visited)
+                    recurse_parents(node.parent, score)
 
         for node in nodes:
-            recurse_parents(node, result)
-        return list(result)
+            recurse_parents(node, node.similarity_score)
+        for uid, parent in result.items():
+            parent.similarity_score = score_by_parent.get(uid)
+        return list(result.values())
 
     def _find_parent_with_uid(self, nodes: list[DocNode], group: str):
         cur_group = nodes[0]._group
         cur_nodes = nodes
         while cur_group != group and cur_nodes[0].parent:
             name = self.node_groups[cur_group]['parent']
-            parent_uids = {n.parent for n in cur_nodes}
+            score_by_parent = {}
+            for n in cur_nodes:
+                if n.similarity_score is not None:
+                    score_by_parent[n.parent] = max(
+                        score_by_parent.get(n.parent, n.similarity_score),
+                        n.similarity_score
+                    )
+            parent_uids = set(n.parent for n in cur_nodes)
             kb_id = cur_nodes[0].global_metadata.get(RAG_KB_ID)
             parents = self._store.get_nodes(group=name, kb_id=kb_id, uids=list(parent_uids), display=True)
             if not parents: break
+            for parent in parents:
+                parent.similarity_score = score_by_parent.get(parent.uid)
             cur_group = parents[0]._group
             cur_nodes = parents
         return cur_nodes if cur_group == group else []

--- a/tests/basic_tests/RAG/test_document.py
+++ b/tests/basic_tests/RAG/test_document.py
@@ -7,7 +7,7 @@ from lazyllm.tools.rag.store.store_base import LAZY_IMAGE_GROUP
 from lazyllm.tools.rag.transform import SentenceSplitter
 from lazyllm.tools.rag.store import LAZY_ROOT_NAME
 from lazyllm.tools.rag.doc_node import DocNode
-from lazyllm.tools.rag.global_metadata import RAG_DOC_PATH, RAG_DOC_ID
+from lazyllm.tools.rag.global_metadata import RAG_DOC_PATH, RAG_DOC_ID, RAG_KB_ID
 from lazyllm.tools.rag import Document, Retriever, TransformArgs, AdaptiveTransform
 import os
 import shutil
@@ -87,6 +87,41 @@ class TestDocImpl(unittest.TestCase):
         )
         node = result[0]
         assert node.text == 'dummy text'
+
+    def test_find_parent_with_node_preserves_best_child_similarity_score(self):
+        block = DocNode(uid='block-a', group='block', text='block')
+        block.similarity_score = 0.99
+        line_1 = DocNode(uid='line-1', group='line', text='line 1', parent=block)
+        line_2 = DocNode(uid='line-2', group='line', text='line 2', parent=block)
+        line_1.similarity_score = 0.91
+        line_2.similarity_score = 0.85
+
+        result = self.doc_impl.find_parent([line_1, line_2], 'block')
+
+        assert result == [block]
+        assert block.similarity_score == 0.91
+
+    def test_find_parent_with_uid_preserves_best_child_similarity_score(self):
+        block = DocNode(uid='block-a', group='block', text='block', global_metadata={RAG_KB_ID: 'kb'})
+        block.similarity_score = 0.99
+        line_1 = DocNode(uid='line-1', group='line', text='line 1', parent='block-a',
+                         global_metadata={RAG_KB_ID: 'kb'})
+        line_2 = DocNode(uid='line-2', group='line', text='line 2', parent='block-a',
+                         global_metadata={RAG_KB_ID: 'kb'})
+        line_1.similarity_score = 0.85
+        line_2.similarity_score = 0.91
+        self.doc_impl.node_groups['line'] = {'parent': 'block'}
+        self.doc_impl.node_groups['block'] = {'parent': LAZY_ROOT_NAME}
+        self.doc_impl._store = MagicMock()
+        self.doc_impl._store.get_nodes.return_value = [block]
+
+        result = self.doc_impl.find_parent([line_1, line_2], 'block')
+
+        assert result == [block]
+        assert block.similarity_score == 0.91
+        self.doc_impl._store.get_nodes.assert_called_once_with(
+            group='block', kb_id='kb', uids=['block-a'], display=True
+        )
 
     def test_add_files(self):
         assert self.doc_impl._store is None


### PR DESCRIPTION
PR for issue: https://github.com/LazyAGI/LazyMind/issues/281

修复 KB 检索中 target='block' 等子节点到父节点聚合时丢失 similarity_score 的问题。现在 line 命中映射回 block 时，会按父节点聚合子节点分数，并将最高 child similarity_score 写回 parent block，确保该 route 在后续 RRF 融合、rerank fallback、AdaptiveK 和 ContextExpansion 中保留原始检索排序信号。

<img width="2494" height="514" alt="image" src="https://github.com/user-attachments/assets/9039914a-d564-4667-bbf7-d7626f8c34c6" />
