### PR TITLE
feat(parse + chat): Normalize bbox for online mineru and paddle server. Add u1 text2image model.

### DIFF
--- a/lazyllm/docs/module.py
+++ b/lazyllm/docs/module.py
@@ -2548,6 +2548,34 @@ Args:
     secret_key (str, optional): API secret key, defaults to None.
 ''')
 
+add_chinese_doc('llms.onlinemodule.supplier.sensenova.SenseNovaText2Image', '''\
+商汤科技 SenseNova 文生图模块，继承自 LazyLLMOnlineText2ImageModuleBase。
+
+提供基于 SenseNova 的文本生成图像功能，调用 ``/v1/images/generations`` 接口根据文本描述生成图像。
+
+Args:
+    api_key (str, optional): API密钥，默认为配置中的 sensenova_api_key。
+    secret_key (str, optional): API秘密密钥，默认为配置中的 sensenova_secret_key。
+    model (str, optional): 模型名称，默认为 "sensenova-u1-fast"。
+    url (str, optional): API基础URL，默认为 "https://token.sensenova.cn/v1/"。
+    return_trace (bool, optional): 是否返回追踪信息，默认为 False。
+    **kwargs: 其他传递给父类的参数。
+''')
+
+add_english_doc('llms.onlinemodule.supplier.sensenova.SenseNovaText2Image', '''\
+SenseTime SenseNova Text-to-Image module, inherits from LazyLLMOnlineText2ImageModuleBase.
+
+Provides text-to-image generation via SenseNova's ``/v1/images/generations`` API.
+
+Args:
+    api_key (str, optional): API key, defaults to configured sensenova_api_key.
+    secret_key (str, optional): Secret key, defaults to configured sensenova_secret_key.
+    model (str, optional): Model name, defaults to "sensenova-u1-fast".
+    url (str, optional): Base API URL, defaults to "https://token.sensenova.cn/v1/".
+    return_trace (bool, optional): Whether to return trace information, defaults to False.
+    **kwargs: Additional parameters passed to the parent class.
+''')
+
 add_chinese_doc('llms.onlinemodule.supplier.doubao.DoubaoText2Image', '''\
 字节跳动豆包文生图模块，支持纯文本生成图像和图像编辑模型。
 

--- a/lazyllm/module/llms/onlinemodule/map_model_type.py
+++ b/lazyllm/module/llms/onlinemodule/map_model_type.py
@@ -80,6 +80,7 @@ MODEL_MAPPING = {
     'sensenova-audio-fusion-0603': 'tts',
     'nova-tts-1': 'tts',
     'nova-embedding-stable': 'embed',
+    'sensenova-u1-fast': 'sd',
 
     # ===== GLM =====
     'chatglm3-6b': 'llm',

--- a/lazyllm/module/llms/onlinemodule/supplier/sensenova.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/sensenova.py
@@ -9,7 +9,9 @@ import uuid
 import lazyllm
 from lazyllm import globals
 from lazyllm.thirdparty import jwt
-from ..base import OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase
+from lazyllm.components.formatter import encode_query_with_filepaths
+from lazyllm.components.utils.file_operate import bytes_to_file
+from ..base import OnlineChatModuleBase, LazyLLMOnlineEmbedModuleBase, LazyLLMOnlineText2ImageModuleBase
 from ..fileHandler import FileHandlerBase
 from ..base.utils import check_and_add_config, LAZY_API_KEY_TOKENS
 
@@ -258,3 +260,42 @@ class SenseNovaEmbed(LazyLLMOnlineEmbedModuleBase, _SenseNovaBase):
             return embeddings[0].get('embedding', [])
         else:
             return [res.get('embedding', []) for res in embeddings]
+
+
+class SenseNovaText2Image(LazyLLMOnlineText2ImageModuleBase, _SenseNovaBase):
+    MODEL_NAME = 'sensenova-u1-fast'
+
+    def _materialize_lazy_api_key(self) -> str:
+        return self._get_api_key(None, None)
+
+    def __init__(self, api_key: str = None, secret_key: str = None, model: str = None,
+                 url: Optional[str] = None, return_trace: bool = False, **kwargs):
+        url = url or 'https://token.sensenova.cn/v1/'
+        if api_key not in LAZY_API_KEY_TOKENS:
+            api_key = self._get_api_key(api_key, secret_key)
+        super().__init__(api_key=api_key, model=model or SenseNovaText2Image.MODEL_NAME,
+                         url=url, return_trace=return_trace, **kwargs)
+        self._endpoint = 'images/generations'
+
+    def _get_image_data_from_url(self, url: str, timeout: int = 30) -> bytes:
+        # SenseNova OSS may return application/octet-stream.
+        self._validate_url_security(url)
+        resp = requests.get(url, timeout=timeout, allow_redirects=True)
+        resp.raise_for_status()
+        data = resp.content
+        self._validate_image_data(data, url)
+        return data
+
+    def _forward(self, input: str = None, files: List[str] = None, size: str = '2752x1536', n: int = 1,
+                 url: str = None, model: str = None, **kwargs):
+        payload = {'model': model, 'prompt': input, 'size': size, 'n': n, **kwargs}
+        if files:
+            for i, file in enumerate(files):
+                b64, _ = self._load_images(file)[0]
+                payload['image' if i == 0 else f'image{i + 1}'] = f'data:image/png;base64,{b64}'
+        resp = requests.post(f'{(url or self._base_url)}{self._endpoint}',
+                             headers=self._header, json=payload, timeout=180)
+        resp.raise_for_status()
+        image_urls = [item['url'] for item in resp.json()['data']]
+        image_bytes = [data for _, data in self._load_images(image_urls)]
+        return encode_query_with_filepaths(None, bytes_to_file(image_bytes))

--- a/lazyllm/tools/rag/readers/ocrReader/dynamic_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/dynamic_pdf_reader.py
@@ -89,6 +89,7 @@ class DynamicPDFReader(LazyLLMReaderBase):
             kwargs.update(timeout=self._timeout, post_func=self._post_func)
             return MineruPDFReader(**kwargs)
         if reader_type == 'paddleocr':
+            kwargs.update(timeout=self._timeout, post_func=self._post_func)
             return PaddleOCRPDFReader(**kwargs)
 
         raise ValueError(f'Unsupported OCR server type: {reader_type!r}')

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -24,7 +24,7 @@ from ...doc_node import DocNode
 from .ocr_ir import (
     Block, BBox, PageRef,
     HeadingBlock, ParagraphBlock, TableBlock, FormulaBlock,
-    FigureBlock, CodeBlock, ListBlock,
+    FigureBlock, CodeBlock, ListBlock, normalize_bbox,
 )
 from .ocr_reader_base import _OcrReaderBase
 from .ocr_service import OcrServiceVariant, default_online_url, resolve_ocr_variant
@@ -42,7 +42,7 @@ _IMAGE_REF_PATTERN = re.compile(
     r'images/[^\s\)"\'\]<]+\.(?:jpg|jpeg|png|gif|bmp|webp|tiff|tif)',
     re.IGNORECASE,
 )
-# Official MinerU API returns unreliable bbox values; keep page_idx only.
+# Official MinerU content_list bbox is in OCR raster space; normalize to PDF points.
 DEFAULT_BBOX = [0, 0, 0, 0]
 
 
@@ -411,13 +411,71 @@ class MineruPDFReader(_OcrReaderBase):
             if not json_members:
                 raise ValueError('No *_content_list.json found in zip')
             content = json.loads(zf.read(json_members[0]))
+            layout = None
+            model = None
+            for member in zf.infolist():
+                name = Path(member.filename).name
+                if name == 'layout.json':
+                    layout = json.loads(zf.read(member))
+                elif name.endswith('_model.json'):
+                    model = json.loads(zf.read(member))
+            if layout is not None and model is not None:
+                content = self._normalize_online_content_bboxes(content, layout, model)
             for member in zf.infolist():
                 if not member.filename.endswith('_content_list.json'):
                     zf.extract(member, task_dir)
         return json.dumps(content), task_dir
 
+    @staticmethod
+    def _normalize_online_content_bboxes(content_list: List[dict], layout: dict,
+                                         model_pages: List) -> List[dict]:
+        '''Rewrite official content_list bboxes from OCR raster space into PDF points.
+
+        layout.json provides PDF page_size; model.json provides 0-1 normalized bboxes.
+        content_list absolute coords ≈ normalized * OCR canvas, so
+        pdf_bbox = content_bbox * page_size / canvas.
+        '''
+        page_sizes = {
+            int(p['page_idx']): p['page_size']
+            for p in (layout.get('pdf_info') or [])
+            if 'page_idx' in p and p.get('page_size')
+        }
+        if not page_sizes or not isinstance(model_pages, list):
+            return content_list
+
+        by_page: Dict[int, List[dict]] = {}
+        for item in content_list:
+            if not isinstance(item, dict) or item.get('bbox') is None:
+                continue
+            page_idx = item.get('page_idx')
+            if page_idx is None:
+                continue
+            by_page.setdefault(int(page_idx), []).append(item)
+
+        for page_idx, items in by_page.items():
+            page_size = page_sizes.get(page_idx)
+            if not page_size or page_idx >= len(model_pages):
+                continue
+            dets = model_pages[page_idx]
+            if not isinstance(dets, list) or not dets:
+                continue
+            try:
+                max_nx = max(float(d['bbox'][2]) for d in dets if isinstance(d, dict) and d.get('bbox'))
+                max_ny = max(float(d['bbox'][3]) for d in dets if isinstance(d, dict) and d.get('bbox'))
+                max_cx = max(float(it['bbox'][2]) for it in items)
+                max_cy = max(float(it['bbox'][3]) for it in items)
+            except (KeyError, TypeError, ValueError):
+                continue
+            if max_nx <= 0 or max_ny <= 0:
+                continue
+            src_size = (max_cx / max_nx, max_cy / max_ny)
+            dst_size = (float(page_size[0]), float(page_size[1]))
+            for it in items:
+                it['bbox'] = normalize_bbox(it['bbox'], src_size, dst_size)
+        return content_list
+
     @override
-    def _adapt_json_to_IR(self, raw) -> List[Block]:
+    def _adapt_json_to_IR(self, raw, file=None) -> List[Block]:
         # Online API (zip extraction) returns a list directly.
         # Local server returns {'result': [{'content_list': [...]}]}.
         if isinstance(raw, dict):
@@ -468,9 +526,7 @@ class MineruPDFReader(_OcrReaderBase):
             LOG.warning(f'[MineruPDFReader] content item missing page_idx field, skipped: {item}')
             return None
         bbox = item.get('bbox')
-        if self._variant == OcrServiceVariant.ONLINE:
-            bbox = DEFAULT_BBOX
-        elif bbox is None:
+        if bbox is None:
             LOG.warning(f'[MineruPDFReader] content item missing bbox field, skipped: {item}')
             return None
         page = PageRef(index=page_idx, bbox=BBox.from_list(bbox))

--- a/lazyllm/tools/rag/readers/ocrReader/ocr_ir.py
+++ b/lazyllm/tools/rag/readers/ocrReader/ocr_ir.py
@@ -20,6 +20,16 @@ class BBox:
         return cls(x0=float(vals[0]), y0=float(vals[1]), x1=float(vals[2]), y1=float(vals[3]))
 
 
+def normalize_bbox(bbox: List[float], src_size: Tuple[float, float],
+                   dst_size: Tuple[float, float]) -> List[float]:
+    '''Scale bbox from src page size to dst page size (typically PDF points).'''
+    sw, sh = src_size
+    dw, dh = dst_size
+    if sw <= 0 or sh <= 0:
+        return [float(v) for v in bbox]
+    return [bbox[0] * dw / sw, bbox[1] * dh / sh, bbox[2] * dw / sw, bbox[3] * dh / sh]
+
+
 @dataclass
 class PageRef:
     index: int

--- a/lazyllm/tools/rag/readers/ocrReader/ocr_reader_base.py
+++ b/lazyllm/tools/rag/readers/ocrReader/ocr_reader_base.py
@@ -10,12 +10,12 @@ from lazyllm.thirdparty import bs4, pypdf
 from lazyllm.common import AuthStrategy, BearerTokenStrategy, CredentialMixin
 from ..readerBase import _RichReader
 from ...doc_node import DocNode
-from .ocr_ir import Block, Cell
+from .ocr_ir import Block, Cell, normalize_bbox
 from .ocr_postprocessor import l1_normalize, l2_associate
 
 
 class _Adapter:
-    def _adapt_json_to_IR(self, raw: dict) -> List[Block]:
+    def _adapt_json_to_IR(self, raw: dict, file=None) -> List[Block]:
         '''Adapt raw JSON response to intermediate block representation.
 
         Subclasses implement service-specific adaptation logic directly.'''
@@ -189,11 +189,30 @@ class _OcrReaderBase(_RichReader, _Adapter, CredentialMixin):
                                    extra_info: Optional[Dict] = None) -> List[DocNode]:
         '''Parse OCR service response into DocNodes.'''
         raw = json.loads(response_text)
-        blocks = self._adapt_json_to_IR(raw)
+        blocks = self._adapt_json_to_IR(raw, file=file)
         # Post processing
         blocks = l1_normalize(blocks)
         blocks = l2_associate(blocks)
         return self._build_nodes_from_blocks(blocks, file, extra_info)
+
+    @staticmethod
+    def _pdf_page_sizes(file) -> List[Tuple[float, float]]:
+        if isinstance(file, str) and file.startswith(('http://', 'https://')):
+            return []
+        try:
+            reader = pypdf.PdfReader(str(file))
+            sizes = []
+            for page in reader.pages:
+                box = page.mediabox
+                sizes.append((float(box.width), float(box.height)))
+            return sizes
+        except Exception:
+            return []
+
+    @staticmethod
+    def _normalize_bbox(bbox: List[float], src_size: Tuple[float, float],
+                        dst_size: Tuple[float, float]) -> List[float]:
+        return normalize_bbox(bbox, src_size, dst_size)
 
     def _load_data(self, file, extra_info: Optional[Dict] = None, use_cache: bool = True,
                    **kwargs) -> List[DocNode]:

--- a/lazyllm/tools/rag/readers/ocrReader/paddleocr_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/paddleocr_pdf_reader.py
@@ -58,6 +58,8 @@ class PaddleOCRPDFReader(_OcrReaderBase):
                          dropped_types=drop_types or dropped_types or {
                              'aside_text', 'header', 'footer', 'number', 'header_image', 'seal'},
                          return_trace=return_trace,
+                         post_func=post_func,
+                         split_doc=split_doc,
                          image_cache_dir=image_cache_dir or os.path.join(
                              lazyllm.config['home'], 'paddleocr_cache'),
                          token=token,
@@ -210,32 +212,45 @@ class PaddleOCRPDFReader(_OcrReaderBase):
         return json.dumps(merged), None
 
     @override
-    def _adapt_json_to_IR(self, raw: dict) -> List[Block]:
+    def _adapt_json_to_IR(self, raw: dict, file=None) -> List[Block]:
         blocks: List[Block] = []
         image_tasks: List[tuple] = []
+        pdf_sizes = self._pdf_page_sizes(file) if file is not None else []
         for page_idx, page_data in enumerate(raw['result']['layoutParsingResults']):
             markdown_images = page_data['markdown']['images']
-            for item in page_data['prunedResult']['parsing_res_list']:
-                block = self._adapt_one(item, page_idx, markdown_images, image_tasks)
+            pruned = page_data['prunedResult']
+            ocr_w = pruned.get('width')
+            ocr_h = pruned.get('height')
+            dst_size = pdf_sizes[page_idx] if page_idx < len(pdf_sizes) else None
+            src_size = (float(ocr_w), float(ocr_h)) if ocr_w and ocr_h else None
+            for item in pruned['parsing_res_list']:
+                block = self._adapt_one(
+                    item, page_idx, markdown_images, image_tasks,
+                    src_size=src_size, dst_size=dst_size,
+                )
                 if block is not None:
                     blocks.append(block)
         self._download_images(image_tasks)
         return blocks
 
     def _adapt_one(self, item: dict, page_idx: int, markdown_images: Dict[str, str],
-                   image_tasks: List[tuple]) -> Optional[Block]:
+                   image_tasks: List[tuple], src_size=None, dst_size=None) -> Optional[Block]:
         label = item['block_label']
         if label in self._dropped_types:
             return None
 
         content = item['block_content']
-        bbox = BBox.from_list(item['block_bbox'])
-        page = PageRef(index=page_idx, bbox=bbox)
+        raw_bbox = item['block_bbox']
+        # Image key matching needs the original OCR-space bbox.
+        bbox = raw_bbox
+        if src_size and dst_size:
+            bbox = self._normalize_bbox(raw_bbox, src_size, dst_size)
+        page = PageRef(index=page_idx, bbox=BBox.from_list(bbox))
 
         if label in ('paragraph_title', 'doc_title'):
             return HeadingBlock(page=page, text=content)
         elif label == 'image':
-            img_src, img_url = self._resolve_image(item['block_bbox'], markdown_images)
+            img_src, img_url = self._resolve_image(raw_bbox, markdown_images)
             if img_src is None:
                 return None
             rel_path = Path(img_src).as_posix().removeprefix('./')

--- a/tests/basic_tests/RAG/test_dynamicpdfreader.py
+++ b/tests/basic_tests/RAG/test_dynamicpdfreader.py
@@ -65,7 +65,13 @@ class TestDynamicPDFReader:
         assert fake_reader.forward.call_count == 2
 
     def test_build_reader_uses_dynamic_auth(self):
-        reader = DynamicPDFReader(ocr_type='paddleocr', ocr_url='http://mock-paddle')
+        post_func = MagicMock()
+        reader = DynamicPDFReader(
+            ocr_type='paddleocr',
+            ocr_url='http://mock-paddle',
+            post_func=post_func,
+            timeout=3600,
+        )
         with patch(
             'lazyllm.tools.rag.readers.ocrReader.dynamic_pdf_reader.PaddleOCRPDFReader'
         ) as mock_cls:
@@ -74,6 +80,8 @@ class TestDynamicPDFReader:
             mock_cls.assert_called_once_with(
                 url='http://mock-paddle',
                 dynamic_auth=True,
+                timeout=3600,
+                post_func=post_func,
             )
 
     def test_unsupported_type_raises(self):
@@ -237,14 +245,11 @@ class TestDynamicPDFReader:
         assert isinstance(image_block, FigureBlock)
         assert image_block.page.bbox.to_list() == [0, 0, 0, 0]
 
-    def test_pdf_official_missing_bbox_uses_zero_bbox(self):
+    def test_pdf_official_missing_bbox_still_skipped(self):
         reader = MineruPDFReader(url='https://mineru.net')
-        block = reader._adapt_one({'type': 'text', 'text': 'hello', 'page_idx': 0})
-        assert isinstance(block, ParagraphBlock)
-        assert block.page.index == 0
-        assert block.page.bbox.to_list() == [0, 0, 0, 0]
+        assert reader._adapt_one({'type': 'text', 'text': 'hello', 'page_idx': 0}) is None
 
-    def test_pdf_official_ignores_returned_bbox(self):
+    def test_pdf_official_keeps_returned_bbox(self):
         reader = MineruPDFReader(url='https://mineru.net')
         block = reader._adapt_one({
             'type': 'text',
@@ -254,7 +259,24 @@ class TestDynamicPDFReader:
         })
         assert isinstance(block, ParagraphBlock)
         assert block.page.index == 2
-        assert block.page.bbox.to_list() == [0, 0, 0, 0]
+        assert block.page.bbox.to_list() == [10.0, 20.0, 100.0, 50.0]
+
+    def test_normalize_online_content_bboxes_to_pdf_space(self):
+        content = [
+            {'type': 'text', 'text': 'title', 'page_idx': 0, 'bbox': [361, 80, 636, 99]},
+            {'type': 'text', 'text': 'body', 'page_idx': 0, 'bbox': [174, 224, 825, 502]},
+        ]
+        layout = {'pdf_info': [{'page_idx': 0, 'page_size': [595, 841]}]}
+        model = [[
+            {'type': 'doc_title', 'bbox': [0.363, 0.081, 0.637, 0.101], 'content': 'title'},
+            {'type': 'text', 'bbox': [0.175, 0.225, 0.826, 0.503], 'content': 'body'},
+        ]]
+        out = MineruPDFReader._normalize_online_content_bboxes(content, layout, model)
+        # OCR canvas inferred from max extent ≈ 1000; result should be near PDF points.
+        assert out[0]['bbox'][0] == pytest.approx(215.0, abs=2.0)
+        assert out[0]['bbox'][1] == pytest.approx(67.5, abs=2.0)
+        assert out[0]['bbox'][2] == pytest.approx(379.0, abs=2.0)
+        assert out[0]['bbox'][3] == pytest.approx(83.5, abs=2.0)
 
     def test_pdf_offline_missing_bbox_still_skipped(self):
         reader = MineruPDFReader(url='http://local-mineru:8000/api/v1/pdf_parse')

--- a/tests/basic_tests/RAG/test_paddleocrpdfreader.py
+++ b/tests/basic_tests/RAG/test_paddleocrpdfreader.py
@@ -146,10 +146,15 @@ def _make_job_response(layout_parsing_results: list) -> str:
     return json.dumps({'result': {'layoutParsingResults': layout_parsing_results}})
 
 
-def _make_page_result(blocks: list, images: dict = None) -> dict:
+def _make_page_result(blocks: list, images: dict = None, width=None, height=None) -> dict:
+    pruned = {'parsing_res_list': blocks}
+    if width is not None:
+        pruned['width'] = width
+    if height is not None:
+        pruned['height'] = height
     return {
         'markdown': {'images': images or {}},
-        'prunedResult': {'parsing_res_list': blocks},
+        'prunedResult': pruned,
     }
 
 
@@ -195,6 +200,51 @@ class TestPaddleOCRPDFReaderMock:
         assert 'paragraph' in types
         assert 'figure' in types
         assert 'table' in types
+
+    def test_forward_applies_post_func(self):
+        pdf = _make_test_pdf()
+
+        def test_post_func(nodes):
+            for node in nodes:
+                node._content += '[after_process]'
+            return nodes
+
+        reader = PaddleOCRPDFReader(post_func=test_post_func)
+
+        with patch.object(reader, '_fetch_async') as mock_fetch, \
+             patch.object(PaddleOCRPDFReader, '_download_images'):
+            mock_fetch.return_value = (_make_mock_response(), None)
+            rich_nodes = reader.forward(str(pdf))
+
+        assert len(rich_nodes) == 1
+        assert isinstance(rich_nodes[0], RichDocNode)
+        for node in rich_nodes[0].nodes:
+            assert node._content.endswith('[after_process]')
+
+    def test_bbox_normalized_to_pdf_space(self):
+        pdf = _make_test_pdf()
+        # Test PDF page is 612 x 792; OCR canvas is 2x that.
+        ocr_w, ocr_h = 1224, 1584
+        raw_bbox = [431, 137, 760, 170]
+        reader = PaddleOCRPDFReader()
+        mock = _make_job_response([
+            _make_page_result(
+                [{'block_label': 'text', 'block_content': 'title', 'block_bbox': raw_bbox}],
+                width=ocr_w,
+                height=ocr_h,
+            ),
+        ])
+        with patch.object(reader, '_fetch_async') as mock_fetch, \
+             patch.object(PaddleOCRPDFReader, '_download_images'):
+            mock_fetch.return_value = (mock, None)
+            docs = reader._load_data(str(pdf))
+
+        assert len(docs) == 1
+        got = docs[0].metadata['bbox']
+        assert got[0] == pytest.approx(raw_bbox[0] * 612 / ocr_w, abs=0.5)
+        assert got[1] == pytest.approx(raw_bbox[1] * 792 / ocr_h, abs=0.5)
+        assert got[2] == pytest.approx(raw_bbox[2] * 612 / ocr_w, abs=0.5)
+        assert got[3] == pytest.approx(raw_bbox[3] * 792 / ocr_h, abs=0.5)
 
     def test_resolve_image_by_bbox(self):
         pdf = _make_test_pdf()


### PR DESCRIPTION
1. 给dynamic ocr 的paddle部分 接入post function
2. 给官方 mineru paddle的bbox返回值 加入归一化。目前lazymind端可以正常渲染。
3. 加入sensenova u1接口