### PR TITLE
fix(agent): preserve structured tool result events

### DIFF
--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -27,16 +27,20 @@ def _write_agent_data(tag: str, **kwargs):
         json.dumps(payload, ensure_ascii=False, default=str))
 
 
-def _unwrap_tool_result(result: Any) -> str:
+def _unwrap_tool_result(result: Any) -> Any:
     # Unpack structured tool results produced by ToolManager._safe_call.
-    # {'ok': True,  'value': v}  → str(v)
+    # {'ok': True,  'value': v}  → v
     # {'ok': False, 'msg':   m}  → m  (already a human-readable error string)
-    # anything else              → str(result)  (sandbox output, parse errors, etc.)
+    # anything else              → result  (sandbox output, parse errors, etc.)
     if isinstance(result, dict) and 'ok' in result:
         if result['ok']:
-            return str(result.get('value', ''))
+            return result.get('value', '')
         return str(result.get('msg', repr(result)))
-    return str(result)
+    return result
+
+
+def _stringify_tool_result(result: Any) -> str:
+    return str(_unwrap_tool_result(result))
 
 
 class LazyLLMAgentBase(ModuleBase):

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -37,12 +37,6 @@ def _unwrap_tool_result(result: Any) -> Any:
             return result.get('value', '')
         return str(result.get('msg', repr(result)))
     return result
-
-
-def _stringify_tool_result(result: Any) -> str:
-    return str(_unwrap_tool_result(result))
-
-
 class LazyLLMAgentBase(ModuleBase):
     def __init__(self, llm=None, tools: Optional[List[Union[str, Callable, Dict]]] = None,
                  max_retries: int = 5, return_trace: bool = False,

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -3,7 +3,7 @@ from lazyllm.components import ChatPrompter, FunctionCallFormatter
 from lazyllm import pipeline, loop, locals, package, FileSystemQueue, once_wrapper
 from .toolsManager import ToolManager
 from typing import List, Any, Dict, Union, Callable, Optional
-from .base import LazyLLMAgentBase, _write_agent_data, _unwrap_tool_result
+from .base import LazyLLMAgentBase, _write_agent_data, _stringify_tool_result
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.common.deprecated import deprecated
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase, create_sandbox
@@ -127,7 +127,7 @@ class FunctionCall(ModuleBase):
             tool_call_results = [
                 {
                     'role': 'tool',
-                    'content': _unwrap_tool_result(tool_call['tool_call_result']),
+                    'content': _stringify_tool_result(tool_call['tool_call_result']),
                     'tool_call_id': tool_call['id'],
                     'name': tool_call['function']['name'],
                 } for tool_call in workspace['tool_call_trace']
@@ -180,7 +180,7 @@ class FunctionCall(ModuleBase):
                         and (tc.get('function') or {}).get('name') in self._stop_tools
                     )
                     if not stop_failed:
-                        return '\n'.join(_unwrap_tool_result(r) for r in tool_calls_results)
+                        return '\n'.join(_stringify_tool_result(r) for r in tool_calls_results)
         else:
             llm_output = llm_output['content']
         return llm_output

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -3,7 +3,7 @@ from lazyllm.components import ChatPrompter, FunctionCallFormatter
 from lazyllm import pipeline, loop, locals, package, FileSystemQueue, once_wrapper
 from .toolsManager import ToolManager
 from typing import List, Any, Dict, Union, Callable, Optional
-from .base import LazyLLMAgentBase, _write_agent_data, _stringify_tool_result
+from .base import LazyLLMAgentBase, _write_agent_data, _unwrap_tool_result
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.common.deprecated import deprecated
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase, create_sandbox
@@ -127,7 +127,7 @@ class FunctionCall(ModuleBase):
             tool_call_results = [
                 {
                     'role': 'tool',
-                    'content': _stringify_tool_result(tool_call['tool_call_result']),
+                    'content': str(_unwrap_tool_result(tool_call['tool_call_result'])),
                     'tool_call_id': tool_call['id'],
                     'name': tool_call['function']['name'],
                 } for tool_call in workspace['tool_call_trace']
@@ -180,7 +180,7 @@ class FunctionCall(ModuleBase):
                         and (tc.get('function') or {}).get('name') in self._stop_tools
                     )
                     if not stop_failed:
-                        return '\n'.join(_stringify_tool_result(r) for r in tool_calls_results)
+                        return '\n'.join(str(_unwrap_tool_result(r)) for r in tool_calls_results)
         else:
             llm_output = llm_output['content']
         return llm_output

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -22,7 +22,11 @@ def add_one(value: int) -> int:
 
 
 def get_status() -> dict:
-    '''Return a structured status result.'''
+    '''Return a structured status result.
+
+    Returns:
+        dict: Structured status information.
+    '''
     return {'status': 'ok', 'content': 'Error handling reference'}
 
 

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -122,24 +122,6 @@ class TestReactAgentEvents(object):
             'status': 'ok',
             'content': 'Error handling reference',
         }
-
-    def test_react_agent_sends_structured_tool_results_to_llm_as_text(self):
-        llm = _FakeLLM([
-            {
-                'role': 'assistant',
-                'content': 'Let me read the status.',
-                'tool_calls': [{
-                    'id': 'call-status',
-                    'type': 'function',
-                    'function': {'name': 'get_status', 'arguments': '{}'},
-                }],
-            },
-            {'role': 'assistant', 'content': 'Done.'},
-        ])
-        agent = ReactAgent(llm=llm, tools=[get_status], max_retries=1, stream=True,
-                           enable_builtin_tools=False)
-
-        assert agent('read status') == 'Done.'
         tool_message = llm.inputs[1]['input'][0]
 
         assert tool_message['role'] == 'tool'

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -21,11 +21,17 @@ def add_one(value: int) -> int:
     return value + 1
 
 
+def get_status() -> dict:
+    '''Return a structured status result.'''
+    return {'status': 'ok', 'content': 'Error handling reference'}
+
+
 class _FakeLLM(object):
     def __init__(self, outputs, *, stream=False):
         self._outputs = outputs
         self._cursor = 0
         self._stream = stream
+        self.inputs = []
         self._module_id = f'fake-llm-{id(self)}'
 
     def share(self, prompt=None, format=None, stream=None, history=None, copy_static_params=False):
@@ -38,6 +44,7 @@ class _FakeLLM(object):
         return self
 
     def __call__(self, input, **kwargs):
+        self.inputs.append(input)
         output = self._outputs[self._cursor]
         self._cursor += 1
         if self._stream:
@@ -87,6 +94,56 @@ def _read_agent_events():
 
 
 class TestReactAgentEvents(object):
+    def test_react_agent_stream_preserves_structured_tool_results(self):
+        llm = _FakeLLM([
+            {
+                'role': 'assistant',
+                'content': 'Let me read the status.',
+                'tool_calls': [{
+                    'id': 'call-status',
+                    'type': 'function',
+                    'function': {'name': 'get_status', 'arguments': '{}'},
+                }],
+            },
+            {'role': 'assistant', 'content': 'Done.'},
+        ])
+        agent = ReactAgent(llm=llm, tools=[get_status], max_retries=1, stream=True,
+                           enable_builtin_tools=False)
+
+        assert agent('read status') == 'Done.'
+        events = _read_agent_events()
+        result_event = next(event for event in events if event.tag == 'tool_results')
+
+        assert result_event.tool_results[0]['result'] == {
+            'status': 'ok',
+            'content': 'Error handling reference',
+        }
+
+    def test_react_agent_sends_structured_tool_results_to_llm_as_text(self):
+        llm = _FakeLLM([
+            {
+                'role': 'assistant',
+                'content': 'Let me read the status.',
+                'tool_calls': [{
+                    'id': 'call-status',
+                    'type': 'function',
+                    'function': {'name': 'get_status', 'arguments': '{}'},
+                }],
+            },
+            {'role': 'assistant', 'content': 'Done.'},
+        ])
+        agent = ReactAgent(llm=llm, tools=[get_status], max_retries=1, stream=True,
+                           enable_builtin_tools=False)
+
+        assert agent('read status') == 'Done.'
+        tool_message = llm.inputs[1]['input'][0]
+
+        assert tool_message['role'] == 'tool'
+        assert tool_message['content'] == str({
+            'status': 'ok',
+            'content': 'Error handling reference',
+        })
+
     def test_react_agent_stream_emits_text_reasoning_and_tool_events(self):
         llm = _FakeLLM([
             {


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Preserve structured tool return values in streamed `tool_results` events.
- Convert tool results to text only when constructing messages sent back to the LLM.
- Cover both contracts through one consolidated agent-flow regression test.

---

# 🎯 问题背景 / Problem Context

- Structured dictionary results were stringified before agent events were emitted, so downstream consumers could not reliably distinguish structured success data from textual errors.

# 🔍 相关 Issue / Related Issue

* None

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `PYTHONPATH=. pytest -q tests/basic_tests/Tools/test_agent_events.py` — 4 passed.
2. `make lint-only-diff` — passed.

---

# 📷 Demo (Optional)

* Not applicable.

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
event = {
    'tag': 'tool_results',
    'tool_results': [{'result': {'status': 'ok', 'content': 'reference'}}],
}
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
result = str(tool_result)
```

## After

```python
event_result = _unwrap_tool_result(tool_result)
llm_content = str(event_result)
```

# ⚠️ 注意事项 / Additional Notes

* The dependent LazyMind PR should update its submodule pointer after this PR is merged if the final upstream commit SHA changes.

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
Preserve structured tool results in agent events while keeping LLM tool messages textual.
```

## 一开始制定了什么方案

Keep unwrapped values in the event contract and stringify only at the LLM-message boundary, with focused regression coverage.

## 方案实施后存在什么问题

The initial tests repeated the same agent execution for the event and LLM-message assertions.

## 我（用户）发现了哪些问题

The duplicate setup made the test change larger than necessary.

## 对这些问题优化后相比于之前有哪些优势

One main-flow test now verifies both contracts with less setup and lower maintenance cost.

## 哪些可以沉淀为自己后续的编码规范

Preserve typed data until a boundary explicitly requires serialization, and consolidate assertions that naturally occur in the same execution flow.
