### PR TITLE
fix relay file argument handling on Windows

### DIFF
--- a/lazyllm/common/__init__.py
+++ b/lazyllm/common/__init__.py
@@ -16,7 +16,7 @@ from .globals import (globals, locals, LazyLlmResponse, LazyLlmRequest, encode_r
                       decode_request, init_session, teardown_session, new_session, SessionConfigableBase)
 from .bind import Bind as bind, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, Placeholder
 from .queue import RecentQueue, FileSystemQueue
-from .utils import compile_func, obj2str, str2obj, str2bool, dump_obj, load_obj
+from .utils import compile_func, obj2str, str2obj, str2bool, dump_obj, dump_obj_to_file, load_obj
 from .auth import (Credential, AuthStrategy, BearerTokenStrategy,
                    ApiKeyHeaderStrategy, QueryParamStrategy,
                    KeySelectPolicy, KeyPool, KeyAuthError, AllKeysExhaustedError)
@@ -52,6 +52,7 @@ __all__ = [
     'str2obj',
     'str2bool',
     'dump_obj',
+    'dump_obj_to_file',
     'load_obj',
     'is_valid_url',
     'is_valid_path',

--- a/lazyllm/common/utils.py
+++ b/lazyllm/common/utils.py
@@ -222,5 +222,21 @@ def dump_obj(f):
     with env_helper():
         return None if f is None else base64.b64encode(cloudpickle.dumps(f)).decode('utf-8')
 
+_FILE_REF_PREFIX = '@file:'
+
+
+def dump_obj_to_file(f, path: str) -> str:
+    '''Serialize *f* with cloudpickle, write raw bytes to *path*, and return a
+    ``@file:<path>`` reference string that ``load_obj`` understands.'''
+    raw = cloudpickle.dumps(f)
+    with open(path, 'wb') as fp:
+        fp.write(raw)
+    return f'{_FILE_REF_PREFIX}{path}'
+
+
 def load_obj(f):
+    if f.startswith(_FILE_REF_PREFIX):
+        path = f[len(_FILE_REF_PREFIX):]
+        with open(path, 'rb') as fp:
+            return cloudpickle.loads(fp.read())
     return cloudpickle.loads(base64.b64decode(f.encode('utf-8')))

--- a/lazyllm/common/utils.py
+++ b/lazyllm/common/utils.py
@@ -228,7 +228,10 @@ _FILE_REF_PREFIX = '@file:'
 def dump_obj_to_file(f, path: str) -> str:
     '''Serialize *f* with cloudpickle, write raw bytes to *path*, and return a
     ``@file:<path>`` reference string that ``load_obj`` understands.'''
-    raw = cloudpickle.dumps(f)
+    # Reuse dump_obj so dynamically generated test modules are registered by
+    # value in exactly the same way as command-line payloads.
+    serialised = dump_obj(f)
+    raw = cloudpickle.dumps(None) if serialised is None else base64.b64decode(serialised.encode('utf-8'))
     with open(path, 'wb') as fp:
         fp.write(raw)
     return f'{_FILE_REF_PREFIX}{path}'
@@ -237,6 +240,12 @@ def dump_obj_to_file(f, path: str) -> str:
 def load_obj(f):
     if f.startswith(_FILE_REF_PREFIX):
         path = f[len(_FILE_REF_PREFIX):]
-        with open(path, 'rb') as fp:
-            return cloudpickle.loads(fp.read())
+        try:
+            with open(path, 'rb') as fp:
+                return cloudpickle.loads(fp.read())
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
     return cloudpickle.loads(base64.b64decode(f.encode('utf-8')))

--- a/lazyllm/components/deploy/relay/base.py
+++ b/lazyllm/components/deploy/relay/base.py
@@ -2,13 +2,21 @@ import os
 import random
 import inspect
 import sys
+import tempfile
 
 from lazyllm import launchers, LazyLLMCMD, dump_obj, config
 from ..base import LazyLLMDeployBase, verify_fastapi_func, verify_ray_func
 from ..utils import get_log_path, make_log_dir
 from typing import Optional
+import base64
 
 config.add('use_ray', bool, False, 'USE_RAY', description='Whether to use Ray for ServerModule(relay server).')
+config.add('pass_args_by_file', bool, False, 'PASS_ARGS_BY_FILE',
+           description='When True, serialised relay cmd args are always written to temp files.')
+
+# Serialised objects longer than this (bytes) are written to a temp file so the
+# OS command-line length limit is not exceeded.
+_CMD_ARG_SIZE_THRESHOLD = 65536
 
 
 class RelayServer(LazyLLMDeployBase):
@@ -18,7 +26,8 @@ class RelayServer(LazyLLMDeployBase):
 
     def __init__(self, port=None, *, func=None, pre_func=None, post_func=None, pythonpath=None,
                  log_path=None, cls=None, launcher=launchers.remote(sync=False), num_replicas: int = 1,  # noqa B008
-                 security_key: Optional[str] = None, defined_pos: Optional[str] = None):
+                 security_key: Optional[str] = None, defined_pos: Optional[str] = None,
+                 pass_args_by_file: Optional[bool] = None):
         # func must dump in __call__ to wait for dependancies.
         self._func = func
         self._pre = dump_obj(pre_func)
@@ -28,8 +37,33 @@ class RelayServer(LazyLLMDeployBase):
         self._num_replicas = num_replicas
         self._security_key = security_key
         self._defined_pos = defined_pos
+        # None means fall back to global config at call time.
+        self._pass_args_by_file = pass_args_by_file
+        self._spill_files: list = []
         super().__init__(launcher=launcher)
         self.temp_folder = make_log_dir(log_path, cls or 'relay') if log_path else None
+
+    @property
+    def _file_args_forced(self) -> bool:
+        if self._pass_args_by_file is not None:
+            return self._pass_args_by_file
+        return config['pass_args_by_file']
+
+    def _prepare_obj_arg(self, serialised: Optional[str], *, force: bool = False) -> Optional[str]:
+        '''Return *serialised* as-is when small, or spill it to a temp file and
+        return a ``@file:<path>`` reference when it exceeds the threshold.
+        Pass ``force=True`` to always write to a file regardless of size.'''
+        if serialised is None:
+            return None
+        if not force and len(serialised) <= _CMD_ARG_SIZE_THRESHOLD:
+            return serialised
+        fd, path = tempfile.mkstemp(suffix='.pkl', prefix='lazyllm_relay_')
+        os.close(fd)
+        raw = base64.b64decode(serialised.encode('utf-8'))
+        with open(path, 'wb') as fp:
+            fp.write(raw)
+        self._spill_files.append(path)
+        return f'@file:{path}'
 
     def cmd(self, func=None):
         FastapiApp.update()
@@ -39,11 +73,13 @@ class RelayServer(LazyLLMDeployBase):
 
         def impl():
             self._real_port = self._port if self._port else random.randint(30000, 40000)
-            cmd = f'{sys.executable} {run_file_path} --open_port={self._real_port} --function="{self._func}" '
+            force = self._file_args_forced
+            func_arg = self._prepare_obj_arg(self._func, force=force)
+            cmd = f'{sys.executable} {run_file_path} --open_port={self._real_port} --function="{func_arg}" '
             if self._pre:
-                cmd += f'--before_function="{self._pre}" '
+                cmd += f'--before_function="{self._prepare_obj_arg(self._pre, force=force)}" '
             if self._post:
-                cmd += f'--after_function="{self._post}" '
+                cmd += f'--after_function="{self._prepare_obj_arg(self._post, force=force)}" '
             if self._pythonpath:
                 cmd += f'--pythonpath="{self._pythonpath}" '
             if self._num_replicas > 1 and config['use_ray']:

--- a/lazyllm/components/deploy/relay/base.py
+++ b/lazyllm/components/deploy/relay/base.py
@@ -61,9 +61,8 @@ class RelayServer(LazyLLMDeployBase):
         temp_dir = os.path.abspath(config['temp_dir'])
         os.makedirs(temp_dir, exist_ok=True)
         fd, path = tempfile.mkstemp(suffix='.pkl', prefix='lazyllm_relay_', dir=temp_dir)
-        os.close(fd)
         raw = base64.b64decode(serialised.encode('utf-8'))
-        with open(path, 'wb') as fp:
+        with os.fdopen(fd, 'wb') as fp:
             fp.write(raw)
         return f'@file:{path}'
 

--- a/lazyllm/components/deploy/relay/base.py
+++ b/lazyllm/components/deploy/relay/base.py
@@ -1,6 +1,8 @@
 import os
 import random
 import inspect
+import shlex
+import subprocess
 import sys
 import tempfile
 
@@ -39,7 +41,6 @@ class RelayServer(LazyLLMDeployBase):
         self._defined_pos = defined_pos
         # None means fall back to global config at call time.
         self._pass_args_by_file = pass_args_by_file
-        self._spill_files: list = []
         super().__init__(launcher=launcher)
         self.temp_folder = make_log_dir(log_path, cls or 'relay') if log_path else None
 
@@ -57,13 +58,20 @@ class RelayServer(LazyLLMDeployBase):
             return None
         if not force and len(serialised) <= _CMD_ARG_SIZE_THRESHOLD:
             return serialised
-        fd, path = tempfile.mkstemp(suffix='.pkl', prefix='lazyllm_relay_')
+        temp_dir = os.path.abspath(config['temp_dir'])
+        os.makedirs(temp_dir, exist_ok=True)
+        fd, path = tempfile.mkstemp(suffix='.pkl', prefix='lazyllm_relay_', dir=temp_dir)
         os.close(fd)
         raw = base64.b64decode(serialised.encode('utf-8'))
         with open(path, 'wb') as fp:
             fp.write(raw)
-        self._spill_files.append(path)
         return f'@file:{path}'
+
+    @staticmethod
+    def _join_command(args) -> str:
+        if os.name == 'nt':
+            return subprocess.list2cmdline([str(arg) for arg in args])
+        return shlex.join([str(arg) for arg in args])
 
     def cmd(self, func=None):
         FastapiApp.update()
@@ -75,20 +83,32 @@ class RelayServer(LazyLLMDeployBase):
             self._real_port = self._port if self._port else random.randint(30000, 40000)
             force = self._file_args_forced
             func_arg = self._prepare_obj_arg(self._func, force=force)
-            cmd = f'{sys.executable} {run_file_path} --open_port={self._real_port} --function="{func_arg}" '
+            args = [
+                sys.executable,
+                run_file_path,
+                f'--open_port={self._real_port}',
+                f'--function={func_arg}',
+            ]
             if self._pre:
-                cmd += f'--before_function="{self._prepare_obj_arg(self._pre, force=force)}" '
+                args.append(f'--before_function={self._prepare_obj_arg(self._pre, force=force)}')
             if self._post:
-                cmd += f'--after_function="{self._prepare_obj_arg(self._post, force=force)}" '
+                args.append(f'--after_function={self._prepare_obj_arg(self._post, force=force)}')
             if self._pythonpath:
-                cmd += f'--pythonpath="{self._pythonpath}" '
+                args.append(f'--pythonpath={self._pythonpath}')
             if self._num_replicas > 1 and config['use_ray']:
-                cmd += f'--num_replicas={self._num_replicas}'
+                args.append(f'--num_replicas={self._num_replicas}')
             if self._security_key:
-                cmd += f'--security_key="{self._security_key}" '
+                args.append(f'--security_key={self._security_key}')
             if self._defined_pos:
-                cmd += '--defined_pos="{}" '.format(dump_obj(self._defined_pos.replace('"', r'\"')))
-            if self.temp_folder: cmd += f' 2>&1 | tee {get_log_path(self.temp_folder)}'
+                defined_pos = dump_obj(self._defined_pos.replace('"', r'\"'))
+                args.append(f'--defined_pos={self._prepare_obj_arg(defined_pos, force=force)}')
+            cmd = self._join_command(args)
+            if self.temp_folder:
+                log_path = get_log_path(self.temp_folder)
+                if os.name == 'nt':
+                    cmd += f' > {subprocess.list2cmdline([log_path])} 2>&1'
+                else:
+                    cmd += f' 2>&1 | tee {shlex.quote(log_path)}'
             return cmd
 
         return LazyLLMCMD(cmd=impl, return_value=self.geturl,

--- a/tests/basic_tests/Common/test_file_arg_passer.py
+++ b/tests/basic_tests/Common/test_file_arg_passer.py
@@ -1,0 +1,44 @@
+import os
+
+import lazyllm
+from lazyllm.common.utils import dump_obj, dump_obj_to_file, load_obj
+from lazyllm.components.deploy.relay.base import RelayServer
+
+
+def test_dump_obj_to_file_round_trip_and_cleanup(tmp_path):
+    path = tmp_path / 'payload.pkl'
+    reference = dump_obj_to_file({'answer': 42}, str(path))
+
+    assert load_obj(reference) == {'answer': 42}
+    assert not path.exists()
+
+    none_path = tmp_path / 'none.pkl'
+    none_reference = dump_obj_to_file(None, str(none_path))
+    assert load_obj(none_reference) is None
+    assert not none_path.exists()
+
+
+def test_relay_file_args_use_lazyllm_temp_dir(tmp_path):
+    relay = RelayServer(func=lambda value: value, pass_args_by_file=True)
+
+    with lazyllm.config.temp('temp_dir', str(tmp_path)):
+        reference = relay._prepare_obj_arg(dump_obj({'answer': 42}), force=True)
+
+    path = reference.removeprefix('@file:')
+    assert os.path.dirname(path) == str(tmp_path)
+    assert load_obj(reference) == {'answer': 42}
+    assert not os.path.exists(path)
+
+
+def test_relay_windows_command_quotes_paths_with_spaces(monkeypatch):
+    monkeypatch.setattr(os, 'name', 'nt')
+
+    command = RelayServer._join_command([
+        r'C:\Program Files\Python\python.exe',
+        r'C:\Lazy Mind\relay server.py',
+        r'--function=@file:C:\Lazy Mind\payload.pkl',
+    ])
+
+    assert command.startswith('"C:\\Program Files\\Python\\python.exe"')
+    assert '"C:\\Lazy Mind\\relay server.py"' in command
+    assert '"--function=@file:C:\\Lazy Mind\\payload.pkl"' in command

--- a/tests/basic_tests/Common/test_file_arg_passer.py
+++ b/tests/basic_tests/Common/test_file_arg_passer.py
@@ -24,10 +24,10 @@ def test_relay_file_args_use_lazyllm_temp_dir(tmp_path):
     with lazyllm.config.temp('temp_dir', str(tmp_path)):
         reference = relay._prepare_obj_arg(dump_obj({'answer': 42}), force=True)
 
-    path = reference.removeprefix('@file:')
-    assert os.path.dirname(path) == str(tmp_path)
+    payloads = list(tmp_path.glob('lazyllm_relay_*.pkl'))
+    assert len(payloads) == 1
     assert load_obj(reference) == {'answer': 42}
-    assert not os.path.exists(path)
+    assert not payloads[0].exists()
 
 
 def test_relay_windows_command_quotes_paths_with_spaces(monkeypatch):


### PR DESCRIPTION
## Summary
- build on #1233 and keep relay payloads out of the Windows command line
- store one-shot payloads under LAZYLLM_TEMP_DIR and remove them after loading
- preserve cloudpickle's dynamic-module context and quote commands with paths containing spaces
- cover function, hooks, and defined position payloads

## Dependency
This is stacked on #1233. Rebase to the merged #1233 commit before merging this PR.

## Validation
- focused pytest coverage for file-backed relay arguments
- flake8 on changed files
- exercised from the LazyMind Windows Desktop runtime