### PR TITLE
fix(skill): skip malformed skill metadata

### DIFF
--- a/lazyllm/cli/skills.py
+++ b/lazyllm/cli/skills.py
@@ -66,7 +66,7 @@ def _load_skill_meta(manager, folder):
             meta = manager._extract_yaml_meta(fp.read())
     except OSError as exc:
         return None, f'Failed to read SKILL.md ({exc}).'
-    if not manager._is_meta_valid(meta or {}):
+    if manager._validate_meta(meta or {}) is not None:
         return None, 'Invalid SKILL.md metadata.'
     return meta, None
 

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -360,7 +360,10 @@ class SkillManager(ModuleBase):
                     meta = self._extract_yaml_meta(content)
                     validation_error = self._validate_meta(meta)
                     if validation_error:
-                        details = ' '.join(f'{key}={value}' for key, value in validation_error.items())
+                        details = ' '.join(
+                            f'{detail_key}={detail_value}'
+                            for detail_key, detail_value in validation_error.items()
+                        )
                         LOG.warning(
                             f'event=skill_load_skipped {details} skill_md={skill_md!r}'
                         )

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -9,7 +9,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import yaml
 
-from lazyllm import config, ModuleBase
+from lazyllm import config, LOG, ModuleBase
 from lazyllm.thirdparty import fsspec
 from .shell_tool import shell_tool as _shell_tool
 
@@ -296,8 +296,33 @@ class SkillManager(ModuleBase):
         return meta if isinstance(meta, dict) else None
 
     @staticmethod
-    def _is_meta_valid(meta: dict) -> bool:
-        return meta is not None and _META_REQUIRED_FIELDS.issubset(meta.keys())
+    def _validate_meta(meta: Optional[dict]) -> Optional[Dict[str, str]]:
+        if not isinstance(meta, dict):
+            return {
+                'code': 'frontmatter_not_mapping',
+                'expected_type': 'dict',
+                'actual_type': type(meta).__name__,
+            }
+        for field in sorted(_META_REQUIRED_FIELDS):
+            if field not in meta:
+                return {
+                    'code': 'metadata_field_missing',
+                    'field': field,
+                }
+            value = meta[field]
+            if not isinstance(value, str):
+                return {
+                    'code': 'metadata_field_type_error',
+                    'field': field,
+                    'expected_type': 'str',
+                    'actual_type': type(value).__name__,
+                }
+            if not value.strip():
+                return {
+                    'code': 'metadata_field_value_error',
+                    'field': field,
+                }
+        return None
 
     def _skill_key_from_dir(self, skill_dir: str) -> str:
         normalized_dir = self._normalize_index_path(skill_dir)
@@ -325,37 +350,44 @@ class SkillManager(ModuleBase):
                 return
             skills_index: Dict[str, Dict] = {}
             for skill_dir, skill_md in self._iter_skill_files():
-                size = self._fs_getsize(skill_md)
-                if size is not None and size > self._max_skill_md_bytes:
-                    continue
                 try:
+                    size = self._fs_getsize(skill_md)
+                    if size is not None and size > self._max_skill_md_bytes:
+                        continue
                     content = self._fs_read(skill_md)
-                except Exception:
+                    if size is None and self._content_exceeds_limit(content):
+                        continue
+                    meta = self._extract_yaml_meta(content)
+                    validation_error = self._validate_meta(meta)
+                    if validation_error:
+                        details = ' '.join(f'{key}={value}' for key, value in validation_error.items())
+                        LOG.warning(
+                            f'event=skill_load_skipped {details} skill_md={skill_md!r}'
+                        )
+                        continue
+                    name = meta['name']
+                    key = self._skill_key_from_dir(skill_dir)
+                    if not key or key in skills_index:
+                        continue
+                    skills_index[key] = {
+                        'key': key,
+                        'name': name,
+                        'description': meta['description'],
+                        'argument-hint': meta.get('argument-hint', ''),
+                        'disable-model-invocation': self._to_bool(meta.get('disable-model-invocation', False)),
+                        'user-invocable': self._to_bool(meta.get('user-invocable', True)),
+                        'allowed-tools': meta.get('allowed-tools'),
+                        'source': self._extract_protocol(skill_dir) or 'file',
+                        'path': skill_dir,
+                        'skill_md': skill_md,
+                        'raw_meta': meta,
+                    }
+                except Exception as exc:
+                    LOG.warning(
+                        'event=skill_load_skipped code=unexpected_skill_load_error '
+                        f'error_type={type(exc).__name__} skill_md={skill_md!r}'
+                    )
                     continue
-                if size is None and self._content_exceeds_limit(content):
-                    continue
-                meta = self._extract_yaml_meta(content)
-                if not self._is_meta_valid(meta):
-                    continue
-                name = meta.get('name')
-                if not name:
-                    continue
-                key = self._skill_key_from_dir(skill_dir)
-                if not key or key in skills_index:
-                    continue
-                skills_index[key] = {
-                    'key': key,
-                    'name': name,
-                    'description': meta.get('description', ''),
-                    'argument-hint': meta.get('argument-hint', ''),
-                    'disable-model-invocation': self._to_bool(meta.get('disable-model-invocation', False)),
-                    'user-invocable': self._to_bool(meta.get('user-invocable', True)),
-                    'allowed-tools': meta.get('allowed-tools'),
-                    'source': self._extract_protocol(skill_dir) or 'file',
-                    'path': skill_dir,
-                    'skill_md': skill_md,
-                    'raw_meta': meta,
-                }
             self._skills_index = skills_index
             if self._skills_expected:
                 self._skills_selected = [

--- a/tests/advanced_tests/Tools/test_skills.py
+++ b/tests/advanced_tests/Tools/test_skills.py
@@ -145,6 +145,56 @@ class TestSkills(object):
         assert skill['status'] == 'ok'
         assert '# Demo' in skill['content']
 
+    def test_invalid_required_metadata_type_does_not_block_valid_skills(self):
+        fs = _MemoryCloudFS(
+            {
+                'skills': [
+                    {'name': 'skills/valid-skill', 'type': 'directory'},
+                    {'name': 'skills/bad-name', 'type': 'directory'},
+                    {'name': 'skills/bad-description', 'type': 'directory'},
+                ],
+                'skills/valid-skill': [
+                    {'name': 'skills/valid-skill/SKILL.md', 'type': 'file'},
+                ],
+                'skills/bad-name': [
+                    {'name': 'skills/bad-name/SKILL.md', 'type': 'file'},
+                ],
+                'skills/bad-description': [
+                    {'name': 'skills/bad-description/SKILL.md', 'type': 'file'},
+                ],
+            },
+            {
+                'skills/valid-skill/SKILL.md': (
+                    b'---\n'
+                    b'name: valid-skill\n'
+                    b'description: valid skill remains available\n'
+                    b'---\n'
+                    b'# Valid Skill\n'
+                ),
+                'skills/bad-name/SKILL.md': (
+                    b'---\n'
+                    b'name: 123\n'
+                    b'description: invalid name type\n'
+                    b'---\n'
+                    b'# Bad Name\n'
+                ),
+                'skills/bad-description/SKILL.md': (
+                    b'---\n'
+                    b'name: bad-description\n'
+                    b'description: 123\n'
+                    b'---\n'
+                    b'# Bad Description\n'
+                ),
+            },
+        )
+        manager = SkillManager(dir='skills', fs=fs)
+
+        prompt = manager.build_prompt()
+
+        assert 'valid skill remains available' in prompt
+        assert 'skills/bad-name' not in prompt
+        assert 'skills/bad-description' not in prompt
+
     def test_skill_manager_enforces_size_limit_when_info_has_no_size(self):
         fs = _MemoryCloudFS(
             {


### PR DESCRIPTION
# 🐛 Bug Fix

## Problem Description
A malformed `SKILL.md` can provide non-string required metadata such as an integer `name` or `description`. The invalid value is indexed and later causes prompt construction to raise, preventing all chats for that user from starting.

## Problem Analysis
- Root cause: skill metadata validation previously checked only for required keys, not their value types or blank values.
- Scope of impact: one invalid skill could interrupt loading and block otherwise valid skills for the same user.
- Reproduction: load one valid skill together with a skill whose `name` or `description` is an integer, then call `SkillManager.build_prompt()`.

## Fix Solution
- Validate required metadata as non-empty strings before adding a skill to the index.
- Return structured validation details from a single `_validate_meta` helper for logging and simple validity checks.
- Isolate each skill load so malformed or unexpectedly unreadable skills are skipped without aborting the full index.
- Keep the CLI metadata check aligned with the same validation path.

## Fix Verification
- [x] Post-fix testing
- [x] Regression testing
- [x] Edge case testing

Verified with five focused SkillManager/CLI tests, including integer `name` and `description` values; all passed. `make lint-only-diff` also passed. The full skill test file reached 13 passing tests; `test_react_agent_with_skills` could not complete because it requires downloading `Qwen2.5-32B-Instruct` and waited on the local ModelScope file lock.

## Impact Assessment
- Existing valid skill behavior remains unchanged.
- Invalid skills are omitted from the prompt and emit a warning with the validation reason.
- No expected performance impact or breaking interface change.

## Prevention Measures
- Added a public-behavior regression test proving invalid required metadata cannot block valid skills.
- Required `name` and `description` values are checked for type and content at the index-loading seam.

## Related Issues
N/A

---

## Change Type
- [ ] Feature addition
- [x] Bug fix
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Testing related
- [ ] Security fix

## Impact Scope
- [ ] User interface
- [ ] API interface
- [ ] Database
- [ ] Configuration files
- [ ] Dependencies

## Priority
- [ ] High - Release immediately
- [x] Medium - Next version
- [ ] Low - Future version

## Release Notes Points
- Malformed skill metadata no longer prevents other user skills or chats from loading.
- No configuration changes or migration steps are required.
