### PR TITLE
Refresh MiniMax chat defaults and regional endpoints

### DIFF
--- a/lazyllm/docs/module.py
+++ b/lazyllm/docs/module.py
@@ -3231,9 +3231,10 @@ Minimax 模块，继承自 OnlineChatModuleBase 和 FileHandlerBase。
 提供基于 Minimax 平台的大语言模型对话能力。
 
 Args:
-    base_url (str, optional): API 基础地址，默认为 "https://api.minimaxi.com/v1/"
-    model (str, optional): 使用的模型名称，默认为 "MiniMax-M2"
+    base_url (str, optional): API 基础地址。默认使用国际站 "https://api.minimax.io/v1/"。
+    model (str, optional): 使用的模型名称，默认为 "MiniMax-M3"
     api_key (str, optional): API 密钥，默认从配置项 lazyllm.config['minimax_api_key'] 中读取
+    region (str, optional): API 区域，可选 ``global`` 或 ``cn``。中国站使用 "https://api.minimaxi.com/v1/"。
     stream (bool, optional): 是否启用流式输出，默认为 True；启用时会自动设置请求参数
     return_trace (bool, optional): 是否返回追踪信息，默认为 False
     **kwargs: 其他传递给父类的可选参数
@@ -3245,9 +3246,11 @@ Minimax module, inheriting from OnlineChatModuleBase and FileHandlerBase.
 Provides large language model chat capabilities based on the Minimax platform.
 
 Args:
-    base_url (str, optional): Base API URL, defaults to "https://api.minimaxi.com/v1/"
-    model (str, optional): Model name to use, defaults to "MiniMax-M2"
+    base_url (str, optional): Base API URL, defaults to the global endpoint "https://api.minimax.io/v1/".
+    model (str, optional): Model name to use, defaults to "MiniMax-M3"
     api_key (str, optional): API key, defaults to lazyllm.config['minimax_api_key']
+    region (str, optional): API region, either ``global`` or ``cn``. The China endpoint is
+        "https://api.minimaxi.com/v1/".
     stream (bool, optional): Whether to enable streaming output, defaults to True; automatically configures request parameters when enabled
     return_trace (bool, optional): Whether to return trace information, defaults to False
     **kwargs: Additional optional parameters passed to the parent classes

--- a/lazyllm/module/llms/onlinemodule/supplier/minimax.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/minimax.py
@@ -13,10 +13,19 @@ from ..fileHandler import FileHandlerBase
 
 class MinimaxChat(OnlineChatModuleBase, FileHandlerBase):
 
+    MODEL_NAME = 'MiniMax-M3'
+    BASE_URLS = {
+        'global': 'https://api.minimax.io/v1/',
+        'cn': 'https://api.minimaxi.com/v1/',
+    }
+
     def __init__(self, base_url: Optional[str] = None, model: Optional[str] = None,
-                 api_key: str = None, stream: bool = True, return_trace: bool = False, **kwargs):
-        base_url = base_url or 'https://api.minimaxi.com/v1/'
-        model = model or 'MiniMax-M2'
+                 api_key: str = None, stream: bool = True, return_trace: bool = False,
+                 region: str = 'global', **kwargs):
+        if region not in self.BASE_URLS:
+            raise ValueError(f'Unsupported MiniMax region: {region!r}. Expected one of {tuple(self.BASE_URLS)}')
+        base_url = base_url or self.BASE_URLS[region]
+        model = model or self.MODEL_NAME
         super().__init__(api_key=api_key or self._default_api_key(), base_url=base_url, model_name=model,
                          stream=stream, return_trace=return_trace, **kwargs)
         FileHandlerBase.__init__(self)


### PR DESCRIPTION
Reason: MiniMax chat defaults still used an older model and only exposed the China API endpoint.

This updates the default chat model to MiniMax-M3 and makes the global and China OpenAI-compatible endpoints selectable through a `region` argument. Explicit `base_url` overrides remain supported, and the API documentation now describes both regional endpoints.

Checks:
- `python3 -m compileall -q lazyllm/module/llms/onlinemodule/supplier/minimax.py lazyllm/docs/module.py`
- `git diff --check`

The direct import smoke check could not run because the local environment does not have the optional `toml` dependency installed.
