### PR TITLE
fix: handle missing pyproject.toml gracefully in thirdparty module

### DIFF
--- a/_build_backend.py
+++ b/_build_backend.py
@@ -1,0 +1,20 @@
+"""Thin wrapper around scikit-build-core that bundles pyproject.toml.
+
+lazyllm.thirdparty reads pyproject.toml at runtime to map missing optional
+imports to pip-install suggestions.  scikit-build-core does not copy it into
+the wheel automatically the way Poetry's ``include`` directive did, so we
+copy it here before the wheel is assembled.
+
+Workaround for https://github.com/LazyAGI/LazyLLM/issues/1245
+"""
+
+import shutil
+from pathlib import Path
+
+from scikit_build_core.build import *  # noqa: F401,F403
+
+_root = Path(__file__).parent
+_src = _root / "pyproject.toml"
+_dst = _root / "lazyllm" / "pyproject.toml"
+if _src.is_file() and not _dst.is_file():
+    shutil.copy2(_src, _dst)

--- a/lazyllm/thirdparty/__init__.py
+++ b/lazyllm/thirdparty/__init__.py
@@ -72,12 +72,14 @@ def load_toml_dict() -> dict[str, Any]:
     try:
         with open(toml_file_path, 'r') as f:
             return toml.load(f)
-    except FileNotFoundError:
-        LOG.error('pyproject.toml is missing. Please reinstall LazyLLM.')
-        raise FileNotFoundError('pyproject.toml is missing. Please reinstall LazyLLM.')
+    except (OSError, toml.TomlDecodeError):
+        LOG.warning('pyproject.toml not found or invalid; optional dependency hints will be unavailable.')
+        return {}
 
 def prepare_requirements_dict():
     toml_config = load_toml_dict()
+    if not toml_config:
+        return
 
     pattern = re.compile(r'''
         ^\s*
@@ -87,12 +89,12 @@ def prepare_requirements_dict():
         \s*$
     ''', re.VERBOSE)
 
-    required_dependencies = toml_config['project']['dependencies']
+    required_dependencies = toml_config.get('project', {}).get('dependencies', [])
     for dep in required_dependencies:
         name, version = split_package_version(dep, pattern)
         requirements[name] = version
 
-    optional_dependencies = toml_config['tool']['poetry']['dependencies']
+    optional_dependencies = toml_config.get('tool', {}).get('poetry', {}).get('dependencies', {})
     for name, spec in optional_dependencies.items():
         version = spec.get('version', '')
         if version == '*':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = ["scikit-build-core>=0.9", "pybind11>=2.11"]
-build-backend = "scikit_build_core.build"
+build-backend = "_build_backend"
+backend-path = ["."]
 
 [tool.scikit-build]
 wheel.packages = ["lazyllm"]


### PR DESCRIPTION
## Summary

- ~~Add `lazyllm/pyproject.toml` as a symlink to the root `pyproject.toml` so scikit-build-core includes it in the wheel (restoring the old Poetry `include` behavior).~~
- Add a _build_backend.py wrapper that copies pyproject.toml into lazyllm/ before the wheel is assembled, restoring the behavior the old Poetry "include" directive provided. The existing CI "cp pyproject.toml lazyllm/" step still works — the wrapper is a no-op when the file already exists.
- Make `load_toml_dict()` return `{}` instead of raising `FileNotFoundError` when `pyproject.toml` is absent, so `PackageWrapper` always raises `ImportError` (which callers like `_load_backend_classes` already handle)
- Make `prepare_requirements_dict()` tolerate the empty config defensively

Fixes #1245

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>