### PR TITLE
feat(rag): add public SegmentStore facade

### DIFF
--- a/docs/en/API Reference/segment_store.md
+++ b/docs/en/API Reference/segment_store.md
@@ -1,0 +1,29 @@
+# SegmentStore
+
+`SegmentStore` is the public facade for persistent text segments that do not
+belong to the `Document` lifecycle. It accepts a LazyLLM store configuration or
+an existing store instance and exposes normalized collection names, lazy
+connection, canonical `id/content/metadata` records, BM25 search, create-only
+writes, and atomic patches.
+
+```python
+from lazyllm.tools.rag import SegmentStore
+
+store = SegmentStore({
+    "type": "SQLiteStore",
+    "kwargs": {"db_path": "segments.db"},
+})
+store.create("events", [{
+    "id": "event-1",
+    "content": "release completed",
+    "metadata": {"user_id": "u1", "hit_count": 0},
+}])
+rows = store.search("events", "release", filters={"user_id": "u1"})
+store.patch("events", {"id": "event-1", "user_id": "u1"},
+            inc_fields={"hit_count": 1})
+```
+
+`create` never overwrites an existing ID. `patch` never falls back to a
+read-modify-write sequence: a backend without an atomic primitive raises
+`SegmentStoreUnsupportedError`. `Document` continues to own DocNode,
+embedding, vector, node-group, and hybrid coordination behavior.

--- a/docs/nav_en.yml
+++ b/docs/nav_en.yml
@@ -52,6 +52,7 @@
   - Flow: API Reference/flow.md
   - Module: API Reference/module.md
   - Tools: API Reference/tools.md
+  - SegmentStore: API Reference/segment_store.md
   - Configs: API Reference/configs.md
   - Launcher: API Reference/launcher.md
   - Hook: API Reference/hook.md

--- a/docs/nav_zh.yml
+++ b/docs/nav_zh.yml
@@ -52,6 +52,7 @@
   - 工作流: API Reference/flow.md
   - 模块: API Reference/module.md
   - 工具: API Reference/tools.md
+  - SegmentStore: API Reference/segment_store.md
   - 配置: API Reference/configs.md
   - 启动器: API Reference/launcher.md
   - 钩子: API Reference/hook.md

--- a/docs/zh/API Reference/segment_store.md
+++ b/docs/zh/API Reference/segment_store.md
@@ -1,0 +1,26 @@
+# SegmentStore
+
+`SegmentStore` 是面向非 `Document` 生命周期文本记录的公共存储 facade。
+它接收 LazyLLM Store 配置或已有 Store 实例，统一提供 collection 名规范化、
+延迟连接、`id/content/metadata` 逻辑记录、BM25 检索、严格追加和原子 patch。
+
+```python
+from lazyllm.tools.rag import SegmentStore
+
+store = SegmentStore({
+    "type": "SQLiteStore",
+    "kwargs": {"db_path": "segments.db"},
+})
+store.create("events", [{
+    "id": "event-1",
+    "content": "版本 发布 完成",
+    "metadata": {"user_id": "u1", "hit_count": 0},
+}])
+rows = store.search("events", "版本 发布", filters={"user_id": "u1"})
+store.patch("events", {"id": "event-1", "user_id": "u1"},
+            inc_fields={"hit_count": 1})
+```
+
+`create` 不会覆盖已有 ID。`patch` 不允许退化为“先读后写”；后端没有原子
+能力时会抛出 `SegmentStoreUnsupportedError`。DocNode、Embedding、Vector、
+Node Group 和 Hybrid 协调仍属于 `Document`。

--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -8703,7 +8703,7 @@ add_chinese_doc('rag.store.segment.OpenSearchStore.get', """\
 Args:
     collection_name (str): 集合名称（索引名）
     criteria (Optional[dict]): 查询条件
-    **kwargs: 其他查询参数。``raise_on_error=True`` 时传播读取异常；默认返回空结果。
+    **kwargs: 其他查询参数
 
 Returns:
     List[dict]: 查询结果数据列表
@@ -8717,8 +8717,7 @@ Query data from specified collection based on criteria, supports primary key que
 Args:
     collection_name (str): Collection name (index name)
     criteria (Optional[dict]): Query criteria
-    **kwargs: Other query parameters. Set ``raise_on_error=True`` to propagate read failures;
-        by default failures return an empty result.
+    **kwargs: Other query parameters
 
 Returns:
     List[dict]: Query result data list
@@ -8731,8 +8730,7 @@ Args:
     query (Optional[str]): Query string.
     topk (Optional[int]): Number of nearest neighbors.
     filters (Optional[dict]): Metadata filter map.
-    kwargs: Other search parameters. Set ``raise_on_error=True`` to propagate search failures;
-        by default failures return an empty result.
+    **kwargs: Other search parameters
 
 **Returns:**\n
 - List[dict]: Return matching results list and similarity 'score'.
@@ -8745,7 +8743,7 @@ Args:
     query (Optional[str]): 查询字符串。
     topk (Optional[int]): 返回邻近数量。
     filters (Optional[dict]): 元数据过滤映射。
-    kwargs: 其他搜索参数。``raise_on_error=True`` 时传播检索异常；默认返回空结果。
+    **kwargs: 其他搜索参数
 
 **Returns:**\n
 - List[dict]: 返回匹配结果列表及相似度 'score'。
@@ -9413,8 +9411,7 @@ add_chinese_doc('rag.store.segment.SQLiteStore.get', """\
 Args:
     collection_name (str): 待查询集合。
     criteria (Optional[dict]): 过滤条件（uid/doc_id/kb_id/parent/number 及 json_extract 自定义字段）。
-    **kwargs: limit / offset / return_total / sort_by_number；``raise_on_error=True`` 时传播读取异常，
-        默认读取失败返回空结果。
+    **kwargs: limit / offset / return_total / sort_by_number。
 
 Returns:
     List[dict] 或 (List[dict], int): 切片列表或 (列表, 总数)。
@@ -9426,8 +9423,7 @@ Query segments by criteria with pagination (limit/offset), sorting (sort_by_numb
 Args:
     collection_name (str): Collection to query.
     criteria (Optional[dict]): Filter conditions (uid/doc_id/kb_id/parent/number, plus json_extract for custom fields).
-    **kwargs: limit / offset / return_total / sort_by_number. Set ``raise_on_error=True`` to
-        propagate read failures; by default failures return an empty result.
+    **kwargs: limit / offset / return_total / sort_by_number.
 
 Returns:
     List[dict] or (List[dict], int): Segment list or (list, total).
@@ -9441,7 +9437,7 @@ Args:
     query (Optional[str]): 搜索关键词（自动追加 ``*`` 分词前缀匹配）。
     topk (Optional[int]): 返回结果数上限（默认 10）。
     filters (Optional[dict]): 元数据过滤条件。
-    **kwargs: 其他参数。``raise_on_error=True`` 时传播检索异常；默认返回空结果。
+    **kwargs: 其他参数。
 
 Returns:
     List[dict]: 带 ``score`` 字段的切片列表（-rank 转换，越大越相关）。
@@ -9455,8 +9451,7 @@ Args:
     query (Optional[str]): Search keyword (``*`` auto-appended for prefix matching).
     topk (Optional[int]): Max results (default 10).
     filters (Optional[dict]): Metadata filter conditions.
-    **kwargs: Other parameters. Set ``raise_on_error=True`` to propagate search failures;
-        by default failures return an empty result.
+    **kwargs: Other parameters.
 
 Returns:
     List[dict]: Segment list with ``score`` field (negated FTS5 rank, higher = more relevant).
@@ -9511,6 +9506,9 @@ add_chinese_doc('rag.store.SegmentStore', """\
 Args:
     store (Union[Dict[str, Any], LazyLLMStoreBase]): backend 配置或已创建的存储实例。
     global_metadata_desc (Optional[dict]): 连接 backend 时使用的全局元数据描述。
+
+Note:
+    严格模式当前适用于 ``SQLiteStore`` 和 ``OpenSearchStore`` 的读取与检索。
 """)
 
 add_english_doc('rag.store.SegmentStore', """\
@@ -9523,6 +9521,9 @@ create-only writes, filtered reads, search, atomic field updates, and deletion.
 Args:
     store (Union[Dict[str, Any], LazyLLMStoreBase]): Backend configuration or an existing store instance.
     global_metadata_desc (Optional[dict]): Global metadata description used when connecting the backend.
+
+Note:
+    Strict mode currently applies to reads and searches backed by ``SQLiteStore`` and ``OpenSearchStore``.
 """)
 
 add_chinese_doc('rag.store.SegmentStore.get', """\
@@ -9531,8 +9532,7 @@ add_chinese_doc('rag.store.SegmentStore.get', """\
 Args:
     name (str): 集合名称。
     filters (dict): ``id``、``user_id`` 等公共过滤条件。
-    strict (bool): 是否启用严格读取。为 ``True`` 时，支持该契约的 backend 会传播读取异常；
-        默认为 ``False``，保留既有的 fail-soft 行为。
+    strict (bool): 是否启用严格读取，默认为 ``False``。
 
 Returns:
     List[dict]: 使用 ``id/content/metadata`` 结构表示的切片列表。
@@ -9544,8 +9544,7 @@ Read text segments matching the supplied filters.
 Args:
     name (str): Collection name.
     filters (dict): Public filters such as ``id`` and ``user_id``.
-    strict (bool): Whether to enable strict reads. When ``True``, backends that support the contract
-        propagate read failures. The default is ``False`` to preserve fail-soft behavior.
+    strict (bool): Whether to enable strict reads. Defaults to ``False``.
 
 Returns:
     List[dict]: Matching segments in the public ``id/content/metadata`` shape.
@@ -9561,7 +9560,7 @@ Args:
     filters (Optional[dict]): 公共过滤条件。
     query_fields (Optional[List[str]]): backend 应查询的字段列表。
     match_mode (Optional[str]): ``"any"`` 或 ``"all"``。
-    strict (bool): 为 ``True`` 时传播 backend 检索异常；默认为 ``False``。
+    strict (bool): 是否启用严格检索，默认为 ``False``。
 
 Returns:
     List[dict]: 带可选 ``score`` 的公共切片列表。
@@ -9577,7 +9576,7 @@ Args:
     filters (Optional[dict]): Public filter conditions.
     query_fields (Optional[List[str]]): Backend fields to query.
     match_mode (Optional[str]): Either ``"any"`` or ``"all"``.
-    strict (bool): Propagate backend search failures when ``True``; defaults to ``False``.
+    strict (bool): Whether to enable strict searches. Defaults to ``False``.
 
 Returns:
     List[dict]: Public segment records with an optional ``score``.

--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -8703,7 +8703,7 @@ add_chinese_doc('rag.store.segment.OpenSearchStore.get', """\
 Args:
     collection_name (str): 集合名称（索引名）
     criteria (Optional[dict]): 查询条件
-    **kwargs: 其他查询参数
+    **kwargs: 其他查询参数。``raise_on_error=True`` 时传播读取异常；默认返回空结果。
 
 Returns:
     List[dict]: 查询结果数据列表
@@ -8717,7 +8717,8 @@ Query data from specified collection based on criteria, supports primary key que
 Args:
     collection_name (str): Collection name (index name)
     criteria (Optional[dict]): Query criteria
-    **kwargs: Other query parameters
+    **kwargs: Other query parameters. Set ``raise_on_error=True`` to propagate read failures;
+        by default failures return an empty result.
 
 Returns:
     List[dict]: Query result data list
@@ -8730,7 +8731,8 @@ Args:
     query (Optional[str]): Query string.
     topk (Optional[int]): Number of nearest neighbors.
     filters (Optional[dict]): Metadata filter map.
-    kwargs: Other search parameters
+    kwargs: Other search parameters. Set ``raise_on_error=True`` to propagate search failures;
+        by default failures return an empty result.
 
 **Returns:**\n
 - List[dict]: Return matching results list and similarity 'score'.
@@ -8743,7 +8745,7 @@ Args:
     query (Optional[str]): 查询字符串。
     topk (Optional[int]): 返回邻近数量。
     filters (Optional[dict]): 元数据过滤映射。
-    kwargs: 其他搜索参数
+    kwargs: 其他搜索参数。``raise_on_error=True`` 时传播检索异常；默认返回空结果。
 
 **Returns:**\n
 - List[dict]: 返回匹配结果列表及相似度 'score'。
@@ -9411,7 +9413,8 @@ add_chinese_doc('rag.store.segment.SQLiteStore.get', """\
 Args:
     collection_name (str): 待查询集合。
     criteria (Optional[dict]): 过滤条件（uid/doc_id/kb_id/parent/number 及 json_extract 自定义字段）。
-    **kwargs: limit / offset / return_total / sort_by_number。
+    **kwargs: limit / offset / return_total / sort_by_number；``raise_on_error=True`` 时传播读取异常，
+        默认读取失败返回空结果。
 
 Returns:
     List[dict] 或 (List[dict], int): 切片列表或 (列表, 总数)。
@@ -9423,7 +9426,8 @@ Query segments by criteria with pagination (limit/offset), sorting (sort_by_numb
 Args:
     collection_name (str): Collection to query.
     criteria (Optional[dict]): Filter conditions (uid/doc_id/kb_id/parent/number, plus json_extract for custom fields).
-    **kwargs: limit / offset / return_total / sort_by_number.
+    **kwargs: limit / offset / return_total / sort_by_number. Set ``raise_on_error=True`` to
+        propagate read failures; by default failures return an empty result.
 
 Returns:
     List[dict] or (List[dict], int): Segment list or (list, total).
@@ -9437,7 +9441,7 @@ Args:
     query (Optional[str]): 搜索关键词（自动追加 ``*`` 分词前缀匹配）。
     topk (Optional[int]): 返回结果数上限（默认 10）。
     filters (Optional[dict]): 元数据过滤条件。
-    **kwargs: 其他参数。
+    **kwargs: 其他参数。``raise_on_error=True`` 时传播检索异常；默认返回空结果。
 
 Returns:
     List[dict]: 带 ``score`` 字段的切片列表（-rank 转换，越大越相关）。
@@ -9451,7 +9455,8 @@ Args:
     query (Optional[str]): Search keyword (``*`` auto-appended for prefix matching).
     topk (Optional[int]): Max results (default 10).
     filters (Optional[dict]): Metadata filter conditions.
-    **kwargs: Other parameters.
+    **kwargs: Other parameters. Set ``raise_on_error=True`` to propagate search failures;
+        by default failures return an empty result.
 
 Returns:
     List[dict]: Segment list with ``score`` field (negated FTS5 rank, higher = more relevant).
@@ -9496,3 +9501,84 @@ Returns:
 """)
 
 
+add_chinese_doc('rag.store.SegmentStore', """\
+文本切片存储的公共 facade。
+
+``SegmentStore`` 负责创建并连接具体 backend、规范化集合名，并在统一的
+``id/content/metadata`` 数据结构和 backend 原始字段之间转换。它提供 create-only 写入、
+条件读取、检索、原子字段更新和删除操作。
+
+Args:
+    store (Union[Dict[str, Any], LazyLLMStoreBase]): backend 配置或已创建的存储实例。
+    global_metadata_desc (Optional[dict]): 连接 backend 时使用的全局元数据描述。
+""")
+
+add_english_doc('rag.store.SegmentStore', """\
+Public facade for text-segment persistence.
+
+``SegmentStore`` constructs and connects the selected backend, normalizes collection names,
+and translates between public ``id/content/metadata`` records and backend-native fields. It provides
+create-only writes, filtered reads, search, atomic field updates, and deletion.
+
+Args:
+    store (Union[Dict[str, Any], LazyLLMStoreBase]): Backend configuration or an existing store instance.
+    global_metadata_desc (Optional[dict]): Global metadata description used when connecting the backend.
+""")
+
+add_chinese_doc('rag.store.SegmentStore.get', """\
+按条件读取文本切片。
+
+Args:
+    name (str): 集合名称。
+    filters (dict): ``id``、``user_id`` 等公共过滤条件。
+    strict (bool): 是否启用严格读取。为 ``True`` 时，支持该契约的 backend 会传播读取异常；
+        默认为 ``False``，保留既有的 fail-soft 行为。
+
+Returns:
+    List[dict]: 使用 ``id/content/metadata`` 结构表示的切片列表。
+""")
+
+add_english_doc('rag.store.SegmentStore.get', """\
+Read text segments matching the supplied filters.
+
+Args:
+    name (str): Collection name.
+    filters (dict): Public filters such as ``id`` and ``user_id``.
+    strict (bool): Whether to enable strict reads. When ``True``, backends that support the contract
+        propagate read failures. The default is ``False`` to preserve fail-soft behavior.
+
+Returns:
+    List[dict]: Matching segments in the public ``id/content/metadata`` shape.
+""")
+
+add_chinese_doc('rag.store.SegmentStore.search', """\
+检索文本切片，并可显式限制查询字段和词项匹配模式。
+
+Args:
+    name (str): 集合名称。
+    query (str): 查询文本。
+    topk (int): 候选结果上限。
+    filters (Optional[dict]): 公共过滤条件。
+    query_fields (Optional[List[str]]): backend 应查询的字段列表。
+    match_mode (Optional[str]): ``"any"`` 或 ``"all"``。
+    strict (bool): 为 ``True`` 时传播 backend 检索异常；默认为 ``False``。
+
+Returns:
+    List[dict]: 带可选 ``score`` 的公共切片列表。
+""")
+
+add_english_doc('rag.store.SegmentStore.search', """\
+Search text segments with optional field selection and term-matching mode.
+
+Args:
+    name (str): Collection name.
+    query (str): Query text.
+    topk (int): Maximum number of candidates.
+    filters (Optional[dict]): Public filter conditions.
+    query_fields (Optional[List[str]]): Backend fields to query.
+    match_mode (Optional[str]): Either ``"any"`` or ``"all"``.
+    strict (bool): Propagate backend search failures when ``True``; defaults to ``False``.
+
+Returns:
+    List[dict]: Public segment records with an optional ``score``.
+""")

--- a/lazyllm/tools/rag/__init__.py
+++ b/lazyllm/tools/rag/__init__.py
@@ -23,7 +23,7 @@ from .dataReader import SimpleDirectoryReader, FileReader
 from .global_metadata import GlobalMetadataDesc as DocField
 from .data_type import DataType
 from .index_base import IndexBase
-from .store import LazyLLMStoreBase
+from .store import LazyLLMStoreBase, SegmentStore
 from .doc_to_db import SchemaExtractor
 from .query_enh_ac import QueryEnhACProcessor
 
@@ -83,6 +83,7 @@ __all__ = [
     'DocField',
     'DataType',
     'IndexBase',
+    'SegmentStore',
     'LazyLLMStoreBase',
     'FileReader',
     'CharacterSplitter',

--- a/lazyllm/tools/rag/store/__init__.py
+++ b/lazyllm/tools/rag/store/__init__.py
@@ -7,6 +7,7 @@ from .store_base import (
 )
 from .hybrid import HybridStore, MapStore, SenseCoreStore, OceanBaseStore
 from .segment import OpenSearchStore, ElasticSearchStore, SQLiteStore
+from .segment_store import SegmentStore, SegmentStoreConflictError, SegmentStoreUnsupportedError
 from .vector import ChromaStore, MilvusStore
 
 __all__ = [
@@ -23,5 +24,8 @@ __all__ = [
     'LAZY_IMAGE_GROUP',
     'LAZY_ROOT_NAME',
     'EMBED_DEFAULT_KEY',
-    'BUILDIN_GLOBAL_META_DESC'
+    'BUILDIN_GLOBAL_META_DESC',
+    'SegmentStore',
+    'SegmentStoreConflictError',
+    'SegmentStoreUnsupportedError',
 ]

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -12,6 +12,7 @@ from lazyllm import LOG, once_wrapper
 from .store_base import (LazyLLMStoreBase, StoreCapability, SegmentType, Segment, INSERT_BATCH_SIZE,
                          BUILDIN_GLOBAL_META_DESC, DEFAULT_KB_ID)
 from .hybrid import HybridStore, MapStore
+from .segment_store import SegmentStore
 from ..default_index import DefaultIndex
 from ..utils import parallel_do_embedding
 
@@ -42,10 +43,10 @@ class _DocumentStore(object):
             self._indices['default'] = DefaultIndex(self._embed, self)
 
     def _prepare_store(self, store: Union[Dict, LazyLLMStoreBase]) -> LazyLLMStoreBase:
+        # Keep Document's raw Segment layout while sharing the public facade's
+        # backend construction rules with non-Document domain users.
         if isinstance(store, dict):
-            # create store from store config
-            if store.get('indices'): store = self._convert_legacy_to_config(store)
-            store = self._create_store_from_config(store)
+            return SegmentStore.create_backend(store)
         if store.capability == StoreCapability.VECTOR:
             segment_store = MapStore(uri=os.path.join(store.dir, 'segments.db') if store.dir else None)
             return HybridStore(segment_store=segment_store, vector_store=store)

--- a/lazyllm/tools/rag/store/hybrid/map_store.py
+++ b/lazyllm/tools/rag/store/hybrid/map_store.py
@@ -121,6 +121,68 @@ class MapStore(LazyLLMStoreBase):
                     conn.commit()
         return
 
+    def create_collection(self, collection_name):
+        if self._sqlite_first:
+            with self._lock:
+                cur = self._open_conn().cursor()
+                self._ensure_table(cur, collection_name)
+                self._open_conn().commit()
+        return True
+
+    def collection_exists(self, collection_name):
+        if self._sqlite_first:
+            return bool(self._open_conn().execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (collection_name,)
+            ).fetchone())
+        return collection_name in self._collection2uids
+
+    def create(self, collection_name, data):
+        with self._lock:
+            existing = set(self._collection2uids.get(collection_name, set()))
+            incoming = [item.get('uid') for item in data]
+            if len(set(incoming)) != len(incoming) or existing.intersection(incoming):
+                raise FileExistsError('segment primary key already exists')
+            if self._sqlite_first:
+                conn = self._open_conn()
+                cur = conn.cursor()
+                self._ensure_table(cur, collection_name)
+                sql = f'''INSERT INTO {collection_name} (
+                    uid, doc_id, 'group', content, meta, global_meta, type, number, kb_id,
+                    excluded_embed_metadata_keys, excluded_llm_metadata_keys, parent, answer, image_keys)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'''
+                try:
+                    cur.executemany(sql, [self._serialize_data(item) for item in data])
+                    conn.commit()
+                except sqlite3.IntegrityError as exc:
+                    conn.rollback()
+                    raise FileExistsError('segment primary key already exists') from exc
+            for item in data:
+                item['kb_id'] = item.get(RAG_KB_ID, DEFAULT_KB_ID)
+                self._cache_segment(collection_name, item)
+        return True
+
+    def patch(self, collection_name, criteria, set_fields=None, inc_fields=None):
+        set_fields, inc_fields = dict(set_fields or {}), dict(inc_fields or {})
+        if any(k != 'number' for k in set_fields | inc_fields):
+            raise ValueError('MapStore atomic patch currently supports number only')
+        with self._lock:
+            uids = self._get_uids_by_criteria(collection_name, criteria)
+            if self._sqlite_first and uids:
+                assignments, args = [], []
+                if 'number' in set_fields:
+                    assignments.append('number = ?'); args.append(set_fields['number'])
+                if 'number' in inc_fields:
+                    assignments.append('number = COALESCE(number, 0) + ?'); args.append(inc_fields['number'])
+                ph = ','.join('?' for _ in uids)
+                self._open_conn().execute(
+                    f'UPDATE {collection_name} SET {", ".join(assignments)} WHERE uid IN ({ph})', args + uids)
+                self._open_conn().commit()
+            for uid in uids:
+                item = self._uid2data[uid]
+                old = item.get('number', 0) or 0
+                item['number'] = set_fields.get('number', old) + inc_fields.get('number', 0)
+            return len(uids)
+
     @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:
         try:
@@ -283,6 +345,14 @@ class MapStore(LazyLLMStoreBase):
             return '', ()
         clauses, args = [], []
         for name, candidates in filters.items():
+            if name in {'uid', 'doc_id', 'kb_id', 'group', 'parent', 'number'}:
+                column = '"group"' if name == 'group' else name
+                values = list(candidates) if isinstance(candidates, (list, set, tuple)) else [candidates]
+                if not values:
+                    return ' WHERE 0', ()
+                clauses.append(f'{column} IN ({",".join("?" for _ in values)})')
+                args.extend(values)
+                continue
             path = self._json_path(name)
             if isinstance(candidates, (list, set, tuple)):
                 values = list(candidates)
@@ -438,7 +508,8 @@ class MapStore(LazyLLMStoreBase):
         for seg in segments:
             global_meta = seg.get('global_meta', {})
             for name, candidates in filters.items():
-                value = global_meta.get(name)
+                value = seg.get(name) if name in {'uid', 'doc_id', 'kb_id', 'group', 'parent', 'number'} \
+                    else global_meta.get(name)
                 if isinstance(candidates, (list, set)):
                     if value not in candidates:
                         break

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -112,6 +112,46 @@ class OpenSearchStore(LazyLLMStoreBase):
                 LOG.error(f'[OpenSearchStore - _ensure_index] Error creating index {name}: {e}')
                 raise e
 
+    def create_collection(self, collection_name):
+        self._ensure_index(collection_name)
+        return True
+
+    def collection_exists(self, collection_name):
+        return bool(self._client.indices.exists(index=collection_name))
+
+    def create(self, collection_name, data):
+        if not data:
+            return True
+        self._ensure_index(collection_name)
+        bulk_data = []
+        for segment in data:
+            segment = self._serialize_node(segment)
+            bulk_data.append({'create': {'_index': collection_name, '_id': segment[self._primary_key]}})
+            bulk_data.append(segment)
+        response = self._client.bulk(index=collection_name, body=bulk_data, refresh='wait_for')
+        if response.get('errors'):
+            conflicts = [item for item in response.get('items', [])
+                         if (item.get('create') or {}).get('status') == 409]
+            if conflicts:
+                raise FileExistsError('segment primary key already exists')
+            raise RuntimeError(f'OpenSearch create failed: {response.get("items", [])[:3]}')
+        return True
+
+    def patch(self, collection_name, criteria, set_fields=None, inc_fields=None):
+        set_fields, inc_fields = dict(set_fields or {}), dict(inc_fields or {})
+        params = {'set': set_fields, 'inc': inc_fields}
+        source = (
+            'for (entry in params.set.entrySet()) { ctx._source[entry.getKey()] = entry.getValue(); } '
+            'for (entry in params.inc.entrySet()) { def k = entry.getKey(); '
+            'ctx._source[k] = (ctx._source.containsKey(k) ? ctx._source[k] : 0) + entry.getValue(); }'
+        )
+        body = self._construct_criteria(criteria) or {'query': {'match_all': {}}}
+        body['script'] = {'lang': 'painless', 'source': source, 'params': params}
+        resp = self._client.update_by_query(index=collection_name, body=body, refresh=True, conflicts='abort')
+        if resp.get('failures'):
+            raise RuntimeError(f'OpenSearch patch failed: {resp["failures"]}')
+        return int(resp.get('updated', 0))
+
     @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:
         if not data: return
@@ -175,7 +215,7 @@ class OpenSearchStore(LazyLLMStoreBase):
             offset = max(kwargs.get('offset', 0) or 0, 0)
             return_total = kwargs.get('return_total', False)
             sort_by_number = kwargs.get('sort_by_number', False)
-            if criteria and self._primary_key in criteria:
+            if criteria and self._primary_key in criteria and len(criteria) == 1:
                 vals = criteria.pop(self._primary_key)
                 if not isinstance(vals, list):
                     vals = [vals]
@@ -341,7 +381,9 @@ class OpenSearchStore(LazyLLMStoreBase):
             vals = criteria.pop(self._primary_key)
             if not isinstance(vals, list):
                 vals = [vals]
-            return {'query': {'ids': {'values': vals}}}
+            must_clauses = [{'ids': {'values': vals}}]
+        else:
+            must_clauses = []
 
         exact_match_fields = {'doc_id', 'kb_id', 'group', 'parent'}
 
@@ -360,7 +402,6 @@ class OpenSearchStore(LazyLLMStoreBase):
                 must_clauses.append({'terms': {key: val}})
             else:
                 must_clauses.append({'term': {key: val}})
-        must_clauses = []
         if RAG_DOC_ID in criteria:
             val = criteria.pop(RAG_DOC_ID)
             _add_clause('doc_id', val)

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -266,6 +266,8 @@ class OpenSearchStore(LazyLLMStoreBase):
             return results
         except Exception as e:
             LOG.error(f'[OpenSearchStore - get] Error getting data from OpenSearch: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     @override
@@ -313,6 +315,8 @@ class OpenSearchStore(LazyLLMStoreBase):
 
         except Exception as e:
             LOG.error(f'[OpenSearchStore - search] Error searching data from OpenSearch: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     @override

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -73,6 +73,7 @@ DEFAULT_MAPPING_BODY = {
 class OpenSearchStore(LazyLLMStoreBase):
     capability = StoreCapability.SEGMENT
     need_embedding = False
+    supports_query_fields_match_mode = True
     supports_index_registration = False
 
     def __init__(self, uris: List[str], client_kwargs: Optional[Dict] = None,
@@ -270,22 +271,26 @@ class OpenSearchStore(LazyLLMStoreBase):
     @override
     def search(self, collection_name: str, query: Optional[str] = None,
                topk: Optional[int] = 10, filters: Optional[dict] = None, **kwargs) -> List[dict]:  # noqa: C901
-        query_fields = ['*']
+        query_fields = kwargs.get('query_fields') or ['*']
         try:
             self._ensure_index(collection_name)
             must_clauses = []
             os_query = {}
-            text_query = {
-                'multi_match': {
-                    'query': query,
-                    'fields': query_fields,
-                }
-            }
+            multi_match = {'query': query, 'fields': query_fields}
+            if operator := {'any': 'or', 'all': 'and'}.get(kwargs.get('match_mode')):
+                multi_match['operator'] = operator
+            text_query = {'multi_match': multi_match}
             must_clauses.append(text_query)
 
             filter_query = self._construct_criteria(filters) if filters else {}
 
-            if must_clauses and filter_query:
+            explicit_search_contract = (
+                kwargs.get('query_fields') is not None or kwargs.get('match_mode') is not None
+            )
+            if must_clauses and filter_query and explicit_search_contract:
+                filter_clauses = filter_query['query']['bool']['must']
+                os_query = {'query': {'bool': {'must': must_clauses, 'filter': filter_clauses}}}
+            elif must_clauses and filter_query:
                 filter_must = filter_query['query']['bool']['must']
                 os_query = {'query': {'bool': {'must': must_clauses + filter_must}}}
             elif must_clauses:

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -72,6 +72,62 @@ class SQLiteStore(LazyLLMStoreBase):
         self._ddl_lock = threading.Lock()
         self._open_conn()
 
+    def create_collection(self, collection_name):
+        with self._ddl_lock:
+            cur = self._open_conn().cursor()
+            self._ensure_table(cur, collection_name)
+            self._ensure_fts(cur, collection_name)
+            self._open_conn().commit()
+        return True
+
+    def collection_exists(self, collection_name):
+        row = self._open_conn().execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (collection_name,)
+        ).fetchone()
+        return bool(row)
+
+    def create(self, collection_name, data):
+        if not data:
+            return True
+        try:
+            with self._ddl_lock:
+                conn = self._open_conn()
+                cur = conn.cursor()
+                self._ensure_table(cur, collection_name)
+                self._ensure_fts(cur, collection_name)
+                sql = (f'INSERT INTO "{collection_name}" ({self._COL_NAMES_SQL}) '
+                       f'VALUES ({self._COL_PLACEHOLDERS})')
+                cur.executemany(sql, [self._serialize_row(item) for item in data])
+                cur.executemany(f'INSERT INTO "{collection_name}_fts"(uid, content) VALUES (?, ?)',
+                                [(item['uid'], self._fts_content(item)) for item in data])
+                conn.commit()
+            return True
+        except sqlite3.IntegrityError as exc:
+            self._open_conn().rollback()
+            raise FileExistsError('segment primary key already exists') from exc
+
+    def patch(self, collection_name, criteria, set_fields=None, inc_fields=None):
+        set_fields, inc_fields = dict(set_fields or {}), dict(inc_fields or {})
+        allowed = {name.strip('"') for name, _ in self._COLS}
+        if any(k not in allowed for k in set_fields | inc_fields):
+            raise ValueError('SQLiteStore patch only supports canonical columns')
+        assignments, values = [], []
+        for key, value in set_fields.items():
+            assignments.append(f'"{key}" = ?')
+            values.append(value)
+        for key, value in inc_fields.items():
+            assignments.append(f'"{key}" = COALESCE("{key}", 0) + ?')
+            values.append(value)
+        if not assignments:
+            return 0
+        with self._ddl_lock:
+            conn = self._open_conn()
+            where, args = self._build_where(criteria)
+            cur = conn.execute(f'UPDATE "{collection_name}" SET {", ".join(assignments)}{where}',
+                               tuple(values) + args)
+            conn.commit()
+            return cur.rowcount
+
     def _ensure_table(self, cursor, table):
         col_defs = ', '.join(f'{name} {typ}' for name, typ in self._COLS)
         cursor.execute(f'CREATE TABLE IF NOT EXISTS "{table}" ({col_defs})')

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -14,6 +14,8 @@ class SQLiteStore(LazyLLMStoreBase):
     capability = StoreCapability.SEGMENT
     need_embedding = False
     supports_index_registration = False
+    supports_query_fields_match_mode = True
+    supported_query_fields = frozenset({'content'})
 
     _COLS = [('uid', 'TEXT PRIMARY KEY'),
              ('doc_id', 'TEXT NOT NULL'),
@@ -268,7 +270,19 @@ class SQLiteStore(LazyLLMStoreBase):
                 return []
 
             cmatch = f'"{collection_name}_fts" MATCH ?'
-            q = [query if query.endswith('*') else query + '*']
+            match_mode = kwargs.get('match_mode')
+            if match_mode in ('any', 'all'):
+                terms = query.split()
+                if not terms:
+                    return []
+                escaped_terms = []
+                for term in terms:
+                    escaped = term.replace('"', '""')
+                    escaped_terms.append(f'"{escaped}"*')
+                fts_query = (' OR ' if match_mode == 'any' else ' AND ').join(escaped_terms)
+            else:
+                fts_query = query if query.endswith('*') else query + '*'
+            q = [fts_query]
             if filters:
                 fw, fa = self._build_fts_filter_where(filters)
                 where = f'{cmatch} AND {fw}'

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -224,6 +224,8 @@ class SQLiteStore(LazyLLMStoreBase):
                     else [self._deserialize_row(r) for r in cur.fetchall()])
         except Exception as e:
             LOG.error(f'[SQLiteStore - get] Error: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return ([], 0) if kwargs.get('return_total') else []
 
     @override
@@ -296,6 +298,8 @@ class SQLiteStore(LazyLLMStoreBase):
                     for r in conn.execute(sql, q + [topk]).fetchall()]
         except Exception as e:
             LOG.error(f'[SQLiteStore - search] Error: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     def _serialize_row(self, item):

--- a/lazyllm/tools/rag/store/segment_store.py
+++ b/lazyllm/tools/rag/store/segment_store.py
@@ -155,13 +155,14 @@ class SegmentStore:
             self.normalize_collection_name(name), [self._to_raw(item) for item in data],
         ))
 
-    def get(self, name: str, filters: dict) -> List[dict]:
+    def get(self, name: str, filters: dict, *, strict: bool = False) -> List[dict]:
+        read_options = {'raise_on_error': True} if strict else {}
         return [self._from_raw(item) for item in self._segment_backend.get(
-            self.normalize_collection_name(name), self._filters(filters))]
+            self.normalize_collection_name(name), self._filters(filters), **read_options)]
 
     def search(self, name: str, query: str, *, topk: int = 10,
                filters: Optional[dict] = None, query_fields: Optional[List[str]] = None,
-               match_mode: Optional[str] = None) -> List[dict]:
+               match_mode: Optional[str] = None, strict: bool = False) -> List[dict]:
         search_options = {}
         if query_fields is not None:
             if not isinstance(query_fields, list) or not query_fields:
@@ -187,6 +188,8 @@ class SegmentStore:
                     f'{type(backend).__name__} does not support query fields: '
                     f'{sorted(unsupported_fields)!r}'
                 )
+        if strict:
+            search_options['raise_on_error'] = True
         return [self._from_raw(item) for item in backend.search(
             self.normalize_collection_name(name), query=query, topk=topk,
             filters=self._filters(filters), **search_options)]

--- a/lazyllm/tools/rag/store/segment_store.py
+++ b/lazyllm/tools/rag/store/segment_store.py
@@ -1,0 +1,182 @@
+import hashlib
+import os
+import re
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+import lazyllm
+
+from .hybrid import HybridStore, MapStore
+from .store_base import BUILDIN_GLOBAL_META_DESC, LazyLLMStoreBase, StoreCapability
+
+
+class SegmentStoreConflictError(RuntimeError):
+    pass
+
+
+class SegmentStoreUnsupportedError(RuntimeError):
+    pass
+
+
+class SegmentStore:
+    '''Public facade for canonical text-segment persistence.
+
+    The facade owns backend construction, lazy connection and collection name
+    normalization.  Domain users exchange ``id/content/metadata`` records;
+    existing RAG callers may access ``backend`` without changing their layout.
+    '''
+
+    _COLLECTION_NAME_PATTERN = re.compile(r'[^a-z0-9_]+')
+    _COLLECTION_NAME_MAX_LEN = 255
+
+    def __init__(self, store: Union[Dict[str, Any], LazyLLMStoreBase], *,
+                 global_metadata_desc=None):
+        self._global_metadata_desc = global_metadata_desc or BUILDIN_GLOBAL_META_DESC
+        self.backend = self.create_backend(store)
+        self._connected = False
+
+    @classmethod
+    def create_backend(cls, store):
+        if not isinstance(store, dict):
+            if store.capability == StoreCapability.VECTOR:
+                segment_store = MapStore(uri=os.path.join(store.dir, 'segments.db') if store.dir else None)
+                return HybridStore(segment_store=segment_store, vector_store=store)
+            return store
+        cfg = dict(store)
+        if cfg.get('indices'):
+            indices = cfg.pop('indices')
+            index_config = indices.get('smart_embedding_index')
+            if not index_config or not index_config.get('backend'):
+                raise ValueError('smart_embedding_index backend is required')
+            cfg = {'type': index_config['backend'], 'kwargs': index_config.get('kwargs', {})}
+        if 'type' in cfg:
+            store_cls = getattr(lazyllm.store, cfg['type'], None)
+            if not store_cls:
+                raise NotImplementedError(f'Not implemented store type: {cfg["type"]}')
+            impl = store_cls(**cfg.get('kwargs', {}))
+            if impl.capability == StoreCapability.VECTOR:
+                path = Path(impl.dir) if impl.dir else None
+                uri = str(path.with_name(f'lazyllm_{path.stem}_segments.db')) if path else None
+                return HybridStore(segment_store=MapStore(uri=uri), vector_store=impl)
+            return impl
+        seg_cfg = cfg.get('segment_store') or {}
+        vec_cfg = cfg.get('vector_store') or {}
+
+        def make(value):
+            return getattr(lazyllm.store, value['type'])(**value.get('kwargs', {})) if value else None
+        segment, vector = make(seg_cfg), make(vec_cfg)
+        if segment and vector:
+            return HybridStore(segment_store=segment, vector_store=vector)
+        if segment:
+            return segment
+        if vector:
+            path = Path(vector.dir) if vector.dir else None
+            uri = str(path.with_name(f'lazyllm_{path.stem}_segments.db')) if path else None
+            return HybridStore(segment_store=MapStore(uri=uri),
+                               vector_store=vector)
+        raise ValueError('Provide either type or segment_store/vector_store config')
+
+    @classmethod
+    def normalize_collection_name(cls, raw_name: str) -> str:
+        normalized = cls._COLLECTION_NAME_PATTERN.sub('_', raw_name.lower()).strip('_') or 'col'
+        if normalized[0].isdigit():
+            normalized = f'col_{normalized}'
+        if normalized == raw_name and len(normalized) <= cls._COLLECTION_NAME_MAX_LEN:
+            return normalized
+        digest = hashlib.sha1(raw_name.encode()).hexdigest()[:12]
+        prefix = normalized[:cls._COLLECTION_NAME_MAX_LEN - 13].rstrip('_') or 'col'
+        return f'{prefix}_{digest}'
+
+    def connect(self):
+        if not self._connected:
+            target = getattr(self.backend, 'segment_store', self.backend)
+            target.connect(global_metadata_desc=self._global_metadata_desc)
+            self._connected = True
+        return self
+
+    @property
+    def _segment_backend(self):
+        self.connect()
+        return getattr(self.backend, 'segment_store', self.backend)
+
+    @staticmethod
+    def _to_raw(item: Dict[str, Any]) -> dict:
+        metadata = dict(item.get('metadata') or {})
+        user_id = metadata.get('user_id')
+        return {
+            'uid': item['id'], 'doc_id': item['id'], 'group': 'segment',
+            'content': item.get('content', ''), 'meta': metadata,
+            'global_meta': metadata, 'kb_id': user_id or '__default__',
+            'number': int(metadata.get('hit_count', 0)), 'type': 1,
+        }
+
+    @staticmethod
+    def _from_raw(item: dict) -> dict:
+        metadata = dict(item.get('meta') or item.get('global_meta') or {})
+        metadata.setdefault('user_id', item.get('kb_id'))
+        metadata['hit_count'] = int(item.get('number', metadata.get('hit_count', 0)) or 0)
+        result = {'id': item.get('uid'), 'content': item.get('content', ''), 'metadata': metadata}
+        if 'score' in item:
+            result['score'] = float(item['score'] or 0)
+        return result
+
+    @staticmethod
+    def _filters(filters: Optional[dict]) -> dict:
+        result = dict(filters or {})
+        if 'id' in result:
+            value = result.pop('id')
+            result['uid'] = value if isinstance(value, (list, set, tuple)) else [value]
+        if 'user_id' in result:
+            result['kb_id'] = result.pop('user_id')
+        return result
+
+    def create_collection(self, name: str) -> bool:
+        return bool(self._segment_backend.create_collection(self.normalize_collection_name(name)))
+
+    def drop_collection(self, name: str) -> bool:
+        return bool(self._segment_backend.drop_collection(self.normalize_collection_name(name)))
+
+    def collection_exists(self, name: str) -> bool:
+        return bool(self._segment_backend.collection_exists(self.normalize_collection_name(name)))
+
+    def create(self, name: str, data: List[dict]) -> bool:
+        try:
+            return bool(self._segment_backend.create(
+                self.normalize_collection_name(name), [self._to_raw(item) for item in data],
+            ))
+        except NotImplementedError as exc:
+            raise SegmentStoreUnsupportedError(str(exc)) from exc
+        except FileExistsError as exc:
+            raise SegmentStoreConflictError(str(exc)) from exc
+
+    def upsert(self, name: str, data: List[dict]) -> bool:
+        return bool(self._segment_backend.upsert(
+            self.normalize_collection_name(name), [self._to_raw(item) for item in data],
+        ))
+
+    def get(self, name: str, filters: dict) -> List[dict]:
+        return [self._from_raw(item) for item in self._segment_backend.get(
+            self.normalize_collection_name(name), self._filters(filters))]
+
+    def search(self, name: str, query: str, *, topk: int = 10,
+               filters: Optional[dict] = None) -> List[dict]:
+        return [self._from_raw(item) for item in self._segment_backend.search(
+            self.normalize_collection_name(name), query=query, topk=topk,
+            filters=self._filters(filters))]
+
+    def patch(self, name: str, filters: dict, *, set_fields=None, inc_fields=None) -> int:
+        mapped_set = dict(set_fields or {})
+        mapped_inc = dict(inc_fields or {})
+        if 'hit_count' in mapped_set:
+            mapped_set['number'] = mapped_set.pop('hit_count')
+        if 'hit_count' in mapped_inc:
+            mapped_inc['number'] = mapped_inc.pop('hit_count')
+        try:
+            return self._segment_backend.patch(self.normalize_collection_name(name), self._filters(filters),
+                                               mapped_set, mapped_inc)
+        except NotImplementedError as exc:
+            raise SegmentStoreUnsupportedError(str(exc)) from exc
+
+    def delete(self, name: str, filters: dict) -> bool:
+        return bool(self._segment_backend.delete(self.normalize_collection_name(name), self._filters(filters)))

--- a/lazyllm/tools/rag/store/segment_store.py
+++ b/lazyllm/tools/rag/store/segment_store.py
@@ -160,10 +160,36 @@ class SegmentStore:
             self.normalize_collection_name(name), self._filters(filters))]
 
     def search(self, name: str, query: str, *, topk: int = 10,
-               filters: Optional[dict] = None) -> List[dict]:
-        return [self._from_raw(item) for item in self._segment_backend.search(
+               filters: Optional[dict] = None, query_fields: Optional[List[str]] = None,
+               match_mode: Optional[str] = None) -> List[dict]:
+        search_options = {}
+        if query_fields is not None:
+            if not isinstance(query_fields, list) or not query_fields:
+                raise ValueError('query_fields must be a non-empty list of field names')
+            if any(not isinstance(field, str) or not field.strip() for field in query_fields):
+                raise ValueError('query_fields must contain only non-empty field names')
+            normalized_fields = [field.strip() for field in query_fields]
+            search_options['query_fields'] = normalized_fields
+        if match_mode is not None:
+            if match_mode not in ('any', 'all'):
+                raise ValueError("match_mode must be 'any', 'all', or None")
+            search_options['match_mode'] = match_mode
+        backend = self._segment_backend
+        if search_options and not getattr(backend, 'supports_query_fields_match_mode', False):
+            raise SegmentStoreUnsupportedError(
+                f'{type(backend).__name__} does not support query_fields/match_mode'
+            )
+        supported_fields = getattr(backend, 'supported_query_fields', None)
+        if query_fields is not None and supported_fields is not None:
+            unsupported_fields = set(normalized_fields) - set(supported_fields)
+            if unsupported_fields:
+                raise SegmentStoreUnsupportedError(
+                    f'{type(backend).__name__} does not support query fields: '
+                    f'{sorted(unsupported_fields)!r}'
+                )
+        return [self._from_raw(item) for item in backend.search(
             self.normalize_collection_name(name), query=query, topk=topk,
-            filters=self._filters(filters))]
+            filters=self._filters(filters), **search_options)]
 
     def patch(self, name: str, filters: dict, *, set_fields=None, inc_fields=None) -> int:
         mapped_set = dict(set_fields or {})

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -96,6 +96,27 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
     need_embedding: bool = True
     supports_index_registration: bool = False
 
+    def create(self, collection_name: str, data: List[dict]) -> bool:
+        '''Create records without overwriting existing primary keys.
+
+        Backends opt in by overriding this method.  Keeping it non-abstract
+        preserves compatibility with third-party stores.
+        '''
+        raise NotImplementedError(f'{type(self).__name__} does not support create-only writes')
+
+    def patch(self, collection_name: str, criteria: dict,
+              set_fields: Optional[Dict[str, Any]] = None,
+              inc_fields: Optional[Dict[str, Union[int, float]]] = None) -> int:
+        '''Atomically patch matching records and return the affected count.'''
+        raise NotImplementedError(f'{type(self).__name__} does not support atomic patch')
+
+    def create_collection(self, collection_name: str) -> bool:
+        '''Create a collection when supported; lazy backends may no-op.'''
+        return True
+
+    def drop_collection(self, collection_name: str) -> bool:
+        return self.delete(collection_name, None)
+
     @property
     def dir(self):
         raise NotImplementedError

--- a/tests/basic_tests/RAG/test_segment_store_facade.py
+++ b/tests/basic_tests/RAG/test_segment_store_facade.py
@@ -7,6 +7,7 @@ from lazyllm.tools.rag.store import (
     SegmentStore,
     SegmentStoreConflictError,
     SegmentStoreUnsupportedError,
+    SQLiteStore,
 )
 
 
@@ -25,6 +26,16 @@ class _FakeOpenSearchClient:
         return {'hits': {'hits': []}}
 
 
+class _FailingOpenSearchIndices:
+    @staticmethod
+    def exists(index):
+        raise ConnectionError(f'OpenSearch unavailable for {index}')
+
+
+class _FailingOpenSearchClient:
+    indices = _FailingOpenSearchIndices()
+
+
 class _LegacySearchBackend:
     def __init__(self):
         self.calls = []
@@ -36,6 +47,23 @@ class _LegacySearchBackend:
             'topk': topk,
             'filters': filters,
         })
+        return []
+
+
+class _StrictReadBackend:
+    def __init__(self):
+        self.strict_values = []
+
+    def get(self, collection_name, filters, *, raise_on_error=False):
+        self.strict_values.append(raise_on_error)
+        if raise_on_error:
+            raise ConnectionError('segment backend unavailable')
+        return []
+
+    def search(self, collection_name, query=None, topk=10, filters=None, *, raise_on_error=False):
+        self.strict_values.append(raise_on_error)
+        if raise_on_error:
+            raise ConnectionError('segment search backend unavailable')
         return []
 
 
@@ -71,8 +99,12 @@ def test_sqlite_facade_create_scope_search_and_increment(tmp_path):
     assert store.search('episodes', 'segmentstore', filters={'user_id': 'user-1'})
     assert store.patch('episodes', {'id': 'ep-1', 'user_id': 'user-1'},
                        inc_fields={'hit_count': 1}) == 1
-    stored = store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'})[0]
+    stored = store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'}, strict=True)[0]
     assert stored['metadata']['hit_count'] == 1
+    assert store.delete('episodes', {'user_id': 'user-2'}) is True
+    assert store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'}, strict=True)
+    assert store.delete('episodes', {'user_id': 'user-1'}) is True
+    assert store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'}, strict=True) == []
 
 
 def test_facade_default_search_keeps_legacy_backend_signature_compatible():
@@ -87,6 +119,72 @@ def test_facade_default_search_keeps_legacy_backend_signature_compatible():
         'topk': 10,
         'filters': {'kb_id': 'user-1'},
     }]
+
+
+def test_facade_strict_get_propagates_backend_read_failure():
+    backend = _StrictReadBackend()
+    store = _facade_with_connected_backend(backend)
+
+    assert store.get('episodes', {'user_id': 'user-1'}) == []
+    with pytest.raises(ConnectionError, match='segment backend unavailable'):
+        store.get('episodes', {'user_id': 'user-1'}, strict=True)
+
+    assert backend.strict_values == [False, True]
+
+
+def test_facade_strict_search_propagates_backend_read_failure():
+    backend = _StrictReadBackend()
+    store = _facade_with_connected_backend(backend)
+
+    assert store.search('episodes', 'mars') == []
+    with pytest.raises(ConnectionError, match='segment search backend unavailable'):
+        store.search('episodes', 'mars', strict=True)
+
+    assert backend.strict_values == [False, True]
+
+
+def test_sqlite_strict_get_propagates_backend_read_failure(monkeypatch, tmp_path):
+    backend = SQLiteStore(db_path=str(tmp_path / 'strict-read.db'))
+    monkeypatch.setattr(
+        backend,
+        '_open_conn',
+        lambda: (_ for _ in ()).throw(ConnectionError('SQLite unavailable')),
+    )
+
+    assert backend.get('episodes') == []
+    with pytest.raises(ConnectionError, match='SQLite unavailable'):
+        backend.get('episodes', raise_on_error=True)
+
+
+def test_sqlite_strict_search_propagates_backend_read_failure(monkeypatch, tmp_path):
+    backend = SQLiteStore(db_path=str(tmp_path / 'strict-search.db'))
+    monkeypatch.setattr(
+        backend,
+        '_open_conn',
+        lambda: (_ for _ in ()).throw(ConnectionError('SQLite search unavailable')),
+    )
+
+    assert backend.search('episodes', query='mars') == []
+    with pytest.raises(ConnectionError, match='SQLite search unavailable'):
+        backend.search('episodes', query='mars', raise_on_error=True)
+
+
+def test_opensearch_strict_get_propagates_backend_read_failure():
+    backend = OpenSearchStore(uris=['http://localhost:9200'])
+    backend._client = _FailingOpenSearchClient()
+
+    assert backend.get('episodes') == []
+    with pytest.raises(ConnectionError, match='OpenSearch unavailable'):
+        backend.get('episodes', raise_on_error=True)
+
+
+def test_opensearch_strict_search_propagates_backend_read_failure():
+    backend = OpenSearchStore(uris=['http://localhost:9200'])
+    backend._client = _FailingOpenSearchClient()
+
+    assert backend.search('episodes', query='mars') == []
+    with pytest.raises(ConnectionError, match='OpenSearch unavailable'):
+        backend.search('episodes', query='mars', raise_on_error=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/basic_tests/RAG/test_segment_store_facade.py
+++ b/tests/basic_tests/RAG/test_segment_store_facade.py
@@ -1,0 +1,55 @@
+import pytest
+from concurrent.futures import ThreadPoolExecutor
+
+from lazyllm.tools.rag.store import MapStore, SegmentStore, SegmentStoreConflictError
+
+
+def test_sqlite_facade_create_scope_search_and_increment(tmp_path):
+    store = SegmentStore({'type': 'SQLiteStore', 'kwargs': {'db_path': str(tmp_path / 'segments.db')}})
+    row = {
+        'id': 'ep-1',
+        'content': '用户 决定 segmentstore',
+        'metadata': {'user_id': 'user-1', 'summary': '用户决定', 'hit_count': 0},
+    }
+    assert store.create('episodes', [row]) is True
+    with pytest.raises(SegmentStoreConflictError):
+        store.create('episodes', [row])
+    assert store.get('episodes', {'id': 'ep-1', 'user_id': 'user-2'}) == []
+    assert store.search('episodes', 'segmentstore', filters={'user_id': 'user-1'})
+    assert store.patch('episodes', {'id': 'ep-1', 'user_id': 'user-1'},
+                       inc_fields={'hit_count': 1}) == 1
+    stored = store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'})[0]
+    assert stored['metadata']['hit_count'] == 1
+
+
+def test_map_facade_enforces_tenant_filter():
+    store = SegmentStore(MapStore())
+    store.create('episodes', [
+        {'id': 'ep-1', 'content': 'segment store decision',
+         'metadata': {'user_id': 'user-1', 'hit_count': 0}},
+        {'id': 'ep-2', 'content': 'segment store decision',
+         'metadata': {'user_id': 'user-2', 'hit_count': 0}},
+    ])
+
+    result = store.search('episodes', 'segment store', filters={'user_id': 'user-1'})
+
+    assert [item['id'] for item in result] == ['ep-1']
+
+
+def test_sqlite_atomic_increment_is_not_lost(tmp_path):
+    store = SegmentStore({'type': 'SQLiteStore', 'kwargs': {'db_path': str(tmp_path / 'atomic.db')}})
+    store.create('episodes', [{
+        'id': 'ep-1', 'content': 'event',
+        'metadata': {'user_id': 'user-1', 'hit_count': 0},
+    }])
+
+    def increment_many(_):
+        for _ in range(25):
+            assert store.patch('episodes', {'id': 'ep-1', 'user_id': 'user-1'},
+                               inc_fields={'hit_count': 1}) == 1
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(increment_many, range(8)))
+
+    stored = store.get('episodes', {'id': 'ep-1', 'user_id': 'user-1'})[0]
+    assert stored['metadata']['hit_count'] == 200

--- a/tests/basic_tests/RAG/test_segment_store_facade.py
+++ b/tests/basic_tests/RAG/test_segment_store_facade.py
@@ -1,7 +1,60 @@
 import pytest
 from concurrent.futures import ThreadPoolExecutor
 
-from lazyllm.tools.rag.store import MapStore, SegmentStore, SegmentStoreConflictError
+from lazyllm.tools.rag.store import (
+    MapStore,
+    OpenSearchStore,
+    SegmentStore,
+    SegmentStoreConflictError,
+    SegmentStoreUnsupportedError,
+)
+
+
+class _FakeOpenSearchIndices:
+    @staticmethod
+    def exists(index):
+        return True
+
+
+class _FakeOpenSearchClient:
+    indices = _FakeOpenSearchIndices()
+
+    def search(self, index, body):
+        self.index = index
+        self.body = body
+        return {'hits': {'hits': []}}
+
+
+class _LegacySearchBackend:
+    def __init__(self):
+        self.calls = []
+
+    def search(self, collection_name, query=None, topk=10, filters=None):
+        self.calls.append({
+            'collection_name': collection_name,
+            'query': query,
+            'topk': topk,
+            'filters': filters,
+        })
+        return []
+
+
+def _facade_with_connected_backend(backend):
+    store = SegmentStore.__new__(SegmentStore)
+    store.backend = backend
+    store._connected = True
+    return store
+
+
+@pytest.fixture
+def opensearch_facade():
+    backend = OpenSearchStore(uris=['http://localhost:9200'])
+    client = _FakeOpenSearchClient()
+    backend._client = client
+    backend._global_metadata_desc = {}
+    store = SegmentStore(backend)
+    store._connected = True
+    return store, client
 
 
 def test_sqlite_facade_create_scope_search_and_increment(tmp_path):
@@ -22,6 +75,53 @@ def test_sqlite_facade_create_scope_search_and_increment(tmp_path):
     assert stored['metadata']['hit_count'] == 1
 
 
+def test_facade_default_search_keeps_legacy_backend_signature_compatible():
+    backend = _LegacySearchBackend()
+    store = _facade_with_connected_backend(backend)
+
+    assert store.search('episodes', 'mars', filters={'user_id': 'user-1'}) == []
+
+    assert backend.calls == [{
+        'collection_name': 'episodes',
+        'query': 'mars',
+        'topk': 10,
+        'filters': {'kb_id': 'user-1'},
+    }]
+
+
+@pytest.mark.parametrize(
+    ('query_fields', 'match_mode'),
+    [([], None), ([''], None), ([None], None), ([123], None), (None, 'invalid')],
+)
+def test_facade_rejects_invalid_explicit_search_contract(query_fields, match_mode):
+    store = _facade_with_connected_backend(_LegacySearchBackend())
+
+    with pytest.raises(ValueError):
+        store.search(
+            'episodes',
+            'mars',
+            query_fields=query_fields,
+            match_mode=match_mode,
+        )
+
+
+def test_facade_rejects_explicit_search_contract_on_unsupported_backend():
+    store = SegmentStore(MapStore())
+
+    with pytest.raises(SegmentStoreUnsupportedError):
+        store.search('episodes', 'mars apple', query_fields=['content'], match_mode='all')
+
+
+def test_sqlite_facade_rejects_unsupported_query_field(tmp_path):
+    store = SegmentStore({
+        'type': 'SQLiteStore',
+        'kwargs': {'db_path': str(tmp_path / 'unsupported-field.db')},
+    })
+
+    with pytest.raises(SegmentStoreUnsupportedError):
+        store.search('episodes', 'mars', query_fields=['definitely_missing_field'])
+
+
 def test_map_facade_enforces_tenant_filter():
     store = SegmentStore(MapStore())
     store.create('episodes', [
@@ -34,6 +134,121 @@ def test_map_facade_enforces_tenant_filter():
     result = store.search('episodes', 'segment store', filters={'user_id': 'user-1'})
 
     assert [item['id'] for item in result] == ['ep-1']
+
+
+def test_sqlite_facade_supports_any_term_search(tmp_path):
+    store = SegmentStore({'type': 'SQLiteStore', 'kwargs': {'db_path': str(tmp_path / 'any.db')}})
+    store.create('episodes', [
+        {'id': 'ep-both', 'content': 'mars apple', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-mars', 'content': 'mars banana', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-apple', 'content': 'venus apple', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-other-user', 'content': 'mars apple', 'metadata': {'user_id': 'user-2'}},
+    ])
+
+    result = store.search(
+        'episodes', 'mars apple', filters={'user_id': 'user-1'},
+        query_fields=['content'], match_mode='any',
+    )
+
+    assert {item['id'] for item in result} == {'ep-both', 'ep-mars', 'ep-apple'}
+
+
+def test_sqlite_facade_keeps_default_all_term_behavior(tmp_path):
+    store = SegmentStore({'type': 'SQLiteStore', 'kwargs': {'db_path': str(tmp_path / 'default.db')}})
+    store.create('episodes', [
+        {'id': 'ep-both', 'content': 'mars apple', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-mars', 'content': 'mars banana', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-apple', 'content': 'venus apple', 'metadata': {'user_id': 'user-1'}},
+    ])
+
+    result = store.search('episodes', 'mars apple', filters={'user_id': 'user-1'})
+
+    assert [item['id'] for item in result] == ['ep-both']
+
+
+def test_sqlite_facade_safely_matches_all_terms(tmp_path):
+    store = SegmentStore({'type': 'SQLiteStore', 'kwargs': {'db_path': str(tmp_path / 'all.db')}})
+    store.create('episodes', [
+        {'id': 'ep-match', 'content': 'EPTEST-A42 mars', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-identifier', 'content': 'EPTEST-A42 venus', 'metadata': {'user_id': 'user-1'}},
+        {'id': 'ep-term', 'content': 'mars', 'metadata': {'user_id': 'user-1'}},
+    ])
+
+    result = store.search(
+        'episodes', 'EPTEST-A42 mars', filters={'user_id': 'user-1'},
+        query_fields=['content'], match_mode='all',
+    )
+
+    assert [item['id'] for item in result] == ['ep-match']
+
+
+@pytest.mark.parametrize(('match_mode', 'operator'), [('any', 'or'), ('all', 'and')])
+def test_opensearch_facade_scopes_text_search_to_content_and_filters(
+    opensearch_facade, match_mode, operator,
+):
+    store, client = opensearch_facade
+
+    assert store.search(
+        'episodes', 'mars apple', filters={'user_id': 'user-1'},
+        query_fields=['content'], match_mode=match_mode,
+    ) == []
+
+    bool_query = client.body['query']['bool']
+    assert bool_query['must'] == [{
+        'multi_match': {
+            'query': 'mars apple',
+            'fields': ['content'],
+            'operator': operator,
+        },
+    }]
+    assert bool_query['filter'] == [{
+        'bool': {
+            'should': [
+                {'term': {'kb_id': 'user-1'}},
+                {'term': {'kb_id.keyword': 'user-1'}},
+            ],
+            'minimum_should_match': 1,
+        },
+    }]
+
+
+def test_opensearch_facade_keeps_default_search_options(opensearch_facade):
+    store, client = opensearch_facade
+
+    assert store.search('episodes', 'mars apple') == []
+
+    assert client.body['query']['bool'] == {'must': [{
+        'multi_match': {
+            'query': 'mars apple',
+            'fields': ['*'],
+        },
+    }]}
+
+
+def test_opensearch_facade_keeps_default_filter_scoring_semantics(opensearch_facade):
+    store, client = opensearch_facade
+
+    assert store.search(
+        'episodes', 'mars apple', filters={'user_id': 'user-1'},
+    ) == []
+
+    assert client.body['query']['bool'] == {'must': [
+        {
+            'multi_match': {
+                'query': 'mars apple',
+                'fields': ['*'],
+            },
+        },
+        {
+            'bool': {
+                'should': [
+                    {'term': {'kb_id': 'user-1'}},
+                    {'term': {'kb_id.keyword': 'user-1'}},
+                ],
+                'minimum_should_match': 1,
+            },
+        },
+    ]}
 
 
 def test_sqlite_atomic_increment_is_not_lost(tmp_path):

--- a/tests/basic_tests/RAG/test_store.py
+++ b/tests/basic_tests/RAG/test_store.py
@@ -68,6 +68,18 @@ def _contains_array_term(query, field):
 
 
 class TestSegmentStoreCriteria(unittest.TestCase):
+    def test_opensearch_keeps_tenant_filter_with_uid(self):
+        store = OpenSearchStore(uris=['http://localhost:9200'])
+
+        criteria = store._construct_criteria({'uid': ['ep-1'], 'kb_id': 'user-1'})
+
+        must = criteria['query']['bool']['must']
+        self.assertIn({'ids': {'values': ['ep-1']}}, must)
+        self.assertTrue(any(
+            clause.get('bool', {}).get('minimum_should_match') == 1
+            for clause in must
+        ))
+
     def test_opensearch_uses_terms_for_parent_and_number_lists(self):
         store = OpenSearchStore(uris=['http://localhost:9200'])
 


### PR DESCRIPTION
# 🚀 Feature

## Feature Description
Add `SegmentStore` as the public facade for persistent text segments outside the `Document` lifecycle, with canonical records, create-only writes, tenant-scoped reads/search/deletes, and atomic updates.

## Feature Details
- [x] Add a lazily connected facade over segment backends with normalized collection names and `id/content/metadata` records
- [x] Support create-only conflict handling, BM25 field/match options, atomic `hit_count` patches, and tenant filters
- [x] Add opt-in strict `get` and `search` semantics for SQLiteStore and OpenSearchStore while preserving default fail-soft behavior

## Use Cases
Domain modules such as Episode Memory can depend on one stable text-segment API and inject either SQLiteStore or OpenSearchStore without depending on backend-specific record layouts.

## Technical Implementation
- The facade translates canonical records and filters to LazyLLM segment-store fields.
- SQLiteStore provides FTS5 search and atomic SQL increments; OpenSearchStore uses create operations, filtered queries, and atomic update scripts.
- `strict=True` is translated to `raise_on_error=True` only for explicit strict reads; default callers remain compatible.
- ElasticsearchStore is intentionally unchanged.

## Test Coverage
- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

`tests/basic_tests/RAG/test_segment_store_facade.py`: 24 passed.

## Documentation Updates
- [x] API documentation
- [ ] User guide
- [x] Example code

English and Chinese SegmentStore API pages, navigation, and registered public API documentation are included.

## Backward Compatibility
- [x] Fully compatible
- [ ] Migration required
- [ ] Breaking changes

Strict error propagation is opt-in; existing reads and searches keep fail-soft defaults.

## Performance Impact
- Atomic patches avoid read-modify-write races.
- Lazy backend connection is retained; no additional work is added to existing callers unless they use the new facade.

## Related Issues
None.

---

## Change Type
- [x] Feature addition
- [x] Bug fix
- [ ] Performance optimization
- [ ] Code refactoring
- [x] Documentation update
- [x] Testing related
- [ ] Security fix

## Impact Scope
- [ ] User interface
- [x] API interface
- [x] Database
- [ ] Configuration files
- [ ] Dependencies

## Priority
- [ ] High - Release immediately
- [x] Medium - Next version
- [ ] Low - Future version

## Release Notes Points
- Adds the public `SegmentStore` facade with SQLiteStore and OpenSearchStore support.
- Adds optional strict reads/searches and atomic numeric patches.
- No configuration changes or data migration are required.
- ElasticsearchStore is not changed by this PR.
