### PR TITLE
feat(rag): add generic segment store capabilities

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -8730,7 +8730,7 @@ Args:
     query (Optional[str]): Query string.
     topk (Optional[int]): Number of nearest neighbors.
     filters (Optional[dict]): Metadata filter map.
-    kwargs: Other search parameters
+    **kwargs: Other search parameters
 
 **Returns:**\n
 - List[dict]: Return matching results list and similarity 'score'.
@@ -8743,7 +8743,7 @@ Args:
     query (Optional[str]): 查询字符串。
     topk (Optional[int]): 返回邻近数量。
     filters (Optional[dict]): 元数据过滤映射。
-    kwargs: 其他搜索参数
+    **kwargs: 其他搜索参数
 
 **Returns:**\n
 - List[dict]: 返回匹配结果列表及相似度 'score'。
@@ -9496,3 +9496,61 @@ Returns:
 """)
 
 
+add_chinese_doc('rag.store.create_segment_store', """\
+构造文本切片存储 Adapter。
+
+该函数接收 ``LazyLLMStoreBase`` 实例或 ``type/kwargs`` 配置，验证结果具备
+``StoreCapability.SEGMENT`` 后直接返回具体 Adapter；不会包装、连接或组合存储。
+""")
+
+add_english_doc('rag.store.create_segment_store', """\
+Construct a text-segment store adapter.
+
+The function accepts a ``LazyLLMStoreBase`` instance or a ``type/kwargs`` configuration,
+validates ``StoreCapability.SEGMENT``, and returns the concrete adapter without wrapping,
+connecting, or composing stores.
+""")
+
+add_chinese_doc('rag.store.LazyLLMStoreBase.create', """\
+仅创建新切片，不覆盖已有主键。SQLite、OpenSearch 和 Elasticsearch Adapter
+在主键冲突时统一抛出 ``FileExistsError``；其他 Store 可不实现该可选能力。
+除非具体后端另有说明，批量创建不承诺跨记录事务。
+""")
+
+add_english_doc('rag.store.LazyLLMStoreBase.create', """\
+Create new segments without overwriting existing primary keys. SQLite, OpenSearch,
+and Elasticsearch adapters raise ``FileExistsError`` on conflict; other stores may
+leave this optional operation unsupported. Batch creation is not transactional across
+records unless a concrete backend documents otherwise.
+""")
+
+add_chinese_doc('rag.store.LazyLLMStoreBase.increment_counters', """\
+按条件原子增加一个或多个命名计数器。SQLite、OpenSearch 和 Elasticsearch
+Adapter 支持该能力，其他 Store 可通过 ``supports_counters`` 判断。
+""")
+
+add_english_doc('rag.store.LazyLLMStoreBase.increment_counters', """\
+Atomically increment one or more named counters on matching records. SQLite, OpenSearch,
+and Elasticsearch adapters support this capability; inspect ``supports_counters`` for other stores.
+""")
+
+add_chinese_doc('rag.store.LazyLLMStoreBase.get', """\
+读取切片。持久化 Segment Adapter 默认保持失败时返回空结果的兼容行为；传入
+``raise_on_error=True`` 可让 SQLite、OpenSearch 和 Elasticsearch 传播读取异常。
+""")
+
+add_english_doc('rag.store.LazyLLMStoreBase.get', """\
+Read segments. Persistent segment adapters preserve fail-soft empty results by default;
+pass ``raise_on_error=True`` to propagate SQLite, OpenSearch, and Elasticsearch read errors.
+""")
+
+add_chinese_doc('rag.store.LazyLLMStoreBase.search', """\
+检索切片。SQLite、OpenSearch 和 Elasticsearch 支持 ``query_fields``、
+``match_mode='any'|'all'`` 和 ``raise_on_error=True``；过滤条件独立于文本匹配。
+""")
+
+add_english_doc('rag.store.LazyLLMStoreBase.search', """\
+Search segments. SQLite, OpenSearch, and Elasticsearch support ``query_fields``,
+``match_mode='any'|'all'``, and ``raise_on_error=True`` while keeping filters separate
+from text matching.
+""")

--- a/lazyllm/tools/rag/__init__.py
+++ b/lazyllm/tools/rag/__init__.py
@@ -23,7 +23,7 @@ from .dataReader import SimpleDirectoryReader, FileReader
 from .global_metadata import GlobalMetadataDesc as DocField
 from .data_type import DataType
 from .index_base import IndexBase
-from .store import LazyLLMStoreBase
+from .store import LazyLLMStoreBase, create_segment_store
 from .doc_to_db import SchemaExtractor
 from .query_enh_ac import QueryEnhACProcessor
 
@@ -83,6 +83,7 @@ __all__ = [
     'DocField',
     'DataType',
     'IndexBase',
+    'create_segment_store',
     'LazyLLMStoreBase',
     'FileReader',
     'CharacterSplitter',

--- a/lazyllm/tools/rag/store/__init__.py
+++ b/lazyllm/tools/rag/store/__init__.py
@@ -7,6 +7,7 @@ from .store_base import (
 )
 from .hybrid import HybridStore, MapStore, SenseCoreStore, OceanBaseStore
 from .segment import OpenSearchStore, ElasticSearchStore, SQLiteStore
+from .factory import create_segment_store
 from .vector import ChromaStore, MilvusStore
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     'OpenSearchStore',
     'ElasticSearchStore',
     'SQLiteStore',
+    'create_segment_store',
     'ChromaStore',
     'MilvusStore',
     'SenseCoreStore',
@@ -23,5 +25,5 @@ __all__ = [
     'LAZY_IMAGE_GROUP',
     'LAZY_ROOT_NAME',
     'EMBED_DEFAULT_KEY',
-    'BUILDIN_GLOBAL_META_DESC'
+    'BUILDIN_GLOBAL_META_DESC',
 ]

--- a/lazyllm/tools/rag/store/factory.py
+++ b/lazyllm/tools/rag/store/factory.py
@@ -1,0 +1,31 @@
+from typing import Any, Dict, Union
+
+import lazyllm
+
+from .store_base import LazyLLMStoreBase, StoreCapability
+
+
+def create_segment_store(
+    store: Union[Dict[str, Any], LazyLLMStoreBase],
+) -> LazyLLMStoreBase:
+    '''Construct or validate a segment-capable store without wrapping it.'''
+
+    if isinstance(store, LazyLLMStoreBase):
+        impl = store
+    elif isinstance(store, dict):
+        cfg = dict(store)
+        store_type = cfg.get('type')
+        if not store_type:
+            raise ValueError('Segment store config requires "type"')
+        store_cls = getattr(lazyllm.store, store_type, None)
+        if store_cls is None:
+            raise NotImplementedError(f'Not implemented store type: {store_type}')
+        impl = store_cls(**cfg.get('kwargs', {}))
+    else:
+        raise TypeError('store must be a LazyLLMStoreBase instance or config dict')
+
+    if not isinstance(impl, LazyLLMStoreBase):
+        raise TypeError(f'{type(impl).__name__} is not a LazyLLMStoreBase')
+    if not impl.capability & StoreCapability.SEGMENT:
+        raise ValueError(f'{type(impl).__name__} is not segment-capable')
+    return impl

--- a/lazyllm/tools/rag/store/segment/elasticsearch_store.py
+++ b/lazyllm/tools/rag/store/segment/elasticsearch_store.py
@@ -62,6 +62,7 @@ DEFAULT_MAPPING_BODY = {
             'excluded_llm_metadata_keys': {'type': 'keyword', 'store': True},
             'parent': {'type': 'keyword', 'store': True},
             'image_keys': {'type': 'keyword', 'store': True},
+            'counters': {'type': 'object', 'dynamic': True},
         },
     },
 }
@@ -71,6 +72,7 @@ class ElasticSearchStore(LazyLLMStoreBase):
     capability = StoreCapability.SEGMENT
     need_embedding = False
     supports_index_registration = False
+    supports_counters = True
 
     def __init__(
         self,
@@ -115,6 +117,7 @@ class ElasticSearchStore(LazyLLMStoreBase):
             self._global_metadata_desc = global_metadata_desc
 
             self._index_kwargs = self._adapt_mapping_for_global_metadata()
+            self._counter_mapping_indices = set()
 
             return True
         # connection failed exception handling
@@ -145,12 +148,77 @@ class ElasticSearchStore(LazyLLMStoreBase):
             LOG.error(f'[ElasticSearch - _ensure_index] Error creating index {index}: {e}')
             raise e
 
+    def create(self, collection_name, data):
+        if not data:
+            return True
+        self._ensure_counter_mapping(collection_name)
+        bulk_data = []
+        for segment in data:
+            segment = self._serialize_node(segment)
+            uid = segment.pop(self._primary_key, None)
+            bulk_data.append({'create': {'_index': collection_name, '_id': uid}})
+            bulk_data.append(segment)
+        response = self._client.bulk(index=collection_name, body=bulk_data, refresh='wait_for')
+        if response.get('errors'):
+            failures = [
+                item.get('create') or {}
+                for item in response.get('items', [])
+                if (item.get('create') or {}).get('status', 200) >= 300
+            ]
+            conflicts = [item for item in failures if item.get('status') == 409]
+            other_failures = [item for item in failures if item.get('status') != 409]
+            if other_failures:
+                raise RuntimeError(f'Elasticsearch create failed: {other_failures[:3]}')
+            if conflicts:
+                raise FileExistsError('segment primary key already exists')
+            raise RuntimeError(f'Elasticsearch create failed: {response.get("items", [])[:3]}')
+        return True
+
+    def increment_counters(self, collection_name, criteria, increments):
+        increments = self._validate_counters(increments, allow_empty=False)
+        self._ensure_counter_mapping(collection_name)
+        body = self._construct_criteria(criteria) or {'query': {'match_all': {}}}
+        body['script'] = {
+            'lang': 'painless',
+            'source': (
+                'if (ctx._source.counters == null) { ctx._source.counters = new HashMap(); } '
+                'for (entry in params.increments.entrySet()) { def k = entry.getKey(); '
+                'ctx._source.counters[k] = '
+                '(ctx._source.counters.containsKey(k) ? ctx._source.counters[k] : 0) '
+                '+ entry.getValue(); }'
+            ),
+            'params': {'increments': increments},
+        }
+        response = self._client.update_by_query(
+            index=collection_name, body=body, refresh=True, conflicts='abort',
+        )
+        if response.get('failures'):
+            raise RuntimeError(f'Elasticsearch counter increment failed: {response["failures"]}')
+        return int(response.get('updated', 0))
+
+    def _ensure_counter_mapping(self, collection_name):
+        self._ensure_index(collection_name)
+        ready = getattr(self, '_counter_mapping_indices', None)
+        if ready is None:
+            ready = self._counter_mapping_indices = set()
+        if collection_name in ready:
+            return
+        with self._ddl_lock:
+            mapping = self._client.indices.get_mapping(index=collection_name)
+            properties = mapping.get(collection_name, {}).get('mappings', {}).get('properties', {})
+            if 'counters' not in properties:
+                self._client.indices.put_mapping(
+                    index=collection_name,
+                    body={'properties': {'counters': {'type': 'object', 'dynamic': True}}},
+                )
+            ready.add(collection_name)
+
     @override
     def upsert(self, collection_name: str = None, data: List[Dict] = None) -> bool:
         if not data:
             return False
         try:
-            self._ensure_index(collection_name)
+            self._ensure_counter_mapping(collection_name)
             for i in range(0, len(data), INSERT_BATCH_SIZE):
                 bulk_data = []
                 batch_data = data[i: i + INSERT_BATCH_SIZE]
@@ -216,7 +284,7 @@ class ElasticSearchStore(LazyLLMStoreBase):
             return_total = kwargs.get('return_total', False)
             sort_by_number = kwargs.get('sort_by_number', False)
             # Query by primary key(mget)
-            if criteria and self._primary_key in criteria:
+            if criteria and self._primary_key in criteria and len(criteria) == 1:
                 vals = criteria.pop(self._primary_key)
                 if not isinstance(vals, list):
                     vals = [vals]
@@ -268,28 +336,36 @@ class ElasticSearchStore(LazyLLMStoreBase):
             return results
         except Exception as e:
             LOG.error(f'[ElasticsearchStore - get] Error getting data from Elasticsearch: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     @override
     def search(self, collection_name: str, query: str,
                topk: Optional[int] = 10, filters: Optional[dict] = None, **kwargs) -> List[Dict]:  # noqa: C901
-        query_fields = ['*']
+        query_fields, match_mode = self._validate_search_options(
+            kwargs.get('query_fields'), kwargs.get('match_mode'),
+        )
+        query_fields = query_fields or ['*']
         try:
             self._ensure_index(collection_name)
             must_clauses = []
             es_query = {}
-            text_query = {
-                'multi_match': {
-                    'query': query,
-                    'fields': query_fields,
-                }
-            }
+            multi_match = {'query': query, 'fields': query_fields}
+            if operator := {'any': 'or', 'all': 'and'}.get(match_mode):
+                multi_match['operator'] = operator
+            text_query = {'multi_match': multi_match}
             must_clauses.append(text_query)
 
             filter_query = self._construct_criteria(filters) if filters else {}
 
-            if must_clauses and filter_query:
-                # combine filter_query and must_clauses
+            explicit_search_contract = (
+                kwargs.get('query_fields') is not None or kwargs.get('match_mode') is not None
+            )
+            if must_clauses and filter_query and explicit_search_contract:
+                filter_clauses = filter_query['query']['bool']['must']
+                es_query = {'query': {'bool': {'must': must_clauses, 'filter': filter_clauses}}}
+            elif must_clauses and filter_query:
                 filter_must = filter_query['query']['bool']['must']
                 es_query = {'query': {'bool': {'must': must_clauses + filter_must}}}
             elif must_clauses:
@@ -313,11 +389,15 @@ class ElasticSearchStore(LazyLLMStoreBase):
 
         except Exception as e:
             LOG.error(f'[ElasticSearchStore - search] Error searching {collection_name}: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     def _serialize_node(self, segment: Dict) -> Dict:
         seg = dict(segment)
         seg.pop('embedding', None)
+        counters = seg.get('counters')
+        seg['counters'] = self._validate_counters({} if counters is None else counters)
 
         # Note: Insertion will fail if a dictionary(meta) has an excessively deep nesting level or overly long keys.
         if self._global_metadata_desc and self._global_metadata_desc == BUILDIN_GLOBAL_META_DESC:
@@ -328,6 +408,7 @@ class ElasticSearchStore(LazyLLMStoreBase):
 
     def _deserialize_node(self, segment: Dict) -> Dict:
         seg = dict(segment)
+        seg.setdefault('counters', {})
         if self._global_metadata_desc and self._global_metadata_desc == BUILDIN_GLOBAL_META_DESC:
             seg['meta'] = json.loads(seg.get('meta', '{}'))
             seg['global_meta'] = json.loads(seg.get('global_meta', '{}'))
@@ -342,7 +423,9 @@ class ElasticSearchStore(LazyLLMStoreBase):
             vals = criteria.pop(self._primary_key)
             if not isinstance(vals, list):
                 vals = [vals]
-            return {'query': {'ids': {'values': vals}}}
+            must_clauses = [{'ids': {'values': vals}}]
+        else:
+            must_clauses = []
 
         exact_match_fields = {'doc_id', 'kb_id', 'group', 'parent'}
 
@@ -361,7 +444,6 @@ class ElasticSearchStore(LazyLLMStoreBase):
                 must_clauses.append({'terms': {key: val}})
             else:
                 must_clauses.append({'term': {key: val}})
-        must_clauses = []
         if RAG_DOC_ID in criteria:
             val = criteria.pop(RAG_DOC_ID)
             _add_clause('doc_id', val)
@@ -433,7 +515,10 @@ class ElasticSearchStore(LazyLLMStoreBase):
 
         mapping = copy.deepcopy(DEFAULT_MAPPING_BODY)
         mapping['mappings']['dynamic'] = 'true'
-        props = {'uid': {'type': 'keyword'}}
+        props = {
+            'uid': {'type': 'keyword'},
+            'counters': {'type': 'object', 'dynamic': True},
+        }
         self._type2es = {
             DataType.VARCHAR: 'text',
             DataType.ARRAY: 'array',

--- a/lazyllm/tools/rag/store/segment/opensearch_store.py
+++ b/lazyllm/tools/rag/store/segment/opensearch_store.py
@@ -65,6 +65,7 @@ DEFAULT_MAPPING_BODY = {
             'excluded_llm_metadata_keys': {'type': 'keyword', 'store': True},
             'parent': {'type': 'keyword', 'store': True},
             'image_keys': {'type': 'keyword', 'store': True},
+            'counters': {'type': 'object', 'dynamic': True},
         }
     }
 }
@@ -73,6 +74,7 @@ DEFAULT_MAPPING_BODY = {
 class OpenSearchStore(LazyLLMStoreBase):
     capability = StoreCapability.SEGMENT
     need_embedding = False
+    supports_counters = True
     supports_index_registration = False
 
     def __init__(self, uris: List[str], client_kwargs: Optional[Dict] = None,
@@ -96,6 +98,7 @@ class OpenSearchStore(LazyLLMStoreBase):
         self._client = opensearchpy.OpenSearch(hosts=self._uris, **self._client_kwargs)
         self._global_metadata_desc = global_metadata_desc or {}
         self._index_kwargs = self._adapt_mapping_for_global_metadata()
+        self._counter_mapping_indices = set()
 
     def _ensure_index(self, name: str):
         if self._client.indices.exists(index=name):
@@ -112,11 +115,75 @@ class OpenSearchStore(LazyLLMStoreBase):
                 LOG.error(f'[OpenSearchStore - _ensure_index] Error creating index {name}: {e}')
                 raise e
 
+    def create(self, collection_name, data):
+        if not data:
+            return True
+        self._ensure_counter_mapping(collection_name)
+        bulk_data = []
+        for segment in data:
+            segment = self._serialize_node(segment)
+            bulk_data.append({'create': {'_index': collection_name, '_id': segment[self._primary_key]}})
+            bulk_data.append(segment)
+        response = self._client.bulk(index=collection_name, body=bulk_data, refresh='wait_for')
+        if response.get('errors'):
+            failures = [
+                item.get('create') or {}
+                for item in response.get('items', [])
+                if (item.get('create') or {}).get('status', 200) >= 300
+            ]
+            conflicts = [item for item in failures if item.get('status') == 409]
+            other_failures = [item for item in failures if item.get('status') != 409]
+            if other_failures:
+                raise RuntimeError(f'OpenSearch create failed: {other_failures[:3]}')
+            if conflicts:
+                raise FileExistsError('segment primary key already exists')
+            raise RuntimeError(f'OpenSearch create failed: {response.get("items", [])[:3]}')
+        return True
+
+    def increment_counters(self, collection_name, criteria, increments):
+        increments = self._validate_counters(increments, allow_empty=False)
+        self._ensure_counter_mapping(collection_name)
+        body = self._construct_criteria(criteria) or {'query': {'match_all': {}}}
+        body['script'] = {
+            'lang': 'painless',
+            'source': (
+                'if (ctx._source.counters == null) { ctx._source.counters = new HashMap(); } '
+                'for (entry in params.increments.entrySet()) { def k = entry.getKey(); '
+                'ctx._source.counters[k] = '
+                '(ctx._source.counters.containsKey(k) ? ctx._source.counters[k] : 0) '
+                '+ entry.getValue(); }'
+            ),
+            'params': {'increments': increments},
+        }
+        response = self._client.update_by_query(
+            index=collection_name, body=body, refresh=True, conflicts='abort',
+        )
+        if response.get('failures'):
+            raise RuntimeError(f'OpenSearch counter increment failed: {response["failures"]}')
+        return int(response.get('updated', 0))
+
+    def _ensure_counter_mapping(self, collection_name):
+        self._ensure_index(collection_name)
+        ready = getattr(self, '_counter_mapping_indices', None)
+        if ready is None:
+            ready = self._counter_mapping_indices = set()
+        if collection_name in ready:
+            return
+        with self._ddl_lock:
+            mapping = self._client.indices.get_mapping(index=collection_name)
+            properties = mapping.get(collection_name, {}).get('mappings', {}).get('properties', {})
+            if 'counters' not in properties:
+                self._client.indices.put_mapping(
+                    index=collection_name,
+                    body={'properties': {'counters': {'type': 'object', 'dynamic': True}}},
+                )
+            ready.add(collection_name)
+
     @override
     def upsert(self, collection_name: str, data: List[dict]) -> bool:
         if not data: return
         try:
-            self._ensure_index(collection_name)
+            self._ensure_counter_mapping(collection_name)
             for i in range(0, len(data), INSERT_BATCH_SIZE):
                 bulk_data = []
                 batch_data = data[i:i + INSERT_BATCH_SIZE]
@@ -175,7 +242,7 @@ class OpenSearchStore(LazyLLMStoreBase):
             offset = max(kwargs.get('offset', 0) or 0, 0)
             return_total = kwargs.get('return_total', False)
             sort_by_number = kwargs.get('sort_by_number', False)
-            if criteria and self._primary_key in criteria:
+            if criteria and self._primary_key in criteria and len(criteria) == 1:
                 vals = criteria.pop(self._primary_key)
                 if not isinstance(vals, list):
                     vals = [vals]
@@ -225,27 +292,36 @@ class OpenSearchStore(LazyLLMStoreBase):
             return results
         except Exception as e:
             LOG.error(f'[OpenSearchStore - get] Error getting data from OpenSearch: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     @override
     def search(self, collection_name: str, query: Optional[str] = None,
                topk: Optional[int] = 10, filters: Optional[dict] = None, **kwargs) -> List[dict]:  # noqa: C901
-        query_fields = ['*']
+        query_fields, match_mode = self._validate_search_options(
+            kwargs.get('query_fields'), kwargs.get('match_mode'),
+        )
+        query_fields = query_fields or ['*']
         try:
             self._ensure_index(collection_name)
             must_clauses = []
             os_query = {}
-            text_query = {
-                'multi_match': {
-                    'query': query,
-                    'fields': query_fields,
-                }
-            }
+            multi_match = {'query': query, 'fields': query_fields}
+            if operator := {'any': 'or', 'all': 'and'}.get(match_mode):
+                multi_match['operator'] = operator
+            text_query = {'multi_match': multi_match}
             must_clauses.append(text_query)
 
             filter_query = self._construct_criteria(filters) if filters else {}
 
-            if must_clauses and filter_query:
+            explicit_search_contract = (
+                kwargs.get('query_fields') is not None or kwargs.get('match_mode') is not None
+            )
+            if must_clauses and filter_query and explicit_search_contract:
+                filter_clauses = filter_query['query']['bool']['must']
+                os_query = {'query': {'bool': {'must': must_clauses, 'filter': filter_clauses}}}
+            elif must_clauses and filter_query:
                 filter_must = filter_query['query']['bool']['must']
                 os_query = {'query': {'bool': {'must': must_clauses + filter_must}}}
             elif must_clauses:
@@ -268,6 +344,8 @@ class OpenSearchStore(LazyLLMStoreBase):
 
         except Exception as e:
             LOG.error(f'[OpenSearchStore - search] Error searching data from OpenSearch: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     @override
@@ -313,6 +391,8 @@ class OpenSearchStore(LazyLLMStoreBase):
     def _serialize_node(self, segment: dict):
         seg = dict(segment)
         seg.pop('embedding', None)
+        counters = seg.get('counters')
+        seg['counters'] = self._validate_counters({} if counters is None else counters)
         if self._global_metadata_desc and self._global_metadata_desc == BUILDIN_GLOBAL_META_DESC:
             seg['global_meta'] = json.dumps(seg.get('global_meta', {}), ensure_ascii=False)
             seg['meta'] = json.dumps(seg.get('meta', {}), ensure_ascii=False)
@@ -321,6 +401,7 @@ class OpenSearchStore(LazyLLMStoreBase):
 
     def _deserialize_node(self, segment: dict) -> dict:
         seg = dict(segment)
+        seg.setdefault('counters', {})
         if self._global_metadata_desc and self._global_metadata_desc == BUILDIN_GLOBAL_META_DESC:
             meta = seg.get('meta', '{}')
             global_meta = seg.get('global_meta', '{}')
@@ -341,7 +422,9 @@ class OpenSearchStore(LazyLLMStoreBase):
             vals = criteria.pop(self._primary_key)
             if not isinstance(vals, list):
                 vals = [vals]
-            return {'query': {'ids': {'values': vals}}}
+            must_clauses = [{'ids': {'values': vals}}]
+        else:
+            must_clauses = []
 
         exact_match_fields = {'doc_id', 'kb_id', 'group', 'parent'}
 
@@ -360,7 +443,6 @@ class OpenSearchStore(LazyLLMStoreBase):
                 must_clauses.append({'terms': {key: val}})
             else:
                 must_clauses.append({'term': {key: val}})
-        must_clauses = []
         if RAG_DOC_ID in criteria:
             val = criteria.pop(RAG_DOC_ID)
             _add_clause('doc_id', val)
@@ -432,7 +514,10 @@ class OpenSearchStore(LazyLLMStoreBase):
 
         mapping = copy.deepcopy(DEFAULT_MAPPING_BODY)
         mapping['mappings']['dynamic'] = 'true'
-        props = {'uid': {'type': 'keyword'}}
+        props = {
+            'uid': {'type': 'keyword'},
+            'counters': {'type': 'object', 'dynamic': True},
+        }
         self._type2os = {
             DataType.VARCHAR: 'text',
             DataType.ARRAY: 'array',

--- a/lazyllm/tools/rag/store/segment/sqlite_store.py
+++ b/lazyllm/tools/rag/store/segment/sqlite_store.py
@@ -14,6 +14,8 @@ class SQLiteStore(LazyLLMStoreBase):
     capability = StoreCapability.SEGMENT
     need_embedding = False
     supports_index_registration = False
+    supports_counters = True
+    supported_query_fields = frozenset({'content'})
 
     _COLS = [('uid', 'TEXT PRIMARY KEY'),
              ('doc_id', 'TEXT NOT NULL'),
@@ -28,7 +30,8 @@ class SQLiteStore(LazyLLMStoreBase):
              ('excluded_llm_metadata_keys', 'TEXT'),
              ('parent', 'TEXT'),
              ('answer', 'TEXT'),
-             ('image_keys', 'TEXT')]
+             ('image_keys', 'TEXT'),
+             ('counters', "TEXT NOT NULL DEFAULT '{}'")]
     _COL_NAMES = [c[0] for c in _COLS]
     _COL_NAMES_SQL = ', '.join(_COL_NAMES)
     _COL_NAMES_FTS = ', '.join(f'm.{c}' for c in _COL_NAMES)
@@ -72,9 +75,84 @@ class SQLiteStore(LazyLLMStoreBase):
         self._ddl_lock = threading.Lock()
         self._open_conn()
 
+    def _collection_exists(self, collection_name):
+        row = self._open_conn().execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (collection_name,)
+        ).fetchone()
+        return bool(row)
+
+    def create(self, collection_name, data):
+        if not data:
+            return True
+        conn = None
+        try:
+            with self._ddl_lock:
+                conn = self._open_conn()
+                cur = conn.cursor()
+                self._ensure_table(cur, collection_name)
+                self._ensure_fts(cur, collection_name)
+                sql = (f'INSERT INTO "{collection_name}" ({self._COL_NAMES_SQL}) '
+                       f'VALUES ({self._COL_PLACEHOLDERS})')
+                cur.executemany(sql, [self._serialize_row(item) for item in data])
+                cur.executemany(f'INSERT INTO "{collection_name}_fts"(uid, content) VALUES (?, ?)',
+                                [(item['uid'], self._fts_content(item)) for item in data])
+                conn.commit()
+            return True
+        except sqlite3.IntegrityError as exc:
+            if conn is not None:
+                conn.rollback()
+            conflict_codes = {
+                getattr(sqlite3, 'SQLITE_CONSTRAINT_PRIMARYKEY', 1555),
+                getattr(sqlite3, 'SQLITE_CONSTRAINT_UNIQUE', 2067),
+            }
+            error_code = getattr(exc, 'sqlite_errorcode', None)
+            message = str(exc).casefold()
+            legacy_uid_conflict = (
+                error_code is None
+                and 'unique constraint failed' in message
+                and '.uid' in message
+            )
+            if error_code in conflict_codes or legacy_uid_conflict:
+                raise FileExistsError('segment primary key already exists') from exc
+            raise
+        except Exception:
+            if conn is not None:
+                conn.rollback()
+            raise
+
+    def increment_counters(self, collection_name, criteria, increments):
+        increments = self._validate_counters(increments, allow_empty=False)
+        if not self._collection_exists(collection_name):
+            return 0
+        paths_and_values = []
+        expressions = []
+        for name, value in increments.items():
+            path = f'$.{name}'
+            expressions.append(
+                "?, COALESCE(json_extract(COALESCE(counters, '{}'), ?), 0) + ?"
+            )
+            paths_and_values.extend((path, path, value))
+        with self._ddl_lock:
+            conn = self._open_conn()
+            cur = conn.cursor()
+            self._ensure_table(cur, collection_name)
+            where, args = self._build_where(criteria, preserve_falsey=True)
+            cur.execute(
+                f'''UPDATE "{collection_name}"
+                    SET counters = json_set(COALESCE(counters, '{{}}'), {", ".join(expressions)}){where}''',
+                tuple(paths_and_values) + args,
+            )
+            conn.commit()
+            return cur.rowcount
+
     def _ensure_table(self, cursor, table):
         col_defs = ', '.join(f'{name} {typ}' for name, typ in self._COLS)
         cursor.execute(f'CREATE TABLE IF NOT EXISTS "{table}" ({col_defs})')
+        columns = {row[1] for row in cursor.execute(f'PRAGMA table_info("{table}")')}
+        if 'counters' not in columns:
+            cursor.execute(
+                f'''ALTER TABLE "{table}" ADD COLUMN counters TEXT NOT NULL DEFAULT '{{}}' ''',
+            )
         for idx_col in self._INDEX_COLS:
             col_name = idx_col.strip('"')
             cursor.execute(f'CREATE INDEX IF NOT EXISTS idx_{table}_{col_name} ON "{table}"({idx_col})')
@@ -145,6 +223,9 @@ class SQLiteStore(LazyLLMStoreBase):
             cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (collection_name,))
             if not cur.fetchone():
                 return ([], 0) if kwargs.get('return_total') else []
+            with self._ddl_lock:
+                self._ensure_table(cur, collection_name)
+                conn.commit()
 
             limit = kwargs.get('limit')
             offset = max(kwargs.get('offset', 0) or 0, 0)
@@ -166,6 +247,8 @@ class SQLiteStore(LazyLLMStoreBase):
                     else [self._deserialize_row(r) for r in cur.fetchall()])
         except Exception as e:
             LOG.error(f'[SQLiteStore - get] Error: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return ([], 0) if kwargs.get('return_total') else []
 
     @override
@@ -204,15 +287,34 @@ class SQLiteStore(LazyLLMStoreBase):
 
     @override
     def search(self, collection_name, query=None, topk=10, filters=None, **kwargs):
+        self._validate_search_options(
+            kwargs.get('query_fields'), kwargs.get('match_mode'),
+            supported_fields=self.supported_query_fields,
+        )
         if not query: return []
         try:
             conn = self._open_conn()
             if not conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?",
                                 (collection_name,)).fetchone():
                 return []
+            with self._ddl_lock:
+                self._ensure_table(conn.cursor(), collection_name)
+                conn.commit()
 
             cmatch = f'"{collection_name}_fts" MATCH ?'
-            q = [query if query.endswith('*') else query + '*']
+            match_mode = kwargs.get('match_mode')
+            if match_mode in ('any', 'all'):
+                terms = query.split()
+                if not terms:
+                    return []
+                escaped_terms = []
+                for term in terms:
+                    escaped = term.replace('"', '""')
+                    escaped_terms.append(f'"{escaped}"*')
+                fts_query = (' OR ' if match_mode == 'any' else ' AND ').join(escaped_terms)
+            else:
+                fts_query = query if query.endswith('*') else query + '*'
+            q = [fts_query]
             if filters:
                 fw, fa = self._build_fts_filter_where(filters)
                 where = f'{cmatch} AND {fw}'
@@ -226,6 +328,8 @@ class SQLiteStore(LazyLLMStoreBase):
                     for r in conn.execute(sql, q + [topk]).fetchall()]
         except Exception as e:
             LOG.error(f'[SQLiteStore - search] Error: {e}')
+            if kwargs.get('raise_on_error'):
+                raise
             return []
 
     def _serialize_row(self, item):
@@ -240,7 +344,10 @@ class SQLiteStore(LazyLLMStoreBase):
                 json.dumps(item.get('excluded_embed_metadata_keys') or []),
                 json.dumps(item.get('excluded_llm_metadata_keys') or []),
                 item.get('parent'), item.get('answer', ''),
-                json.dumps(item.get('image_keys') or []))
+                json.dumps(item.get('image_keys') or []),
+                json.dumps(self._validate_counters(
+                    {} if item.get('counters') is None else item.get('counters'),
+                )))
 
     def _deserialize_row(self, row):
         gm = json.loads(row[5]) if row[5] else {}
@@ -250,7 +357,8 @@ class SQLiteStore(LazyLLMStoreBase):
                   'excluded_embed_metadata_keys': json.loads(row[9]) if row[9] else [],
                   'excluded_llm_metadata_keys': json.loads(row[10]) if row[10] else [],
                   'parent': row[11], 'answer': row[12],
-                  'image_keys': json.loads(row[13]) if row[13] else []}
+                  'image_keys': json.loads(row[13]) if row[13] else [],
+                  'counters': json.loads(row[14]) if len(row) > 14 and row[14] else {}}
         for k in self._global_metadata_desc:
             if k not in self._STD_KEYS and k in gm:
                 result[k] = gm[k]
@@ -264,12 +372,20 @@ class SQLiteStore(LazyLLMStoreBase):
     _STD_WHERE = {RAG_DOC_ID: 'doc_id', RAG_KB_ID: 'kb_id', 'parent': 'parent',
                   'number': 'number', 'uid': 'uid', 'doc_id': 'doc_id', 'kb_id': 'kb_id'}
 
-    def _build_where(self, criteria):
+    def _build_where(self, criteria, *, preserve_falsey=False):
         if not criteria: return '', ()
         clauses, args = [], []
         for field, vals in criteria.items():
-            if not vals: continue
-            if not isinstance(vals, (list, set, tuple)): vals = [vals]
+            if isinstance(vals, (list, set, tuple)):
+                vals = list(vals)
+                if not vals:
+                    if preserve_falsey:
+                        clauses.append('0')
+                    continue
+            else:
+                if not vals and not preserve_falsey:
+                    continue
+                vals = [vals]
             if lookup := self._STD_WHERE.get(field):
                 clauses.append(f'"{lookup}" IN ({",".join("?" * len(vals))})')
                 args.extend(vals)

--- a/lazyllm/tools/rag/store/store_base.py
+++ b/lazyllm/tools/rag/store/store_base.py
@@ -64,6 +64,7 @@ class Segment(BaseModel):
     answer: Optional[str] = ''
     image_keys: Optional[List[str]] = Field(default_factory=list)
     copy_source: Optional[Dict[str, str]] = Field(default_factory=dict)
+    counters: Dict[str, int] = Field(default_factory=dict)
 
 
 class StoreCapability(IntFlag):
@@ -95,6 +96,52 @@ class LazyLLMStoreBase(ABC, metaclass=LazyLLMRegisterMetaABCClass):
     capability: StoreCapability
     need_embedding: bool = True
     supports_index_registration: bool = False
+    supports_counters: bool = False
+    _COUNTER_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+    def create(self, collection_name: str, data: List[dict]) -> bool:
+        '''Create records without overwriting existing primary keys.
+
+        Backends opt in by overriding this method.  Keeping it non-abstract
+        preserves compatibility with third-party stores.  A batch is not a
+        transaction across records unless a concrete backend documents that.
+        '''
+        raise NotImplementedError(f'{type(self).__name__} does not support create-only writes')
+
+    def increment_counters(self, collection_name: str, criteria: dict,
+                           increments: Dict[str, int]) -> int:
+        '''Atomically increment named counters on every matching record.'''
+        raise NotImplementedError(f'{type(self).__name__} does not support named counters')
+
+    @classmethod
+    def _validate_counters(cls, counters: Dict[str, int], *, allow_empty: bool = True) -> Dict[str, int]:
+        if not isinstance(counters, dict):
+            raise ValueError('counters must be a dict')
+        if not counters and not allow_empty:
+            raise ValueError('counter increments must not be empty')
+        for name, value in counters.items():
+            if not isinstance(name, str) or not cls._COUNTER_NAME_PATTERN.fullmatch(name):
+                raise ValueError(f'invalid counter name: {name!r}')
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise ValueError(f'counter {name!r} must be an integer')
+        return dict(counters)
+
+    @staticmethod
+    def _validate_search_options(query_fields, match_mode, *, supported_fields=None):
+        normalized_fields = None
+        if query_fields is not None:
+            if not isinstance(query_fields, list) or not query_fields:
+                raise ValueError('query_fields must be a non-empty list of field names')
+            if any(not isinstance(field, str) or not field.strip() for field in query_fields):
+                raise ValueError('query_fields must contain only non-empty field names')
+            normalized_fields = [field.strip() for field in query_fields]
+            if supported_fields is not None:
+                unsupported = set(normalized_fields) - set(supported_fields)
+                if unsupported:
+                    raise ValueError(f'store does not support query fields: {sorted(unsupported)!r}')
+        if match_mode not in (None, 'any', 'all'):
+            raise ValueError("match_mode must be 'any', 'all', or None")
+        return normalized_fields, match_mode
 
     @property
     def dir(self):

--- a/tests/basic_tests/RAG/test_segment_store.py
+++ b/tests/basic_tests/RAG/test_segment_store.py
@@ -1,0 +1,464 @@
+import sqlite3
+import threading
+
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from lazyllm.tools.rag.store import (
+    BUILDIN_GLOBAL_META_DESC,
+    ChromaStore,
+    ElasticSearchStore,
+    MapStore,
+    OpenSearchStore,
+    SQLiteStore,
+    create_segment_store,
+)
+
+
+def _segment(uid='ep-1', *, user_id='user-1', content='mars apple'):
+    return {
+        'uid': uid,
+        'doc_id': uid,
+        'group': 'episode',
+        'content': content,
+        'meta': {'summary': content},
+        'global_meta': {},
+        'kb_id': user_id,
+        'counters': {'hit_count': 0, 'recall_count': 2},
+    }
+
+
+class _FakeIndices:
+    def __init__(self):
+        self.properties = {}
+        self.mapping_body = None
+
+    @staticmethod
+    def exists(index):
+        return True
+
+    def get_mapping(self, index):
+        return {index: {'mappings': {'properties': dict(self.properties)}}}
+
+    def put_mapping(self, index, body):
+        self.mapping_body = body
+        self.properties.update(body['properties'])
+
+
+class _FakeRemoteClient:
+    def __init__(self):
+        self.indices = _FakeIndices()
+        self.body = None
+        self.bulk_body = None
+        self.bulk_response = {'errors': False, 'items': []}
+        self.update_body = None
+
+    def search(self, index, body):
+        self.index = index
+        self.body = body
+        return {'hits': {'hits': []}}
+
+    def bulk(self, index, body, refresh):
+        self.bulk_body = body
+        return self.bulk_response
+
+    def update_by_query(self, index, body, refresh, conflicts):
+        self.update_body = body
+        return {'updated': 1, 'failures': []}
+
+
+class _FailingIndices:
+    @staticmethod
+    def exists(index):
+        raise ConnectionError(f'segment backend unavailable for {index}')
+
+
+class _FailingRemoteClient:
+    indices = _FailingIndices()
+
+
+def _remote_store(store_cls):
+    store = store_cls(uris=['http://localhost:9200'])
+    client = _FakeRemoteClient()
+    store._client = client
+    store._ddl_lock = threading.Lock()
+    store._global_metadata_desc = {}
+    return store, client
+
+
+def test_create_segment_store_returns_concrete_adapter_and_passes_instances_through(tmp_path):
+    store = create_segment_store({
+        'type': 'SQLiteStore',
+        'kwargs': {'db_path': str(tmp_path / 'factory.db')},
+    })
+    existing = MapStore()
+
+    assert isinstance(store, SQLiteStore)
+    assert not hasattr(store, 'backend')
+    assert create_segment_store(existing) is existing
+
+
+@pytest.mark.parametrize(
+    ('store_type', 'store_cls'),
+    [('opensearch', OpenSearchStore), ('elasticsearch', ElasticSearchStore)],
+)
+def test_create_segment_store_uses_registered_persistent_adapter_names(store_type, store_cls):
+    store = create_segment_store({
+        'type': store_type,
+        'kwargs': {'uris': ['http://localhost:9200']},
+    })
+
+    assert isinstance(store, store_cls)
+
+
+def test_create_segment_store_validates_config_and_capability():
+    vector_store = ChromaStore.__new__(ChromaStore)
+
+    with pytest.raises(ValueError, match='requires "type"'):
+        create_segment_store({})
+    with pytest.raises(NotImplementedError, match='missing_store'):
+        create_segment_store({'type': 'missing_store'})
+    with pytest.raises(TypeError, match='config dict'):
+        create_segment_store(object())
+    with pytest.raises(ValueError, match='not segment-capable'):
+        create_segment_store(vector_store)
+
+
+def test_counter_capability_is_optional_for_existing_stores():
+    store = MapStore()
+
+    assert store.supports_counters is False
+    with pytest.raises(NotImplementedError, match='named counters'):
+        store.increment_counters('segments', {'uid': 'segment-1'}, {'hits': 1})
+
+
+@pytest.mark.parametrize(
+    'increments',
+    [{}, {'bad-name': 1}, {'hit_count': True}, {'hit_count': 1.5}],
+)
+def test_counter_interface_rejects_invalid_increments(tmp_path, increments):
+    store = SQLiteStore(db_path=str(tmp_path / 'invalid-counter.db'))
+
+    with pytest.raises(ValueError):
+        store.increment_counters('episodes', {'uid': 'ep-1'}, increments)
+
+
+def test_sqlite_segment_store_lifecycle_with_named_counters(tmp_path):
+    store = create_segment_store({
+        'type': 'SQLiteStore',
+        'kwargs': {'db_path': str(tmp_path / 'segments.db')},
+    })
+    store.connect(global_metadata_desc=BUILDIN_GLOBAL_META_DESC)
+    row = _segment()
+
+    assert store.supports_counters is True
+    assert store.create('episodes', [row]) is True
+    with pytest.raises(FileExistsError):
+        store.create('episodes', [row])
+    assert store.get(
+        'episodes', {'uid': 'ep-1', 'kb_id': 'user-2'}, raise_on_error=True,
+    ) == []
+    assert store.search(
+        'episodes', 'mars', filters={'kb_id': 'user-1'},
+        query_fields=['content'], match_mode='any', raise_on_error=True,
+    )
+    assert store.increment_counters(
+        'episodes', {'uid': 'ep-1', 'kb_id': 'user-1'},
+        {'hit_count': 1, 'recall_count': 3},
+    ) == 1
+
+    stored = store.get(
+        'episodes', {'uid': 'ep-1', 'kb_id': 'user-1'}, raise_on_error=True,
+    )[0]
+    assert stored['counters'] == {'hit_count': 1, 'recall_count': 5}
+    assert store.delete('episodes', {'kb_id': 'user-2'}) is True
+    assert store.get('episodes', {'uid': 'ep-1'}, raise_on_error=True)
+    assert store.delete('episodes', {'kb_id': 'user-1'}) is True
+    assert store.get('episodes', {'uid': 'ep-1'}, raise_on_error=True) == []
+
+
+def test_sqlite_create_rolls_back_non_conflict_failures(tmp_path, monkeypatch):
+    store = SQLiteStore(db_path=str(tmp_path / 'create-errors.db'))
+    store.connect()
+
+    missing_doc_id = _segment()
+    missing_doc_id['doc_id'] = None
+    with pytest.raises(sqlite3.IntegrityError):
+        store.create('episodes', [missing_doc_id])
+
+    monkeypatch.setattr(
+        store,
+        '_fts_content',
+        lambda _item: (_ for _ in ()).throw(RuntimeError('FTS serialization failed')),
+    )
+    with pytest.raises(RuntimeError, match='FTS serialization failed'):
+        store.create('episodes', [_segment()])
+
+    assert store.get('episodes', {'uid': 'ep-1'}, raise_on_error=True) == []
+
+
+def test_sqlite_adds_counters_to_existing_collection_without_data_rewrite(tmp_path):
+    db_path = tmp_path / 'legacy.db'
+    conn = sqlite3.connect(db_path)
+    conn.execute('''CREATE TABLE episodes (
+        uid TEXT PRIMARY KEY, doc_id TEXT NOT NULL, "group" TEXT, content TEXT,
+        meta TEXT, global_meta TEXT, type INTEGER, number INTEGER, kb_id TEXT,
+        excluded_embed_metadata_keys TEXT, excluded_llm_metadata_keys TEXT,
+        parent TEXT, answer TEXT, image_keys TEXT
+    )''')
+    conn.execute(
+        'INSERT INTO episodes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        ('ep-1', 'ep-1', 'episode', 'legacy event', '{}', '{}', 1, 0, 'user-1',
+         '[]', '[]', None, '', '[]'),
+    )
+    conn.commit()
+    conn.close()
+
+    store = SQLiteStore(db_path=str(db_path))
+    store.connect()
+
+    assert store.get('episodes', {'uid': 'ep-1'}, raise_on_error=True)[0]['counters'] == {}
+    assert store.increment_counters(
+        'episodes', {'uid': 'ep-1'}, {'hit_count': 1},
+    ) == 1
+    assert store.get(
+        'episodes', {'uid': 'ep-1'}, raise_on_error=True,
+    )[0]['counters'] == {'hit_count': 1}
+
+
+def test_sqlite_named_counter_increment_is_not_lost(tmp_path):
+    store = SQLiteStore(db_path=str(tmp_path / 'atomic.db'))
+    store.connect()
+    store.create('episodes', [_segment(content='event')])
+
+    def increment_many(_):
+        for _ in range(25):
+            assert store.increment_counters(
+                'episodes', {'uid': 'ep-1', 'kb_id': 'user-1'}, {'hit_count': 1},
+            ) == 1
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(increment_many, range(8)))
+
+    stored = store.get('episodes', {'uid': 'ep-1'}, raise_on_error=True)[0]
+    assert stored['counters']['hit_count'] == 200
+
+
+def test_sqlite_counter_criteria_preserves_falsey_values(tmp_path):
+    store = SQLiteStore(db_path=str(tmp_path / 'falsey-criteria.db'))
+    store.connect()
+    zero = _segment('ep-zero')
+    zero['number'] = 0
+    one = _segment('ep-one')
+    one['number'] = 1
+    store.create('episodes', [zero, one])
+
+    assert store.increment_counters('episodes', {'number': 0}, {'hit_count': 1}) == 1
+    assert store.increment_counters('episodes', {'uid': []}, {'hit_count': 1}) == 0
+
+    rows = {row['uid']: row for row in store.get('episodes', raise_on_error=True)}
+    assert rows['ep-zero']['counters']['hit_count'] == 1
+    assert rows['ep-one']['counters']['hit_count'] == 0
+
+
+def test_sqlite_strict_reads_propagate_backend_failure(monkeypatch, tmp_path):
+    store = SQLiteStore(db_path=str(tmp_path / 'strict.db'))
+    monkeypatch.setattr(
+        store, '_open_conn',
+        lambda: (_ for _ in ()).throw(ConnectionError('SQLite unavailable')),
+    )
+
+    assert store.get('episodes') == []
+    assert store.search('episodes', query='mars') == []
+    with pytest.raises(ConnectionError, match='SQLite unavailable'):
+        store.get('episodes', raise_on_error=True)
+    with pytest.raises(ConnectionError, match='SQLite unavailable'):
+        store.search('episodes', query='mars', raise_on_error=True)
+
+
+def test_sqlite_segment_search_supports_any_terms_and_tenant_scope(tmp_path):
+    store = SQLiteStore(db_path=str(tmp_path / 'any.db'))
+    store.connect()
+    store.create('episodes', [
+        _segment('ep-both', content='mars apple'),
+        _segment('ep-mars', content='mars banana'),
+        _segment('ep-apple', content='venus apple'),
+        _segment('ep-other', user_id='user-2', content='mars apple'),
+    ])
+
+    result = store.search(
+        'episodes', 'mars apple', filters={'kb_id': 'user-1'},
+        query_fields=['content'], match_mode='any', raise_on_error=True,
+    )
+    all_terms = store.search(
+        'episodes', 'mars apple', filters={'kb_id': 'user-1'},
+        query_fields=['content'], match_mode='all', raise_on_error=True,
+    )
+
+    assert {item['uid'] for item in result} == {'ep-both', 'ep-mars', 'ep-apple'}
+    assert [item['uid'] for item in all_terms] == ['ep-both']
+
+
+def test_sqlite_segment_search_rejects_non_content_field(tmp_path):
+    store = SQLiteStore(db_path=str(tmp_path / 'invalid-search.db'))
+    store.connect()
+
+    with pytest.raises(ValueError, match='does not support query fields'):
+        store.search('episodes', 'mars', query_fields=['summary'])
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+def test_remote_segment_store_adds_mapping_and_increments_named_counters(store_cls):
+    store, client = _remote_store(store_cls)
+
+    assert store.supports_counters is True
+    assert store.increment_counters(
+        'episodes', {'uid': 'ep-1', 'kb_id': 'user-1'}, {'hit_count': 1},
+    ) == 1
+    assert client.indices.mapping_body == {
+        'properties': {'counters': {'type': 'object', 'dynamic': True}},
+    }
+    assert client.update_body['script']['params'] == {'increments': {'hit_count': 1}}
+    must = client.update_body['query']['bool']['must']
+    assert {'ids': {'values': ['ep-1']}} in must
+    assert {
+        'bool': {
+            'should': [
+                {'term': {'kb_id': 'user-1'}},
+                {'term': {'kb_id.keyword': 'user-1'}},
+            ],
+            'minimum_should_match': 1,
+        },
+    } in must
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+def test_remote_segment_create_is_create_only(store_cls):
+    store, client = _remote_store(store_cls)
+    row = _segment(content='event')
+
+    assert store.create('episodes', [row]) is True
+    assert client.bulk_body[0] == {'create': {'_index': 'episodes', '_id': 'ep-1'}}
+
+    client.bulk_response = {
+        'errors': True,
+        'items': [{'create': {'status': 409}}],
+    }
+    with pytest.raises(FileExistsError):
+        store.create('episodes', [row])
+
+    client.bulk_response = {
+        'errors': True,
+        'items': [
+            {'create': {'status': 409}},
+            {'create': {'status': 400, 'error': {'type': 'mapper_parsing_exception'}}},
+        ],
+    }
+    with pytest.raises(RuntimeError, match='mapper_parsing_exception'):
+        store.create('episodes', [row])
+
+
+@pytest.mark.parametrize('store_cls', [SQLiteStore, OpenSearchStore, ElasticSearchStore])
+def test_persistent_segment_create_rejects_non_dict_counters(store_cls, tmp_path):
+    if store_cls is SQLiteStore:
+        store = store_cls(db_path=str(tmp_path / 'invalid-initial-counters.db'))
+        store.connect()
+    else:
+        store, _ = _remote_store(store_cls)
+    row = _segment()
+    row['counters'] = []
+
+    with pytest.raises(ValueError, match='counters must be a dict'):
+        store.create('episodes', [row])
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+def test_remote_counter_mapping_is_not_reapplied_when_already_present(store_cls):
+    store, client = _remote_store(store_cls)
+    client.indices.properties['counters'] = {'type': 'object', 'dynamic': True}
+
+    assert store.increment_counters(
+        'episodes', {'uid': 'ep-1'}, {'hit_count': 1},
+    ) == 1
+    assert client.indices.mapping_body is None
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+def test_remote_strict_reads_propagate_backend_failure(store_cls):
+    store = store_cls(uris=['http://localhost:9200'])
+    store._client = _FailingRemoteClient()
+
+    assert store.get('episodes') == []
+    assert store.search('episodes', query='mars') == []
+    with pytest.raises(ConnectionError, match='segment backend unavailable'):
+        store.get('episodes', raise_on_error=True)
+    with pytest.raises(ConnectionError, match='segment backend unavailable'):
+        store.search('episodes', query='mars', raise_on_error=True)
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+@pytest.mark.parametrize(('match_mode', 'operator'), [('any', 'or'), ('all', 'and')])
+def test_remote_segment_search_uses_explicit_fields_operator_and_filter(
+    store_cls, match_mode, operator,
+):
+    store, client = _remote_store(store_cls)
+
+    assert store.search(
+        'episodes', 'mars apple', filters={'kb_id': 'user-1'},
+        query_fields=['content'], match_mode=match_mode, raise_on_error=True,
+    ) == []
+
+    bool_query = client.body['query']['bool']
+    assert bool_query['must'] == [{
+        'multi_match': {
+            'query': 'mars apple',
+            'fields': ['content'],
+            'operator': operator,
+        },
+    }]
+    assert bool_query['filter'] == [{
+        'bool': {
+            'should': [
+                {'term': {'kb_id': 'user-1'}},
+                {'term': {'kb_id.keyword': 'user-1'}},
+            ],
+            'minimum_should_match': 1,
+        },
+    }]
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+def test_remote_segment_search_preserves_default_scoring_semantics(store_cls):
+    store, client = _remote_store(store_cls)
+
+    assert store.search('episodes', 'mars', filters={'kb_id': 'user-1'}) == []
+
+    assert client.body['query']['bool']['must'] == [
+        {'multi_match': {'query': 'mars', 'fields': ['*']}},
+        {
+            'bool': {
+                'should': [
+                    {'term': {'kb_id': 'user-1'}},
+                    {'term': {'kb_id.keyword': 'user-1'}},
+                ],
+                'minimum_should_match': 1,
+            },
+        },
+    ]
+
+
+@pytest.mark.parametrize('store_cls', [OpenSearchStore, ElasticSearchStore])
+@pytest.mark.parametrize(
+    ('query_fields', 'match_mode'),
+    [([], None), ([''], None), ([None], None), ([123], None), (None, 'invalid')],
+)
+def test_remote_segment_search_rejects_invalid_explicit_options(
+    store_cls, query_fields, match_mode,
+):
+    store = store_cls(uris=['http://localhost:9200'])
+
+    with pytest.raises(ValueError):
+        store.search(
+            'episodes', 'mars', query_fields=query_fields, match_mode=match_mode,
+        )

--- a/tests/basic_tests/RAG/test_store.py
+++ b/tests/basic_tests/RAG/test_store.py
@@ -68,6 +68,20 @@ def _contains_array_term(query, field):
 
 
 class TestSegmentStoreCriteria(unittest.TestCase):
+    def test_remote_stores_keep_tenant_filter_with_uid(self):
+        for store_cls in (OpenSearchStore, ElasticSearchStore):
+            with self.subTest(store_cls=store_cls.__name__):
+                store = store_cls(uris=['http://localhost:9200'])
+
+                criteria = store._construct_criteria({'uid': ['ep-1'], 'kb_id': 'user-1'})
+
+                must = criteria['query']['bool']['must']
+                self.assertIn({'ids': {'values': ['ep-1']}}, must)
+                self.assertTrue(any(
+                    clause.get('bool', {}).get('minimum_should_match') == 1
+                    for clause in must
+                ))
+
     def test_opensearch_uses_terms_for_parent_and_number_lists(self):
         store = OpenSearchStore(uris=['http://localhost:9200'])
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- 在 `LazyLLMStoreBase` 上补充可选的 create-only 和 named counter 通用能力。
- 新增 `create_segment_store()` 轻量工厂，只构造或校验具体 Adapter。
- SQLite、OpenSearch、Elasticsearch 对称支持 strict read、any/all 文本检索和 counter。
- 保持 MapStore、HybridStore、VectorStore 等既有行为不变。

---

# 🎯 问题背景 / Problem Context

- 上层业务需要依赖稳定的 Segment Store 接口，而不是直接识别和调用具体后端。
- Episode 等业务需要 create-only、严格读取和原子命中计数，但这些能力应保持业务中性。

# 🔍 相关 Issue / Related Issue

* N/A

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [x] New feature
* [x] Refactor
* [ ] Breaking change
* [x] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. `pytest -q tests/basic_tests/RAG/test_segment_store.py tests/basic_tests/RAG/test_store.py::TestSegmentStoreCriteria`
2. `make lint-only-diff`
3. `python -m compileall -q lazyllm/tools/rag/store tests/basic_tests/RAG/test_segment_store.py`

---

# 📷 Demo (Optional)

* N/A

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
from lazyllm.tools.rag.store import create_segment_store

store = create_segment_store({
    'type': 'SQLiteStore',
    'kwargs': {'db_path': '/tmp/segments.db'},
})
store.connect()
store.create('episodes', [segment])
store.increment_counters('episodes', {'uid': segment['uid']}, {'hit_count': 1})
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
# 上层自行选择具体 Store，并缺少统一 create-only/counter 契约。
```

## After

```python
store = create_segment_store(config)
assert store.supports_counters
```

# ⚠️ 注意事项 / Additional Notes

* 工厂不包装、不连接、不组合 Store，也不隐藏既有具体 Store 入口。
* 其他 Store 不必实现 counter；调用时仍会得到 `NotImplementedError`。
* 远端批量 create 不承诺跨文档事务。

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
从 LazyLLM 视角完善 Segment 存储抽象，再让 LazyMind Episode 依赖该通用接口。
```

## 一开始制定了什么方案

最初考虑新增转发型 SegmentStore facade，随后改为复用 `LazyLLMStoreBase`，只增加轻量 factory
和业务中性的 named counter。

## 方案实施后存在什么问题

审查发现 SQLite falsey criteria 可能丢失 WHERE、create 异常需要完整 rollback，远端 mixed bulk
错误可能被冲突掩盖。

## 我（用户）发现了哪些问题

用户指出公开 facade 可能扩大开源 API 变更面，并要求 counter 使用中性概念、LazyLLM 三个持久化
Segment Adapter 保持对称，而 LazyMind 仍只启用 SQLite/OpenSearch。

## 对这些问题优化后相比于之前有哪些优势

最终接口更薄、兼容面更小；业务字段留在 LazyMind，后端原子能力留在 LazyLLM；严格读取默认
仍 fail-soft，只有显式调用才传播异常。

## 哪些可以沉淀为自己后续的编码规范

优先扩展已有 Base 契约；新增能力保持可选且不破坏第三方实现；多租户条件必须在主键快路径中
完整保留；原子更新应覆盖 falsey 条件和失败回滚。
