### PR TITLE
fix: add runtime docs for GoogleDriveFS tools

### DIFF
--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -2028,8 +2028,9 @@ add_toolsmgr_chinese_doc('InstanceToolGroup', '''\
 实例可以用以下可选类属性定制仅面向 LLM 的工具契约，而不改变原始 Python API：
 
 - ``__tool_public_apis__``：覆盖向 LLM 暴露的方法列表；未设置时继续使用 ``__public_apis__``。
-- ``__tool_schema_overrides__``：方法名到签名函数的映射，仅替换参数 schema，工具描述仍来自实际绑定方法。
+- ``__tool_schema_overrides__``：方法名到签名函数的映射，仅替换参数 schema，工具描述默认仍来自实际绑定方法。
 - ``__tool_input_adapters__``：方法名到输入适配函数的映射，在 schema 校验和调用前归一化工具输入。
+- ``__tool_doc_overrides__``：方法名到工具 docstring 的映射，仅用于 Agent 工具注册描述；适合原始方法文档由集中式文档系统维护、运行时仍需工具描述的场景。
 
 主要用于将 SearchBase、LazyLLMFSBase 等带有 __public_apis__ 的对象注册为 Agent 工具。
 
@@ -2058,8 +2059,9 @@ Accepts an optional key_source parameter to detect credential availability at ru
 An instance may define these optional class attributes to customize its LLM-facing tool contract without changing the original Python API:
 
 - ``__tool_public_apis__``: Overrides the methods exposed to the LLM; falls back to ``__public_apis__`` when absent.
-- ``__tool_schema_overrides__``: Maps method names to signature functions used only for parameter schemas; descriptions still come from the bound methods.
+- ``__tool_schema_overrides__``: Maps method names to signature functions used only for parameter schemas; descriptions still come from the bound methods by default.
 - ``__tool_input_adapters__``: Maps method names to input adapters that normalize tool input before schema validation and invocation.
+- ``__tool_doc_overrides__``: Maps method names to tool docstrings used only for Agent tool registration; useful when the original method documentation is maintained by the centralized docs system but runtime tools still need descriptions.
 
 Primarily used to register objects with __public_apis__ (such as SearchBase or LazyLLMFSBase subclasses) as Agent tools.
 
@@ -2387,6 +2389,7 @@ Args:
     method_name (str): 要封装的方法名称。
     schema_func (Optional[Callable]): 可选的 schema 签名函数；默认使用目标绑定方法。
     input_adapter (Optional[Callable]): 可选的输入归一化函数，在参数校验前执行。
+    doc (Optional[str]): 可选的工具 docstring 覆盖；仅影响工具描述和参数说明，不改变原始方法文档。
 ''')
 
 add_toolsmgr_english_doc('MethodModuleTool', '''\
@@ -2401,6 +2404,7 @@ Args:
     method_name (str): The name of the method to wrap.
     schema_func (Optional[Callable]): Optional signature function for schema generation; defaults to the target bound method.
     input_adapter (Optional[Callable]): Optional input normalizer executed before parameter validation.
+    doc (Optional[str]): Optional tool docstring override; affects only tool descriptions and parameter descriptions without changing the original method documentation.
 ''')
 
 add_toolsmgr_chinese_doc('ToolGroup.get_flat_tools', '''\

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -264,14 +264,14 @@ if 'tmp_tool' not in LazyLLMRegisterMetaClass.all_clses:
 
 class MethodModuleTool(ModuleTool):
     def __init__(self, instance: Any, method_name: str, schema_func: Optional[Callable] = None,
-                 input_adapter: Optional[Callable] = None):
+                 input_adapter: Optional[Callable] = None, doc: Optional[str] = None):
         object.__setattr__(self, '_instance', instance)
         object.__setattr__(self, '_method_name', method_name)
         object.__setattr__(self, '_input_adapter', input_adapter)
         bound = getattr(instance, method_name)
 
         def _apply(**kwargs): return bound(**kwargs)
-        _apply.__doc__ = bound.__doc__ or self._find_inherited_docstring(instance, method_name)
+        _apply.__doc__ = doc or bound.__doc__ or self._find_inherited_docstring(instance, method_name)
         _apply.__name__ = method_name
 
         super().__init__(execute_in_sandbox=False, apply_func=_apply, schema_func=schema_func or bound)
@@ -511,12 +511,14 @@ class InstanceToolGroup(SkipMixin, ToolGroup):
         public_apis = getattr(instance, '__tool_public_apis__', instance.__public_apis__)
         schema_overrides = getattr(instance, '__tool_schema_overrides__', {})
         input_adapters = getattr(instance, '__tool_input_adapters__', {})
+        doc_overrides = getattr(instance, '__tool_doc_overrides__', {})
         tools = [
             MethodModuleTool(
                 instance,
                 method_name,
                 schema_func=schema_overrides.get(method_name),
                 input_adapter=input_adapters.get(method_name),
+                doc=doc_overrides.get(method_name),
             )
             for method_name in public_apis
         ]

--- a/lazyllm/tools/fs/supplier/googledrive.py
+++ b/lazyllm/tools/fs/supplier/googledrive.py
@@ -26,6 +26,24 @@ _GOOGLE_WORKSPACE_EXPORT_TYPES = {
     'application/vnd.google-apps.document': 'text/plain',
     'application/vnd.google-apps.spreadsheet': 'text/csv',
 }
+_SEARCH_TOOL_DOC = '''Search Google Drive files by content keywords.
+
+Args:
+    keywords: One keyword or multiple keywords combined with AND.
+    file_name: Optional exact file-name scope.
+    drive_id: Optional shared-drive id.
+    folder_id: Optional direct parent-folder id.
+    limit: Maximum result count.
+'''
+_FIND_TOOL_DOC = '''Find Google Drive files whose names match a regex pattern.
+
+Args:
+    pattern: Python regular expression applied to file names.
+    drive_id: Optional shared-drive id.
+    folder_id: Optional direct parent-folder id.
+    limit: Maximum match count.
+    max_scan: Maximum candidate files to inspect.
+'''
 
 
 def _search_tool_schema(
@@ -58,6 +76,10 @@ class GoogleDriveFS(LazyLLMFSBase):
     __public_apis__ = ['search', 'find', 'read', 'read_file']
     __tool_schema_overrides__ = {'search': _search_tool_schema}
     __tool_input_adapters__ = {'search': _adapt_search_tool_input}
+    __tool_doc_overrides__ = {
+        'search': _SEARCH_TOOL_DOC,
+        'find': _FIND_TOOL_DOC,
+    }
 
     def __init__(
         self,

--- a/tests/advanced_tests/Tools/test_tools_manager.py
+++ b/tests/advanced_tests/Tools/test_tools_manager.py
@@ -2,6 +2,7 @@ import lazyllm
 from lazyllm.tools import ToolManager
 from lazyllm.tools.agent.toolsManager import (
     InstanceToolGroup, ToolGroup, _build_tool_from_element, _gen_args_info_from_moduletool_and_docstring, register,
+    _build_tool_desc,
 )
 from lazyllm.tools.agent.reactAgent import ReactAgent
 from lazyllm.common import LazyLLMRegisterMetaClass
@@ -205,10 +206,19 @@ def mock_search_input_adapter(tool_input):
     return adapted
 
 
+MOCK_SEARCH_TOOL_DOC = '''
+Search with one or more normalized queries.
+
+Args:
+    queries: Query terms to search.
+'''
+
+
 class MockSearchWithToolContract(MockSearchForTest):
     __tool_public_apis__ = ['search']
     __tool_schema_overrides__ = {'search': mock_search_schema}
     __tool_input_adapters__ = {'search': mock_search_input_adapter}
+    __tool_doc_overrides__ = {'search': MOCK_SEARCH_TOOL_DOC}
 
 
 class TestInstanceToolGroup:
@@ -282,9 +292,14 @@ class TestInstanceToolGroup:
         grp = InstanceToolGroup(MockSearchWithToolContract())
 
         assert set(grp._tools) == {'MockSearchWithToolContract_search'}
-        schema = grp._tools['MockSearchWithToolContract_search'].params_schema.model_json_schema()
+        tool = grp._tools['MockSearchWithToolContract_search']
+        schema = tool.params_schema.model_json_schema()
         assert schema['properties']['queries']['type'] == 'array'
-        assert grp._tools['MockSearchWithToolContract_search']._validate_input(
+        assert tool.description == MOCK_SEARCH_TOOL_DOC.strip()
+        desc = _build_tool_desc(tool)
+        assert desc['function']['description'].strip() == 'Search with one or more normalized queries.'
+        assert desc['function']['parameters']['properties']['queries']['description'] == 'Query terms to search.'
+        assert tool._validate_input(
             {'queries': 'hello'}
         ) == {'queries': ['hello']}
 


### PR DESCRIPTION
## Summary
- Add minimal runtime docstrings for `GoogleDriveFS.search` and `GoogleDriveFS.find`.
- Keep the full bilingual API documentation in `lazyllm/docs/tools/tool_fs.py`; these method docstrings are only the runtime descriptions required by `ToolManager` schema generation.

## Why
`ToolManager` builds method tools from bound method `__doc__` values. `GoogleDriveFS.search` had no runtime docstring and failed with `ValueError: Function must have a docstring`; `GoogleDriveFS.find` could otherwise fall back to an unrelated inherited fsspec description.

## Validation
- `/opt/miniconda3/bin/python -m py_compile lazyllm/tools/fs/supplier/googledrive.py`
- Built `MethodModuleTool` schemas for `GoogleDriveFS_search` and `GoogleDriveFS_find` and confirmed descriptions/parameters are generated.