### PR TITLE
fix(parse): Clear ocr config before ocr injection

### DIFF
--- a/lazyllm/tools/rag/readers/reader_config_inject.py
+++ b/lazyllm/tools/rag/readers/reader_config_inject.py
@@ -22,6 +22,10 @@ def inject_reader_config(
     *,
     ocr_config: Optional[Dict[str, Any]] = None,
 ) -> None:
+    # Always reset first so a task without OCR does not reuse the previous task's config.
+    globals.config['dynamic_ocr_configs'] = None
+    globals.config['dynamic_ocr_auth'] = None
+
     if not ocr_config or not isinstance(ocr_config, dict):
         return
 

--- a/tests/basic_tests/RAG/test_reader_config_inject.py
+++ b/tests/basic_tests/RAG/test_reader_config_inject.py
@@ -1,0 +1,36 @@
+from lazyllm import globals
+from lazyllm.tools.rag.readers.reader_config_inject import inject_reader_config
+
+
+def test_inject_reader_config_clears_previous_ocr_when_missing():
+    inject_reader_config(ocr_config={
+        'ocr_type': 'mineru',
+        'ocr_url': 'https://mineru.net/api/v4/',
+        'ocr_auth': {'mineru': 'token-a'},
+    })
+    assert globals.config['dynamic_ocr_configs']['ocr_type'] == 'mineru'
+    assert globals.config['dynamic_ocr_auth']['mineru'] == 'token-a'
+
+    inject_reader_config(ocr_config=None)
+
+    assert globals.config['dynamic_ocr_configs'] is None
+    assert globals.config['dynamic_ocr_auth'] is None
+
+
+def test_inject_reader_config_replaces_previous_ocr():
+    inject_reader_config(ocr_config={
+        'ocr_type': 'mineru',
+        'ocr_url': 'https://mineru.net/api/v4/',
+        'ocr_auth': {'mineru': 'token-a'},
+    })
+    inject_reader_config(ocr_config={
+        'ocr_type': 'paddleocr',
+        'ocr_url': 'http://paddle:8000',
+        'ocr_auth': {'paddleocr': 'token-b'},
+    })
+
+    assert globals.config['dynamic_ocr_configs'] == {
+        'ocr_type': 'paddleocr',
+        'ocr_url': 'http://paddle:8000',
+    }
+    assert globals.config['dynamic_ocr_auth'] == {'paddleocr': 'token-b'}


### PR DESCRIPTION
# 动态注入ocr信息之前 清空旧的信息，避免前端清空了ocr选项但是算法测还是用了上轮请求的ocr解析器