### PR TITLE
feat(writer): complete block revisions and Feishu document publishing

### DIFF
--- a/lazyllm/docs/tools/__init__.py
+++ b/lazyllm/docs/tools/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa E501
-from . import git, tool_agent, tool_sandbox, tool_tools, search, tool_services, tool_infer_service, tool_rag, tool_http_request, tool_mcp, tool_fs
-del git, tool_agent, tool_sandbox, tool_tools, search, tool_services, tool_infer_service, tool_rag, tool_http_request, tool_mcp, tool_fs
+from . import git, tool_agent, tool_sandbox, tool_tools, search, tool_services, tool_infer_service, tool_rag, tool_http_request, tool_mcp, tool_fs, tool_writer
+del git, tool_agent, tool_sandbox, tool_tools, search, tool_services, tool_infer_service, tool_rag, tool_http_request, tool_mcp, tool_fs, tool_writer

--- a/lazyllm/docs/tools/tool_fs.py
+++ b/lazyllm/docs/tools/tool_fs.py
@@ -1292,6 +1292,14 @@ Returns:
 Raises:
     ValueError: children_id does not contain exactly one subtree root.
 ''')
+_add_feishu_chinese('FeishuFSBase.replace_block', '''
+替换飞书内容块并保留其后代。
+''')
+
+_add_feishu_english('FeishuFSBase.replace_block', '''
+Replace a Feishu block while preserving its descendants.
+''')
+
 _add_feishu_chinese('FeishuFSBase.write_doc_blocks', '''\
 向已有飞书 Docx 文档末尾追加原生块，并返回写入后重新读取的完整块列表。
 

--- a/lazyllm/docs/tools/tool_writer.py
+++ b/lazyllm/docs/tools/tool_writer.py
@@ -1,0 +1,243 @@
+# flake8: noqa E501
+import functools
+import importlib
+from .. import utils
+
+add_writer_chinese_doc = functools.partial(utils.add_chinese_doc, module=importlib.import_module('lazyllm.tools.writer'))
+add_writer_english_doc = functools.partial(utils.add_english_doc, module=importlib.import_module('lazyllm.tools.writer'))
+add_writer_models_chinese_doc = functools.partial(utils.add_chinese_doc, module=importlib.import_module('lazyllm.tools.writer.data_models'))
+add_writer_models_english_doc = functools.partial(utils.add_english_doc, module=importlib.import_module('lazyllm.tools.writer.data_models'))
+add_writer_adapter_chinese_doc = functools.partial(utils.add_chinese_doc, module=importlib.import_module('lazyllm.tools.writer.adapter.feishu'))
+add_writer_adapter_english_doc = functools.partial(utils.add_english_doc, module=importlib.import_module('lazyllm.tools.writer.adapter.feishu'))
+
+add_writer_chinese_doc('WriterToolBase', '''
+写作工具基类，封装共享的模型、适配器和产物存储。
+''')
+
+add_writer_english_doc('WriterToolBase', '''
+Base class for writer tools with shared model, adapter, and artifact storage support.
+''')
+
+add_writer_models_chinese_doc('ModifyInstruction.validate_move', '''
+校验移动指令所需的锚点和位置。
+''')
+
+add_writer_models_english_doc('ModifyInstruction.validate_move', '''
+Validate the anchor and position required by a move instruction.
+''')
+
+add_writer_chinese_doc('WriterPlanningTools.generate_outline', '''
+根据写作任务和上下文生成结构化大纲。
+''')
+
+add_writer_english_doc('WriterPlanningTools.generate_outline', '''
+Generate a structured outline from a writing task and context.
+''')
+
+add_writer_chinese_doc('WriterPlanningTools.generate_section_instructions', '''
+为大纲中的各章节生成写作指令。
+''')
+
+add_writer_english_doc('WriterPlanningTools.generate_section_instructions', '''
+Generate drafting instructions for the sections in an outline.
+''')
+
+add_writer_models_chinese_doc('WriterDocument.validate_document', '''
+校验文档标识以及块标识的唯一性。
+''')
+
+add_writer_models_english_doc('WriterDocument.validate_document', '''
+Validate the document identifier and block identifier uniqueness.
+''')
+
+add_writer_models_chinese_doc('WriterDocument.iter_blocks', '''
+按文档顺序遍历全部内容块。
+''')
+
+add_writer_models_english_doc('WriterDocument.iter_blocks', '''
+Iterate over all blocks in document order.
+''')
+
+add_writer_models_chinese_doc('WriterDocument.block_by_id', '''
+按节点标识查找内容块。
+''')
+
+add_writer_models_english_doc('WriterDocument.block_by_id', '''
+Find a block by its node identifier.
+''')
+
+add_writer_models_chinese_doc('WriterBlock.validate_block', '''
+校验内容块标识和可见内容。
+''')
+
+add_writer_models_english_doc('WriterBlock.validate_block', '''
+Validate a block identifier and its visible content.
+''')
+
+add_writer_models_chinese_doc('WriterBlock.iter_blocks', '''
+遍历当前内容块及其后代。
+''')
+
+add_writer_models_english_doc('WriterBlock.iter_blocks', '''
+Iterate over this block and its descendants.
+''')
+
+add_writer_chinese_doc('NaiveWriterWorkflow', '''
+协调默认的规划、起草和修订流程。
+''')
+
+add_writer_english_doc('NaiveWriterWorkflow', '''
+Coordinate the default planning, drafting, and revision workflow.
+''')
+
+add_writer_chinese_doc('NaiveWriterWorkflow.write', '''
+执行写作任务的完整工作流。
+''')
+
+add_writer_english_doc('NaiveWriterWorkflow.write', '''
+Run the complete workflow for a writing task.
+''')
+
+add_writer_chinese_doc('NaiveWriterWorkflow.revise', '''
+执行已有文档的修订工作流。
+''')
+
+add_writer_english_doc('NaiveWriterWorkflow.revise', '''
+Run the revision workflow for an existing document.
+''')
+
+add_writer_chinese_doc('ArtifactModel.save', '''
+将模型保存为带版本信息的 JSON 产物。
+''')
+
+add_writer_english_doc('ArtifactModel.save', '''
+Save the model as a versioned JSON artifact.
+''')
+
+add_writer_chinese_doc('ArtifactModel.load', '''
+从 JSON 产物加载并校验模型。
+''')
+
+add_writer_english_doc('ArtifactModel.load', '''
+Load and validate the model from a JSON artifact.
+''')
+
+add_writer_chinese_doc('WriterQualityTools.validate_section', '''
+根据章节指令校验草稿章节。
+''')
+
+add_writer_english_doc('WriterQualityTools.validate_section', '''
+Validate a drafted section against its section instruction.
+''')
+
+add_writer_chinese_doc('WriterQualityTools.validate_draft_document', '''
+校验完整的草稿文档。
+''')
+
+add_writer_english_doc('WriterQualityTools.validate_draft_document', '''
+Validate a complete draft document.
+''')
+
+add_writer_chinese_doc('WriterQualityTools.validate_patch_set', '''
+根据修订任务校验补丁集。
+''')
+
+add_writer_english_doc('WriterQualityTools.validate_patch_set', '''
+Validate a patch set against its revision task.
+''')
+
+add_writer_models_chinese_doc('PatchHunk.validate_operation', '''
+校验各补丁操作所需的字段。
+''')
+
+add_writer_models_english_doc('PatchHunk.validate_operation', '''
+Validate the fields required by each patch operation.
+''')
+
+add_writer_models_chinese_doc('WriterConstraints.validate_word_range', '''
+校验最小和最大字数限制。
+''')
+
+add_writer_models_english_doc('WriterConstraints.validate_word_range', '''
+Validate the minimum and maximum word count constraints.
+''')
+
+add_writer_adapter_chinese_doc('FeishuWriterAdapter.merge_refreshed_document', '''
+将刷新的飞书绑定信息合并到修订后的文档。
+''')
+
+add_writer_adapter_english_doc('FeishuWriterAdapter.merge_refreshed_document', '''
+Merge refreshed Feishu bindings into a revised document.
+''')
+
+add_writer_chinese_doc('WriterToolKit', '''
+将共享依赖下的写作工具组合成工具包。
+''')
+
+add_writer_english_doc('WriterToolKit', '''
+Bundle writer tools that share the same dependencies.
+''')
+
+add_writer_chinese_doc('WriterToolKit.as_tool_groups', '''
+按工作流阶段返回写作工具分组。
+''')
+
+add_writer_english_doc('WriterToolKit.as_tool_groups', '''
+Return writer tools grouped by workflow stage.
+''')
+
+add_writer_chinese_doc('WriterRevisionTools.locate_revision_target', '''
+定位修订任务涉及的文档块。
+''')
+
+add_writer_english_doc('WriterRevisionTools.locate_revision_target', '''
+Locate document blocks targeted by a revision task.
+''')
+
+add_writer_chinese_doc('WriterRevisionTools.generate_modify_plan', '''
+为定位到的修订目标生成修改计划。
+''')
+
+add_writer_english_doc('WriterRevisionTools.generate_modify_plan', '''
+Generate a modification plan for located revision targets.
+''')
+
+add_writer_chinese_doc('WriterRevisionTools.generate_patch_set', '''
+根据修改计划生成补丁集。
+''')
+
+add_writer_english_doc('WriterRevisionTools.generate_patch_set', '''
+Generate a patch set from a modification plan.
+''')
+
+add_writer_chinese_doc('WriterRevisionTools.apply_patch', '''
+将补丁集应用到写作文档。
+''')
+
+add_writer_english_doc('WriterRevisionTools.apply_patch', '''
+Apply a patch set to a writer document.
+''')
+
+add_writer_chinese_doc('WriterDraftingTools.generate_draft_section', '''
+为单个章节生成草稿内容块。
+''')
+
+add_writer_english_doc('WriterDraftingTools.generate_draft_section', '''
+Generate a draft block for one section.
+''')
+
+add_writer_chinese_doc('WriterDraftingTools.generate_draft_document', '''
+将草稿内容块组装为草稿文档。
+''')
+
+add_writer_english_doc('WriterDraftingTools.generate_draft_document', '''
+Assemble draft blocks into a draft document.
+''')
+
+add_writer_chinese_doc('WriterDraftingTools.generate_final_document', '''
+将草稿渲染为最终文档。
+''')
+
+add_writer_english_doc('WriterDraftingTools.generate_final_document', '''
+Render a draft as a final document.
+''')

--- a/lazyllm/tools/fs/base.py
+++ b/lazyllm/tools/fs/base.py
@@ -372,6 +372,7 @@ class LinkDocumentFSBase(LazyLLMFSBase):
     __document_public_apis__ = [
         'resolve_link',
         'read_with_references',
+        'create_document',
         'get_document_id',
         'get_doc_blocks',
         'update_doc_block_text',
@@ -432,6 +433,10 @@ class LinkDocumentFSBase(LazyLLMFSBase):
 
     def _format_document_references_footer(self, refs: List[Dict[str, Any]]) -> str:
         return self.format_document_references_footer(refs, self._document_provider_name)
+
+    def create_document(self, title: str, parent: str = '') -> Dict[str, Any]:
+        '''Create an empty document under an optional provider parent location.'''
+        raise NotImplementedError(f'{self.__class__.__name__}.create_document is not implemented')
 
     def _list_document_references(self, path: str) -> List[Dict[str, Any]]:
         return []

--- a/lazyllm/tools/fs/client.py
+++ b/lazyllm/tools/fs/client.py
@@ -42,7 +42,7 @@ def _feishu_needs_wiki(space_id: Optional[str], real_path: str) -> bool:
     norm = real_path.lstrip('/')
     if any(norm.startswith(p) for p in _FEISHU_WIKI_PATH_PREFIXES):
         return True
-    return bool((globals.config.get('feishu_wiki_space_id') or '').strip())
+    return bool((globals.config['feishu_wiki_space_id'] or '').strip())
 
 
 def _match_bare_document_url(path: str) -> Optional[str]:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 import re
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode, urlparse
 
 import requests
@@ -679,7 +679,7 @@ class FeishuFSBase(LinkDocumentFSBase):
             document_revision_id=document_revision_id,
         )
 
-    def _rollback_move_copy(
+    def _rollback_subtree_copy(
         self,
         document_id: str,
         target_parent_block_id: str,
@@ -689,12 +689,10 @@ class FeishuFSBase(LinkDocumentFSBase):
     ) -> Dict[str, Any]:
         if created_root_block_id:
             target_children = self._get_docx_children(document_id, target_parent_block_id)
-            create_index = next(
-                (
-                    index for index, block in enumerate(target_children)
-                    if block.get('block_id') == created_root_block_id
-                ),
-                create_index,
+            create_index = self._block_index(
+                target_children,
+                created_root_block_id,
+                default=create_index,
             )
         return self._batch_delete_child_blocks(
             document_id,
@@ -704,7 +702,22 @@ class FeishuFSBase(LinkDocumentFSBase):
             document_revision_id=document_revision_id,
         )
 
-    def _verify_move_copy(
+    @staticmethod
+    def _block_index(
+        blocks: List[Dict[str, Any]],
+        block_id: str,
+        *,
+        default: Optional[int] = None,
+    ) -> Optional[int]:
+        return next(
+            (
+                index for index, block in enumerate(blocks)
+                if block.get('block_id') == block_id
+            ),
+            default,
+        )
+
+    def _verify_subtree_copy(
         self,
         document_id: str,
         descendants: List[Dict[str, Any]],
@@ -719,7 +732,7 @@ class FeishuFSBase(LinkDocumentFSBase):
             and isinstance(relation.get('block_id'), str)
         }
         if set(temporary_to_created) != set(source_by_temporary_id):
-            raise RuntimeError('created move copy returned incomplete block ID relations.')
+            raise RuntimeError('created subtree copy returned incomplete block ID relations.')
 
         expected_by_temporary_id = {
             block.get('block_id'): block for block in descendants
@@ -733,11 +746,11 @@ class FeishuFSBase(LinkDocumentFSBase):
             created_id = temporary_to_created[temporary_id]
             created = created_by_id.get(created_id)
             if not isinstance(expected, dict) or not isinstance(created, dict):
-                raise RuntimeError('created move copy is missing a block from the copied subtree.')
+                raise RuntimeError('created subtree copy is missing a block from the copied subtree.')
             block_type = expected.get('block_type')
             if created.get('block_type') != block_type:
                 raise RuntimeError(
-                    f'created move block {source_block_id!r} has a different block type.')
+                    f'created subtree block {source_block_id!r} has a different block type.')
             content_key = DOCX_BLOCK_TYPE_FIELDS.get(block_type)
             expected_content, _ = normalize_docx_clone_content(
                 block_type, expected.get(content_key))
@@ -745,20 +758,20 @@ class FeishuFSBase(LinkDocumentFSBase):
                 block_type, created.get(content_key))
             if created_content != expected_content:
                 raise RuntimeError(
-                    f'created move block {source_block_id!r} has different content or formatting.')
+                    f'created subtree block {source_block_id!r} has different content or formatting.')
             expected_children = [
                 temporary_to_created[child_id]
                 for child_id in (expected.get('children') or [])
             ]
             if (created.get('children') or []) != expected_children:
                 raise RuntimeError(
-                    f'created move block {source_block_id!r} has different children.')
+                    f'created subtree block {source_block_id!r} has different children.')
         return {
             source_by_temporary_id[temporary_id]: created_id
             for temporary_id, created_id in temporary_to_created.items()
         }
 
-    def _create_and_verify_move_copy(
+    def _create_and_verify_subtree_copy(
         self,
         document_id: str,
         target_parent_block_id: str,
@@ -767,6 +780,7 @@ class FeishuFSBase(LinkDocumentFSBase):
         descendants: List[Dict[str, Any]],
         source_by_temporary_id: Dict[str, str],
         document_revision_id: int,
+        operation_name: str,
     ) -> Tuple[Dict[str, Any], int, Dict[str, str]]:
         create_data = self._create_descendant_blocks(
             document_id,
@@ -789,7 +803,7 @@ class FeishuFSBase(LinkDocumentFSBase):
         )
         created_root_block_id = root_relation.get('block_id')
         try:
-            block_id_relations = self._verify_move_copy(
+            block_id_relations = self._verify_subtree_copy(
                 document_id,
                 descendants,
                 source_by_temporary_id,
@@ -797,7 +811,7 @@ class FeishuFSBase(LinkDocumentFSBase):
             )
         except Exception as verify_error:
             try:
-                self._rollback_move_copy(
+                self._rollback_subtree_copy(
                     document_id,
                     target_parent_block_id,
                     create_index,
@@ -806,15 +820,15 @@ class FeishuFSBase(LinkDocumentFSBase):
                 )
             except Exception as rollback_error:
                 raise RuntimeError(
-                    'move_block partially applied: target copy verification failed and '
+                    f'{operation_name} partially applied: target copy verification failed and '
                     f'rollback failed: {rollback_error}'
                 ) from verify_error
             raise RuntimeError(
-                'move_block aborted: target copy verification failed and was rolled back.'
+                f'{operation_name} aborted: target copy verification failed and was rolled back.'
             ) from verify_error
         return create_data, created_revision, block_id_relations
 
-    def _delete_move_source(
+    def _delete_subtree_source(
         self,
         document_id: str,
         source_parent_block_id: str,
@@ -823,18 +837,13 @@ class FeishuFSBase(LinkDocumentFSBase):
         create_index: int,
         created_root_block_id: str,
         created_revision: int,
+        operation_name: str,
     ) -> Dict[str, Any]:
         source_children = self._get_docx_children(document_id, source_parent_block_id)
-        delete_index = next(
-            (
-                index for index, block in enumerate(source_children)
-                if block.get('block_id') == source_block_id
-            ),
-            None,
-        )
+        delete_index = self._block_index(source_children, source_block_id)
         if delete_index is None:
             try:
-                self._rollback_move_copy(
+                self._rollback_subtree_copy(
                     document_id,
                     target_parent_block_id,
                     create_index,
@@ -843,11 +852,12 @@ class FeishuFSBase(LinkDocumentFSBase):
                 )
             except Exception as rollback_error:
                 raise RuntimeError(
-                    'move_block partially applied: source disappeared and target-copy '
+                    f'{operation_name} partially applied: source disappeared and target-copy '
                     f'rollback failed: {rollback_error}'
                 ) from rollback_error
             raise RuntimeError(
-                'move source block disappeared before deletion; target copy was rolled back.')
+                f'{operation_name} source block disappeared before deletion; '
+                'target copy was rolled back.')
         try:
             return self._batch_delete_child_blocks(
                 document_id,
@@ -865,13 +875,13 @@ class FeishuFSBase(LinkDocumentFSBase):
                 )
             except Exception as reconcile_error:
                 raise RuntimeError(
-                    'move_block outcome is uncertain: source delete failed and source '
+                    f'{operation_name} outcome is uncertain: source delete failed and source '
                     f'presence could not be checked: {reconcile_error}'
                 ) from delete_error
             if not source_still_exists:
                 return {'status': 'confirmed_after_error'}
             try:
-                self._rollback_move_copy(
+                self._rollback_subtree_copy(
                     document_id,
                     target_parent_block_id,
                     create_index,
@@ -880,12 +890,62 @@ class FeishuFSBase(LinkDocumentFSBase):
                 )
             except Exception as rollback_error:
                 raise RuntimeError(
-                    'move_block partially applied: source delete failed and target-copy '
+                    f'{operation_name} partially applied: source delete failed and target-copy '
                     f'rollback failed: {rollback_error}'
                 ) from delete_error
             raise RuntimeError(
-                'move_block aborted: source delete failed and target copy was rolled back.'
+                f'{operation_name} aborted: source delete failed and target copy was rolled back.'
             ) from delete_error
+
+    def _clone_subtree_transaction(
+        self,
+        document_id: str,
+        source_parent_block_id: str,
+        source_block_id: str,
+        target_parent_block_id: str,
+        create_index: int,
+        document_revision_id: int,
+        operation_name: str,
+        transform_root: Optional[Callable[[Dict[str, Any]], None]] = None,
+    ) -> Dict[str, Any]:
+        source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
+        children_id, descendants, source_by_temporary_id, normalized_fields = \
+            prepare_docx_clone_descendants(source_blocks, source_block_id)
+        if len(children_id) != 1:
+            raise ValueError(f'{operation_name} requires exactly one root block.')
+
+        if transform_root is not None:
+            root_id = children_id[0]
+            root = next(
+                (block for block in descendants if block.get('block_id') == root_id),
+                None,
+            )
+            if root is None:
+                raise RuntimeError(
+                    f'{operation_name} source root is missing from its cloned subtree.')
+            transform_root(root)
+
+        create_data, created_revision, block_id_relations = self._create_and_verify_subtree_copy(
+            document_id, target_parent_block_id, create_index, children_id,
+            descendants, source_by_temporary_id, document_revision_id, operation_name,
+        )
+        created_root_block_id = block_id_relations[source_block_id]
+        delete_data = self._delete_subtree_source(
+            document_id, source_parent_block_id, source_block_id, target_parent_block_id,
+            create_index, created_root_block_id, created_revision, operation_name,
+        )
+        final_revision = delete_data.get('document_revision_id', created_revision)
+        if delete_data.get('status') == 'confirmed_after_error':
+            final_revision = -1
+        return {
+            'create': create_data,
+            'delete': delete_data,
+            'block_id_relations': block_id_relations,
+            'normalized_fields': normalized_fields,
+            'document_revision_id': (
+                final_revision if final_revision is not None else created_revision
+            ),
+        }
 
     def move_block(
         self,
@@ -901,15 +961,12 @@ class FeishuFSBase(LinkDocumentFSBase):
         if source_index < 0 or target_index < 0:
             raise ValueError('move_block source and target indexes must not be negative.')
         source_children = self._get_docx_children(document_id, source_parent_block_id)
-        current_source_index = next(
-            (
-                index for index, block in enumerate(source_children)
-                if block.get('block_id') == source_block_id
-            ),
-            None,
-        )
+        current_source_index = self._block_index(source_children, source_block_id)
         if current_source_index is None:
             raise ValueError('move source block does not belong to the expected parent.')
+        if source_index != current_source_index:
+            raise ValueError(
+                'move source index does not match the current provider layout.')
         target_children = (
             source_children
             if source_parent_block_id == target_parent_block_id
@@ -920,42 +977,16 @@ class FeishuFSBase(LinkDocumentFSBase):
         if target_index > max_target_index:
             raise ValueError('move target index is outside the target parent.')
 
-        source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
-        children_id, descendants, source_by_temporary_id, normalized_fields = \
-            prepare_docx_clone_descendants(source_blocks, source_block_id)
-        if len(children_id) != 1:
-            raise ValueError('move_block requires exactly one root block.')
         create_index = target_index
         if (
             source_parent_block_id == target_parent_block_id
             and current_source_index < target_index
         ):
             create_index += 1
-        create_data, created_revision, block_id_relations = self._create_and_verify_move_copy(
-            document_id,
-            target_parent_block_id,
-            create_index,
-            children_id,
-            descendants,
-            source_by_temporary_id,
-            document_revision_id,
+        return self._clone_subtree_transaction(
+            document_id, source_parent_block_id, source_block_id, target_parent_block_id,
+            create_index, document_revision_id, 'move_block',
         )
-        created_root_block_id = block_id_relations[source_block_id]
-        delete_data = self._delete_move_source(
-            document_id,
-            source_parent_block_id,
-            source_block_id,
-            target_parent_block_id,
-            create_index,
-            created_root_block_id,
-            created_revision,
-        )
-        return {
-            'create': create_data,
-            'delete': delete_data,
-            'block_id_relations': block_id_relations,
-            'normalized_fields': normalized_fields,
-        }
 
     def replace_block(
         self,
@@ -970,64 +1001,28 @@ class FeishuFSBase(LinkDocumentFSBase):
         if source_index < 0:
             raise ValueError('replace_block source index must not be negative.')
         siblings = self._get_docx_children(document_id, parent_block_id)
-        current_source_index = next(
-            (
-                index for index, block in enumerate(siblings)
-                if block.get('block_id') == source_block_id
-            ),
-            None,
-        )
+        current_source_index = self._block_index(siblings, source_block_id)
         if current_source_index is None:
             raise ValueError('replace source block does not belong to the expected parent.')
+        if source_index != current_source_index:
+            raise ValueError(
+                'replace source index does not match the current provider layout.')
         if not isinstance(replacement_block, dict):
             raise TypeError('replacement_block must be a dict.')
 
-        source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
-        children_id, descendants, source_by_temporary_id, normalized_fields = \
-            prepare_docx_clone_descendants(source_blocks, source_block_id)
-        if len(children_id) != 1:
-            raise ValueError('replace_block requires exactly one root block.')
+        def replace_root(root: Dict[str, Any]) -> None:
+            root_id = root['block_id']
+            children = root.get('children')
+            root.clear()
+            root.update(deepcopy(replacement_block))
+            root['block_id'] = root_id
+            if children:
+                root['children'] = children
 
-        root_id = children_id[0]
-        root = next(
-            (block for block in descendants if block.get('block_id') == root_id),
-            None,
+        return self._clone_subtree_transaction(
+            document_id, parent_block_id, source_block_id, parent_block_id,
+            current_source_index, document_revision_id, 'replace_block', replace_root,
         )
-        if root is None:
-            raise RuntimeError('replace source root is missing from its cloned subtree.')
-        children = root.get('children')
-        root.clear()
-        root.update(deepcopy(replacement_block))
-        root['block_id'] = root_id
-        if children:
-            root['children'] = children
-
-        create_data, created_revision, block_id_relations = \
-            self._create_and_verify_move_copy(
-                document_id,
-                parent_block_id,
-                current_source_index,
-                children_id,
-                descendants,
-                source_by_temporary_id,
-                document_revision_id,
-            )
-        created_root_block_id = block_id_relations[source_block_id]
-        delete_data = self._delete_move_source(
-            document_id,
-            parent_block_id,
-            source_block_id,
-            parent_block_id,
-            current_source_index,
-            created_root_block_id,
-            created_revision,
-        )
-        return {
-            'create': create_data,
-            'delete': delete_data,
-            'block_id_relations': block_id_relations,
-            'normalized_fields': normalized_fields,
-        }
 
     def write_doc_blocks(
         self,

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -1050,7 +1050,7 @@ class FeishuFS(FeishuFSBase):
         r'https?://[^\s/]+\.(?:feishu\.(?:cn|com)|larksuite\.com)(?:[/:?#]|$)',
         r'飞书|(?<!\w)feishu(?!\w)',
     ]
-    __public_apis__ = LazyLLMFSBase.__public_apis__
+    __public_apis__ = LazyLLMFSBase.__public_apis__ + ['create_document']
 
     def __new__(cls, base_url: Optional[str] = None, app_id: Optional[str] = None, app_secret: Optional[str] = None,
                 space_id: Optional[str] = None, user_refresh_token: Optional[str] = None,
@@ -1125,6 +1125,35 @@ class FeishuFS(FeishuFSBase):
               **kwargs) -> CloudFSBufferedFile:
         return CloudFSBufferedFile(self, path, mode=mode, block_size=block_size or self.blocksize,
                                    autocommit=autocommit, cache_options=cache_options)
+
+    def _create_drive_docx(self, title: str, folder_token: str = '') -> Dict[str, Any]:
+        params = {'folder_token': folder_token} if folder_token else None
+        data = self._post(
+            f'{self._base_url}/docx/v1/documents',
+            params=params,
+            json={'title': title},
+        )
+        document = (data.get('data') or {}).get('document') or {}
+        document_id = document.get('document_id') or ''
+        if not document_id:
+            raise RuntimeError('Feishu drive docx create failed: empty document_id')
+        return {
+            'document_id': document_id,
+            'title': document.get('title') or title,
+            'path': f'/~docx/{document_id}',
+            'browser_url': f'https://feishu.cn/docx/{document_id}',
+            'container': 'drive',
+            'folder_token': folder_token,
+        }
+
+    def create_document(self, title: str, parent: str = '') -> Dict[str, Any]:
+        '''Create a Feishu Docx in the default Cloud Docs root or a selected folder.'''
+        title = (title or '').strip()
+        if not title:
+            raise ValueError('title is required')
+        parent = (parent or '').strip()
+        folder_token = self._resolve_path_to_token(parent) if parent and parent != '/' else ''
+        return self._create_drive_docx(title, folder_token=folder_token)
 
     def mkdir(self, path: str, create_parents: bool = True, **kwargs) -> None:
         parts = [p for p in path.strip('/').split('/') if p]
@@ -1201,17 +1230,13 @@ class FeishuFS(FeishuFSBase):
                 self._upload_file_to_drive(name, data, folder_token=parent_token)
                 return
             doc_title = name[:-3] if name.endswith('.md') else name
-            folder_token = parent_token or self._drive_root_folder_token()
-            create_resp = self._post(
-                f'{self._base_url}/docx/v1/documents',
-                params={'folder_token': folder_token},
-                json={'title': doc_title},
-            )
-            doc_id = ((create_resp.get('data') or {}).get('document') or {}).get('document_id') or ''
-            if not doc_id:
+            try:
+                created = self._create_drive_docx(doc_title, folder_token=parent_token)
+            except RuntimeError:
                 LOG.warning('Feishu drive docx create returned no document_id, falling back to file upload')
                 self._upload_file_to_drive(name, data, folder_token=parent_token)
                 return
+            doc_id = created['document_id']
             try:
                 top_blocks, block_children = self._convert_markdown_via_api(text)
                 _, block_id_map = self._append_docx_blocks(doc_id, top_blocks)
@@ -1275,14 +1300,62 @@ class FeishuWikiFS(FeishuFSBase):
     document_provider = 'feishu'
     __public_apis__ = LinkDocumentFSBase.build_public_apis(extra=['search', 'find'])
 
-    def _create_docx_node(self, title: str, parent_token: str = '') -> str:
+    def _create_docx_node(self, title: str, parent_token: str = '') -> Dict[str, Any]:
         url = f'{self._base_url}/wiki/v2/spaces/{self._effective_space_id()}/nodes'
         payload: Dict[str, Any] = {'obj_type': 'docx', 'node_type': 'origin', 'title': title}
         if parent_token:
             payload['parent_node_token'] = parent_token
         data = self._post(url, json=payload)
         node = data.get('data', {}).get('node') or {}
-        return node.get('obj_token') or ''
+        if not node.get('obj_token'):
+            raise RuntimeError('Feishu wiki create docx node failed: empty obj_token')
+        return node
+
+    def create_document(self, title: str, parent: str = '') -> Dict[str, Any]:
+        '''Create an empty Feishu Docx node in a Wiki space.'''
+        title = (title or '').strip()
+        if not title:
+            raise ValueError('title is required')
+        parent = (parent or '').strip()
+        parent_token = ''
+        parent_url = ''
+        if parent and parent != '/':
+            if self.is_link_path(parent):
+                parent_url = self.decode_link_path(parent)
+                ref = self.resolve_wiki_ref(parent)
+                parent_token = ref.get('node_token') or ''
+            elif _FEISHU_BARE_HOST_RE.match(parent):
+                parent_url = parent
+                ref = self.resolve_wiki_ref(parent)
+                parent_token = ref.get('node_token') or ''
+            elif parent.lstrip('/').startswith('~node/'):
+                ref = self.resolve_wiki_ref(parent)
+                parent_token = ref.get('node_token') or ''
+            else:
+                parent_token = self._resolve_path_to_token(parent)
+            if not parent_token:
+                raise ValueError('Feishu wiki parent must point to a wiki node.')
+
+        node = self._create_docx_node(title, parent_token=parent_token)
+        document_id = node.get('obj_token') or ''
+        node_token = node.get('node_token') or ''
+        space_id = node.get('space_id') or self._effective_space_id()
+        browser_origin = 'https://feishu.cn'
+        if parent_url:
+            parsed_parent = urlparse(parent_url)
+            if parsed_parent.scheme and parsed_parent.netloc:
+                browser_origin = f'{parsed_parent.scheme}://{parsed_parent.netloc}'
+        browser_path = f'/wiki/{node_token}' if node_token else f'/docx/{document_id}'
+        return {
+            'document_id': document_id,
+            'node_token': node_token,
+            'space_id': space_id,
+            'title': node.get('title') or title,
+            'path': f'/~node/{node_token}' if node_token else f'/~docx/{document_id}',
+            'browser_url': f'{browser_origin}{browser_path}',
+            'container': 'wiki',
+            'parent_node_token': parent_token,
+        }
 
     def _append_docx_text(self, document_id: str, text: str) -> None:
         if not text:
@@ -1639,9 +1712,7 @@ class FeishuWikiFS(FeishuFSBase):
         parts = [p for p in path.strip('/').split('/') if p]
         name = parts[-1] if parts else 'untitled'
         parent_token = self._resolve_path_to_token('/' + '/'.join(parts[:-1])) if len(parts) > 1 else ''
-        doc_id = self._create_docx_node(name, parent_token=parent_token)
-        if not doc_id:
-            raise RuntimeError('Feishu wiki create docx node failed: empty obj_token')
+        doc_id = self._create_docx_node(name, parent_token=parent_token)['obj_token']
         try:
             text = data.decode('utf-8')
         except UnicodeDecodeError as e:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -12,6 +12,8 @@ from lazyllm import globals as lazyllm_globals
 from lazyllm.common import Credential
 from lazyllm.tools.writer.utils.feishu_docx import (
     DOCX_BLOCK_TYPE_FIELDS,
+    normalize_docx_clone_content,
+    prepare_docx_clone_descendants,
     prepare_docx_descendants,
 )
 from ..base import LazyLLMFSBase, LinkDocumentFSBase, CloudFSBufferedFile
@@ -681,8 +683,18 @@ class FeishuFSBase(LinkDocumentFSBase):
         document_id: str,
         target_parent_block_id: str,
         create_index: int,
+        created_root_block_id: Optional[str],
         document_revision_id: int,
     ) -> Dict[str, Any]:
+        if created_root_block_id:
+            target_children = self._get_docx_children(document_id, target_parent_block_id)
+            create_index = next(
+                (
+                    index for index, block in enumerate(target_children)
+                    if block.get('block_id') == created_root_block_id
+                ),
+                create_index,
+            )
         return self._batch_delete_child_blocks(
             document_id,
             target_parent_block_id,
@@ -694,20 +706,56 @@ class FeishuFSBase(LinkDocumentFSBase):
     def _verify_move_copy(
         self,
         document_id: str,
-        target_parent_block_id: str,
-        create_index: int,
-        root_id: str,
         descendants: List[Dict[str, Any]],
-    ) -> None:
-        created_children = self._get_docx_children(document_id, target_parent_block_id)
-        created_root = created_children[create_index]
-        expected_root = next(
-            item for item in descendants if item.get('block_id') == root_id)
-        if created_root.get('block_type') != expected_root.get('block_type'):
-            raise RuntimeError('created move root has a different block type.')
-        expected_text = self._docx_block_plain_text(expected_root)
-        if expected_text and self._docx_block_plain_text(created_root) != expected_text:
-            raise RuntimeError('created move root has different text content.')
+        source_by_temporary_id: Dict[str, str],
+        create_data: Dict[str, Any],
+    ) -> Dict[str, str]:
+        temporary_to_created = {
+            relation.get('temporary_block_id'): relation.get('block_id')
+            for relation in (create_data.get('block_id_relations') or [])
+            if isinstance(relation, dict)
+            and isinstance(relation.get('temporary_block_id'), str)
+            and isinstance(relation.get('block_id'), str)
+        }
+        if set(temporary_to_created) != set(source_by_temporary_id):
+            raise RuntimeError('created move copy returned incomplete block ID relations.')
+
+        expected_by_temporary_id = {
+            block.get('block_id'): block for block in descendants
+        }
+        created_by_id = {
+            block.get('block_id'): block
+            for block in self._get_doc_blocks_raw(document_id, with_descendants=True)
+        }
+        for temporary_id, source_block_id in source_by_temporary_id.items():
+            expected = expected_by_temporary_id.get(temporary_id)
+            created_id = temporary_to_created[temporary_id]
+            created = created_by_id.get(created_id)
+            if not isinstance(expected, dict) or not isinstance(created, dict):
+                raise RuntimeError('created move copy is missing a block from the copied subtree.')
+            block_type = expected.get('block_type')
+            if created.get('block_type') != block_type:
+                raise RuntimeError(
+                    f'created move block {source_block_id!r} has a different block type.')
+            content_key = DOCX_BLOCK_TYPE_FIELDS.get(block_type)
+            expected_content, _ = normalize_docx_clone_content(
+                block_type, expected.get(content_key))
+            created_content, _ = normalize_docx_clone_content(
+                block_type, created.get(content_key))
+            if created_content != expected_content:
+                raise RuntimeError(
+                    f'created move block {source_block_id!r} has different content or formatting.')
+            expected_children = [
+                temporary_to_created[child_id]
+                for child_id in (expected.get('children') or [])
+            ]
+            if (created.get('children') or []) != expected_children:
+                raise RuntimeError(
+                    f'created move block {source_block_id!r} has different children.')
+        return {
+            source_by_temporary_id[temporary_id]: created_id
+            for temporary_id, created_id in temporary_to_created.items()
+        }
 
     def _create_and_verify_move_copy(
         self,
@@ -716,8 +764,9 @@ class FeishuFSBase(LinkDocumentFSBase):
         create_index: int,
         children_id: List[str],
         descendants: List[Dict[str, Any]],
+        source_by_temporary_id: Dict[str, str],
         document_revision_id: int,
-    ) -> Tuple[Dict[str, Any], int]:
+    ) -> Tuple[Dict[str, Any], int, Dict[str, str]]:
         create_data = self._create_descendant_blocks(
             document_id,
             target_parent_block_id,
@@ -729,13 +778,21 @@ class FeishuFSBase(LinkDocumentFSBase):
         created_revision = create_data.get('document_revision_id', -1)
         if not isinstance(created_revision, int) or isinstance(created_revision, bool):
             created_revision = -1
+        root_relation = next(
+            (
+                relation for relation in (create_data.get('block_id_relations') or [])
+                if isinstance(relation, dict)
+                and relation.get('temporary_block_id') == children_id[0]
+            ),
+            {},
+        )
+        created_root_block_id = root_relation.get('block_id')
         try:
-            self._verify_move_copy(
+            block_id_relations = self._verify_move_copy(
                 document_id,
-                target_parent_block_id,
-                create_index,
-                children_id[0],
                 descendants,
+                source_by_temporary_id,
+                create_data,
             )
         except Exception as verify_error:
             try:
@@ -743,6 +800,7 @@ class FeishuFSBase(LinkDocumentFSBase):
                     document_id,
                     target_parent_block_id,
                     create_index,
+                    created_root_block_id,
                     created_revision,
                 )
             except Exception as rollback_error:
@@ -753,18 +811,42 @@ class FeishuFSBase(LinkDocumentFSBase):
             raise RuntimeError(
                 'move_block aborted: target copy verification failed and was rolled back.'
             ) from verify_error
-        return create_data, created_revision
+        return create_data, created_revision, block_id_relations
 
     def _delete_move_source(
         self,
         document_id: str,
         source_parent_block_id: str,
         source_block_id: str,
-        delete_index: int,
         target_parent_block_id: str,
         create_index: int,
+        created_root_block_id: str,
         created_revision: int,
     ) -> Dict[str, Any]:
+        source_children = self._get_docx_children(document_id, source_parent_block_id)
+        delete_index = next(
+            (
+                index for index, block in enumerate(source_children)
+                if block.get('block_id') == source_block_id
+            ),
+            None,
+        )
+        if delete_index is None:
+            try:
+                self._rollback_move_copy(
+                    document_id,
+                    target_parent_block_id,
+                    create_index,
+                    created_root_block_id,
+                    created_revision,
+                )
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    'move_block partially applied: source disappeared and target-copy '
+                    f'rollback failed: {rollback_error}'
+                ) from rollback_error
+            raise RuntimeError(
+                'move source block disappeared before deletion; target copy was rolled back.')
         try:
             return self._batch_delete_child_blocks(
                 document_id,
@@ -776,8 +858,9 @@ class FeishuFSBase(LinkDocumentFSBase):
         except Exception as delete_error:
             try:
                 source_still_exists = any(
-                    child.get('block_id') == source_block_id
-                    for child in self._get_docx_children(document_id, source_parent_block_id)
+                    block.get('block_id') == source_block_id
+                    for block in self._get_doc_blocks_raw(
+                        document_id, with_descendants=True)
                 )
             except Exception as reconcile_error:
                 raise RuntimeError(
@@ -791,6 +874,7 @@ class FeishuFSBase(LinkDocumentFSBase):
                     document_id,
                     target_parent_block_id,
                     create_index,
+                    created_root_block_id,
                     created_revision,
                 )
             except Exception as rollback_error:
@@ -810,37 +894,82 @@ class FeishuFSBase(LinkDocumentFSBase):
         source_index: int,
         target_parent_block_id: str,
         target_index: int,
-        children_id: List[str],
-        descendants: List[Dict[str, Any]],
+        target_anchor_block_id: str,
+        position: str,
         *,
         document_revision_id: int = -1,
     ) -> Dict[str, Any]:
+        if source_index < 0 or target_index < 0:
+            raise ValueError('move_block source and target indexes must not be negative.')
+        if position not in {'before', 'after'}:
+            raise ValueError('move_block position must be before or after.')
+        source_children = self._get_docx_children(document_id, source_parent_block_id)
+        current_source_index = next(
+            (
+                index for index, block in enumerate(source_children)
+                if block.get('block_id') == source_block_id
+            ),
+            None,
+        )
+        if current_source_index is None:
+            raise ValueError('move source block does not belong to the expected parent.')
+        target_children = (
+            source_children
+            if source_parent_block_id == target_parent_block_id
+            else self._get_docx_children(document_id, target_parent_block_id)
+        )
+        current_anchor_index = next(
+            (
+                index for index, block in enumerate(target_children)
+                if block.get('block_id') == target_anchor_block_id
+            ),
+            None,
+        )
+        if current_anchor_index is None:
+            raise ValueError('move anchor block does not belong to the expected parent.')
+        target_index = current_anchor_index + (1 if position == 'after' else 0)
+        if (
+            source_parent_block_id == target_parent_block_id
+            and current_source_index < current_anchor_index
+        ):
+            target_index -= 1
+
+        source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
+        children_id, descendants, source_by_temporary_id, normalized_fields = \
+            prepare_docx_clone_descendants(source_blocks, source_block_id)
         if len(children_id) != 1:
             raise ValueError('move_block requires exactly one root block.')
         create_index = target_index
-        if source_parent_block_id == target_parent_block_id and source_index < target_index:
+        if (
+            source_parent_block_id == target_parent_block_id
+            and current_source_index < target_index
+        ):
             create_index += 1
-        create_data, created_revision = self._create_and_verify_move_copy(
+        create_data, created_revision, block_id_relations = self._create_and_verify_move_copy(
             document_id,
             target_parent_block_id,
             create_index,
             children_id,
             descendants,
+            source_by_temporary_id,
             document_revision_id,
         )
-        delete_index = source_index
-        if source_parent_block_id == target_parent_block_id and create_index <= source_index:
-            delete_index += len(children_id)
+        created_root_block_id = block_id_relations[source_block_id]
         delete_data = self._delete_move_source(
             document_id,
             source_parent_block_id,
             source_block_id,
-            delete_index,
             target_parent_block_id,
             create_index,
+            created_root_block_id,
             created_revision,
         )
-        return {'create': create_data, 'delete': delete_data}
+        return {
+            'create': create_data,
+            'delete': delete_data,
+            'block_id_relations': block_id_relations,
+            'normalized_fields': normalized_fields,
+        }
 
     def write_doc_blocks(
         self,

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
+from copy import deepcopy
 import re
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -894,15 +895,11 @@ class FeishuFSBase(LinkDocumentFSBase):
         source_index: int,
         target_parent_block_id: str,
         target_index: int,
-        target_anchor_block_id: str,
-        position: str,
         *,
         document_revision_id: int = -1,
     ) -> Dict[str, Any]:
         if source_index < 0 or target_index < 0:
             raise ValueError('move_block source and target indexes must not be negative.')
-        if position not in {'before', 'after'}:
-            raise ValueError('move_block position must be before or after.')
         source_children = self._get_docx_children(document_id, source_parent_block_id)
         current_source_index = next(
             (
@@ -918,21 +915,10 @@ class FeishuFSBase(LinkDocumentFSBase):
             if source_parent_block_id == target_parent_block_id
             else self._get_docx_children(document_id, target_parent_block_id)
         )
-        current_anchor_index = next(
-            (
-                index for index, block in enumerate(target_children)
-                if block.get('block_id') == target_anchor_block_id
-            ),
-            None,
-        )
-        if current_anchor_index is None:
-            raise ValueError('move anchor block does not belong to the expected parent.')
-        target_index = current_anchor_index + (1 if position == 'after' else 0)
-        if (
-            source_parent_block_id == target_parent_block_id
-            and current_source_index < current_anchor_index
-        ):
-            target_index -= 1
+        max_target_index = len(target_children) - (
+            1 if source_parent_block_id == target_parent_block_id else 0)
+        if target_index > max_target_index:
+            raise ValueError('move target index is outside the target parent.')
 
         source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
         children_id, descendants, source_by_temporary_id, normalized_fields = \
@@ -971,6 +957,78 @@ class FeishuFSBase(LinkDocumentFSBase):
             'normalized_fields': normalized_fields,
         }
 
+    def replace_block(
+        self,
+        document_id: str,
+        parent_block_id: str,
+        source_block_id: str,
+        source_index: int,
+        replacement_block: Dict[str, Any],
+        *,
+        document_revision_id: int = -1,
+    ) -> Dict[str, Any]:
+        if source_index < 0:
+            raise ValueError('replace_block source index must not be negative.')
+        siblings = self._get_docx_children(document_id, parent_block_id)
+        current_source_index = next(
+            (
+                index for index, block in enumerate(siblings)
+                if block.get('block_id') == source_block_id
+            ),
+            None,
+        )
+        if current_source_index is None:
+            raise ValueError('replace source block does not belong to the expected parent.')
+        if not isinstance(replacement_block, dict):
+            raise TypeError('replacement_block must be a dict.')
+
+        source_blocks = self._get_doc_blocks_raw(document_id, with_descendants=True)
+        children_id, descendants, source_by_temporary_id, normalized_fields = \
+            prepare_docx_clone_descendants(source_blocks, source_block_id)
+        if len(children_id) != 1:
+            raise ValueError('replace_block requires exactly one root block.')
+
+        root_id = children_id[0]
+        root = next(
+            (block for block in descendants if block.get('block_id') == root_id),
+            None,
+        )
+        if root is None:
+            raise RuntimeError('replace source root is missing from its cloned subtree.')
+        children = root.get('children')
+        root.clear()
+        root.update(deepcopy(replacement_block))
+        root['block_id'] = root_id
+        if children:
+            root['children'] = children
+
+        create_data, created_revision, block_id_relations = \
+            self._create_and_verify_move_copy(
+                document_id,
+                parent_block_id,
+                current_source_index,
+                children_id,
+                descendants,
+                source_by_temporary_id,
+                document_revision_id,
+            )
+        created_root_block_id = block_id_relations[source_block_id]
+        delete_data = self._delete_move_source(
+            document_id,
+            parent_block_id,
+            source_block_id,
+            parent_block_id,
+            current_source_index,
+            created_root_block_id,
+            created_revision,
+        )
+        return {
+            'create': create_data,
+            'delete': delete_data,
+            'block_id_relations': block_id_relations,
+            'normalized_fields': normalized_fields,
+        }
+
     def write_doc_blocks(
         self,
         document_id: str,
@@ -989,6 +1047,45 @@ class FeishuFSBase(LinkDocumentFSBase):
                 'children_id': children_id,
                 'descendants': descendants,
             })
+        return self._get_doc_blocks_raw(document_id, with_descendants=True)
+
+    def replace_doc_blocks(
+        self,
+        document_id: str,
+        blocks: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        '''Replace all root content blocks in an existing Feishu document.'''
+        if not isinstance(blocks, list):
+            raise TypeError(f'blocks must be a list, got {type(blocks).__name__}.')
+        if not blocks:
+            raise ValueError('blocks must not be empty.')
+
+        existing_blocks = self._get_docx_children(document_id, document_id)
+        existing_count = len(existing_blocks)
+        children_id, descendants = self._prepare_docx_descendants(blocks)
+        document_revision_id = -1
+        if descendants:
+            created = self._create_descendant_blocks(
+                document_id,
+                document_id,
+                -1,
+                children_id,
+                descendants,
+            )
+            try:
+                document_revision_id = int(created.get('document_revision_id', -1))
+            except (TypeError, ValueError):
+                document_revision_id = -1
+
+        # Insert first so a failed write never destroys the existing document.
+        if existing_count:
+            self._batch_delete_child_blocks(
+                document_id,
+                document_id,
+                0,
+                existing_count,
+                document_revision_id=document_revision_id,
+            )
         return self._get_doc_blocks_raw(document_id, with_descendants=True)
 
     def _get_table_cells(self, document_id: str, table_block_id: str) -> List[Dict[str, Any]]:

--- a/lazyllm/tools/fs/supplier/feishu.py
+++ b/lazyllm/tools/fs/supplier/feishu.py
@@ -10,6 +10,10 @@ import requests
 from lazyllm import LOG, config
 from lazyllm import globals as lazyllm_globals
 from lazyllm.common import Credential
+from lazyllm.tools.writer.utils.feishu_docx import (
+    DOCX_BLOCK_TYPE_FIELDS,
+    prepare_docx_descendants,
+)
 from ..base import LazyLLMFSBase, LinkDocumentFSBase, CloudFSBufferedFile
 
 config.add('feishu_app_id', str, None, 'FEISHU_APP_ID', description='Feishu App ID for tenant_access_token.')
@@ -290,13 +294,7 @@ class FeishuFSBase(LinkDocumentFSBase):
                             json={'upload_id': upload_id, 'block_num': num_blocks})
         return result.get('data', {}).get('file_token', '')
 
-    _DOCX_BLOCK_TYPE_KEY: Dict[int, str] = {
-        1: 'page', 2: 'text', 3: 'heading1', 4: 'heading2', 5: 'heading3', 6: 'heading4',
-        7: 'heading5', 8: 'heading6', 9: 'heading7', 10: 'heading8', 11: 'heading9',
-        12: 'bullet', 13: 'ordered', 14: 'code', 15: 'quote', 17: 'todo',
-        19: 'callout', 22: 'divider', 24: 'grid', 25: 'grid_column',
-        31: 'table', 32: 'table_cell', 34: 'quote_container',
-    }
+    _DOCX_BLOCK_TYPE_KEY = DOCX_BLOCK_TYPE_FIELDS
 
     @staticmethod
     def _docx_element_plain_text(element: Dict[str, Any]) -> str:
@@ -411,45 +409,7 @@ class FeishuFSBase(LinkDocumentFSBase):
     def _prepare_docx_descendants(
         cls, blocks: List[Dict[str, Any]],
     ) -> Tuple[List[str], List[Dict[str, Any]]]:
-        content_blocks = [block for block in blocks if block.get('block_type') != 1]
-        raw_by_id = {block['block_id']: block for block in content_blocks}
-        children_by_parent: Dict[str, List[str]] = {}
-        for block in content_blocks:
-            parent_id = block.get('parent_id')
-            if parent_id in raw_by_id:
-                children_by_parent.setdefault(parent_id, []).append(block['block_id'])
-
-        root_block_ids: List[str] = []
-        descendants: List[Dict[str, Any]] = []
-        for block in content_blocks:
-            block_id = block['block_id']
-            block_type = block.get('block_type')
-            content_key = cls._DOCX_BLOCK_TYPE_KEY.get(block_type)
-            if content_key is None:
-                raise ValueError(f'Feishu block type {block_type!r} is not supported for structured writing.')
-            content = block.get(content_key)
-            if block_type == 22 and content is None:
-                content = {}
-            content = dict(content)
-            if block_type == 31:
-                content.pop('cells', None)
-                content.pop('merge_info', None)
-                prop = dict(content.get('property') or {})
-                prop.pop('merge_info', None)
-                content['property'] = prop
-
-            descendant = {
-                'block_id': block_id,
-                'block_type': block_type,
-                content_key: content,
-            }
-            children = children_by_parent.get(block_id)
-            if children:
-                descendant['children'] = children
-            descendants.append(descendant)
-            if block.get('parent_id') not in raw_by_id:
-                root_block_ids.append(block_id)
-        return root_block_ids, descendants
+        return prepare_docx_descendants(blocks)
 
     def _resolve_and_insert_children(
         self,
@@ -600,10 +560,13 @@ class FeishuFSBase(LinkDocumentFSBase):
         index: int,
         children_id: List[str],
         descendants: List[Dict[str, Any]],
+        *,
+        document_revision_id: int = -1,
     ) -> Dict[str, Any]:
         url = f'{self._base_url}/docx/v1/documents/{document_id}/blocks/{parent_block_id}/descendant'
         response = self._post(
             url,
+            params={'document_revision_id': document_revision_id},
             json={
                 'index': index,
                 'children_id': children_id,
@@ -654,9 +617,17 @@ class FeishuFSBase(LinkDocumentFSBase):
         index: int,
         children_id: List[str],
         descendants: List[Dict[str, Any]],
+        *,
+        document_revision_id: int = -1,
     ) -> Dict[str, Any]:
         return self._create_descendant_blocks(
-            document_id, parent_block_id, index, children_id, descendants)
+            document_id,
+            parent_block_id,
+            index,
+            children_id,
+            descendants,
+            document_revision_id=document_revision_id,
+        )
 
     def update_block(
         self,
@@ -705,37 +676,169 @@ class FeishuFSBase(LinkDocumentFSBase):
             document_revision_id=document_revision_id,
         )
 
-    def move_block(
+    def _rollback_move_copy(
         self,
         document_id: str,
-        source_parent_block_id: str,
-        source_index: int,
         target_parent_block_id: str,
-        target_index: int,
+        create_index: int,
+        document_revision_id: int,
+    ) -> Dict[str, Any]:
+        return self._batch_delete_child_blocks(
+            document_id,
+            target_parent_block_id,
+            create_index,
+            create_index + 1,
+            document_revision_id=document_revision_id,
+        )
+
+    def _verify_move_copy(
+        self,
+        document_id: str,
+        target_parent_block_id: str,
+        create_index: int,
+        root_id: str,
+        descendants: List[Dict[str, Any]],
+    ) -> None:
+        created_children = self._get_docx_children(document_id, target_parent_block_id)
+        created_root = created_children[create_index]
+        expected_root = next(
+            item for item in descendants if item.get('block_id') == root_id)
+        if created_root.get('block_type') != expected_root.get('block_type'):
+            raise RuntimeError('created move root has a different block type.')
+        expected_text = self._docx_block_plain_text(expected_root)
+        if expected_text and self._docx_block_plain_text(created_root) != expected_text:
+            raise RuntimeError('created move root has different text content.')
+
+    def _create_and_verify_move_copy(
+        self,
+        document_id: str,
+        target_parent_block_id: str,
+        create_index: int,
         children_id: List[str],
         descendants: List[Dict[str, Any]],
-    ) -> Dict[str, Any]:
-        if len(children_id) != 1:
-            raise ValueError('move_block requires exactly one root block.')
-        create_index = target_index
-        if source_parent_block_id == target_parent_block_id and source_index < target_index:
-            create_index += 1
+        document_revision_id: int,
+    ) -> Tuple[Dict[str, Any], int]:
         create_data = self._create_descendant_blocks(
             document_id,
             target_parent_block_id,
             create_index,
             children_id,
             descendants,
+            document_revision_id=document_revision_id,
+        )
+        created_revision = create_data.get('document_revision_id', -1)
+        if not isinstance(created_revision, int) or isinstance(created_revision, bool):
+            created_revision = -1
+        try:
+            self._verify_move_copy(
+                document_id,
+                target_parent_block_id,
+                create_index,
+                children_id[0],
+                descendants,
+            )
+        except Exception as verify_error:
+            try:
+                self._rollback_move_copy(
+                    document_id,
+                    target_parent_block_id,
+                    create_index,
+                    created_revision,
+                )
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    'move_block partially applied: target copy verification failed and '
+                    f'rollback failed: {rollback_error}'
+                ) from verify_error
+            raise RuntimeError(
+                'move_block aborted: target copy verification failed and was rolled back.'
+            ) from verify_error
+        return create_data, created_revision
+
+    def _delete_move_source(
+        self,
+        document_id: str,
+        source_parent_block_id: str,
+        source_block_id: str,
+        delete_index: int,
+        target_parent_block_id: str,
+        create_index: int,
+        created_revision: int,
+    ) -> Dict[str, Any]:
+        try:
+            return self._batch_delete_child_blocks(
+                document_id,
+                source_parent_block_id,
+                delete_index,
+                delete_index + 1,
+                document_revision_id=created_revision,
+            )
+        except Exception as delete_error:
+            try:
+                source_still_exists = any(
+                    child.get('block_id') == source_block_id
+                    for child in self._get_docx_children(document_id, source_parent_block_id)
+                )
+            except Exception as reconcile_error:
+                raise RuntimeError(
+                    'move_block outcome is uncertain: source delete failed and source '
+                    f'presence could not be checked: {reconcile_error}'
+                ) from delete_error
+            if not source_still_exists:
+                return {'status': 'confirmed_after_error'}
+            try:
+                self._rollback_move_copy(
+                    document_id,
+                    target_parent_block_id,
+                    create_index,
+                    created_revision,
+                )
+            except Exception as rollback_error:
+                raise RuntimeError(
+                    'move_block partially applied: source delete failed and target-copy '
+                    f'rollback failed: {rollback_error}'
+                ) from delete_error
+            raise RuntimeError(
+                'move_block aborted: source delete failed and target copy was rolled back.'
+            ) from delete_error
+
+    def move_block(
+        self,
+        document_id: str,
+        source_parent_block_id: str,
+        source_block_id: str,
+        source_index: int,
+        target_parent_block_id: str,
+        target_index: int,
+        children_id: List[str],
+        descendants: List[Dict[str, Any]],
+        *,
+        document_revision_id: int = -1,
+    ) -> Dict[str, Any]:
+        if len(children_id) != 1:
+            raise ValueError('move_block requires exactly one root block.')
+        create_index = target_index
+        if source_parent_block_id == target_parent_block_id and source_index < target_index:
+            create_index += 1
+        create_data, created_revision = self._create_and_verify_move_copy(
+            document_id,
+            target_parent_block_id,
+            create_index,
+            children_id,
+            descendants,
+            document_revision_id,
         )
         delete_index = source_index
         if source_parent_block_id == target_parent_block_id and create_index <= source_index:
             delete_index += len(children_id)
-        delete_data = self._batch_delete_child_blocks(
+        delete_data = self._delete_move_source(
             document_id,
             source_parent_block_id,
+            source_block_id,
             delete_index,
-            delete_index + 1,
-            document_revision_id=create_data.get('document_revision_id', -1),
+            target_parent_block_id,
+            create_index,
+            created_revision,
         )
         return {'create': create_data, 'delete': delete_data}
 

--- a/lazyllm/tools/writer/adapter/base.py
+++ b/lazyllm/tools/writer/adapter/base.py
@@ -10,7 +10,7 @@ from ..data_models.writer_ir import WriterDocument, WriterStage
 
 
 NativeBlock = Dict[str, Any]
-NativePatchOperationType = Literal['create', 'update', 'delete', 'move']
+NativePatchOperationType = Literal['create', 'update', 'replace', 'delete', 'move']
 
 
 @dataclass(frozen=True)

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -237,7 +237,6 @@ class FeishuWriterAdapter(WriterAdapterBase):
             previous = previous_blocks.get(block.node_id)
             if previous is None:
                 continue
-            block.status = previous.status
             block.authoring = deepcopy(previous.authoring)
             block.references = deepcopy(previous.references)
         return WriterDocument.model_validate(refreshed_document.model_dump())

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -83,11 +83,30 @@ class FeishuWriterAdapter(WriterAdapterBase):
             )
             for index, block_id in enumerate(source_order)
         }
+        page_ids = {
+            block_id
+            for block_id in source_order
+            if raw_by_id[block_id].get('block_type') == 1
+        }
+
+        def visible_children(block_ids: List[str]) -> List[WriterBlock]:
+            visible: List[WriterBlock] = []
+            for block_id in block_ids:
+                if block_id in page_ids:
+                    visible.extend(visible_children(child_ids.get(block_id, [])))
+                else:
+                    visible.append(writer_by_id[block_id])
+            return visible
+
         for parent_id, children in child_ids.items():
-            writer_by_id[parent_id].children = [writer_by_id[child_id] for child_id in children]
+            if parent_id not in page_ids:
+                writer_by_id[parent_id].children = visible_children(children)
 
         nested_ids = {child_id for children in child_ids.values() for child_id in children}
-        root_blocks = [writer_by_id[block_id] for block_id in source_order if block_id not in nested_ids]
+        root_ids = [block_id for block_id in source_order if block_id not in nested_ids]
+        # A Feishu Page block is the provider's document container. WriterDocument
+        # already represents that container, so expose only its content blocks in IR.
+        root_blocks = visible_children(root_ids)
         resolved_title = title
         if not resolved_title:
             document_block = next((

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..utils.feishu_docx import DOCX_BLOCK_TYPE_FIELDS, prepare_docx_descendants
-from ..data_models.revision import PatchBlock, PatchHunk
+from ..data_models.revision import PatchHunk
 from ..data_models.writer_ir import WriterBlock, WriterDocument, WriterSpan, WriterStage
 from .base import NativeBlock, NativePatchOperation, WriterAdapterBase
 
@@ -26,13 +26,15 @@ _IR_BLOCK_TYPES: Dict[str, int] = {
 
 _TEXT_BLOCK_TYPES = frozenset(range(2, 16)) | {17}
 _STYLE_TO_IR = {
-    'bold': 'strong',
+    'bold': 'bold',
     'italic': 'italic',
     'underline': 'underline',
     'strikethrough': 'strikethrough',
-    'inline_code': 'code',
+    'inline_code': 'inline_code',
 }
-_STYLE_FROM_IR = {value: key for key, value in _STYLE_TO_IR.items()}
+_VALUE_STYLE_FIELDS = {
+    'text_color', 'background_color', 'font_size', 'font_family',
+}
 _ELEMENT_TEXT_FIELDS = ('content', 'title', 'name', 'text')
 
 
@@ -56,19 +58,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
         if not isinstance(blocks, list):
             raise TypeError(f'blocks must be a list, got {type(blocks).__name__}.')
 
-        raw_by_id: Dict[str, NativeBlock] = {}
-        source_order: List[str] = []
-        for index, raw in enumerate(blocks):
-            if not isinstance(raw, dict):
-                raise TypeError(f'blocks[{index}] must be a dict, got {type(raw).__name__}.')
-            block_id = raw.get('block_id')
-            if not isinstance(block_id, str) or not block_id.strip():
-                raise ValueError(f'blocks[{index}].block_id must be a non-empty string.')
-            block_id = block_id.strip()
-            if block_id in raw_by_id:
-                raise ValueError(f'duplicate Feishu block_id: {block_id!r}.')
-            raw_by_id[block_id] = raw
-            source_order.append(block_id)
+        raw_by_id, source_order = self._index_raw_blocks(blocks)
 
         child_ids = self._build_child_relations(raw_by_id, source_order)
         self._validate_relations(child_ids, source_order)
@@ -136,6 +126,25 @@ class FeishuWriterAdapter(WriterAdapterBase):
             ui_editable=False,
         )
 
+    @staticmethod
+    def _index_raw_blocks(
+        blocks: List[NativeBlock],
+    ) -> Tuple[Dict[str, NativeBlock], List[str]]:
+        raw_by_id: Dict[str, NativeBlock] = {}
+        source_order: List[str] = []
+        for index, raw in enumerate(blocks):
+            if not isinstance(raw, dict):
+                raise TypeError(f'blocks[{index}] must be a dict, got {type(raw).__name__}.')
+            block_id = raw.get('block_id')
+            if not isinstance(block_id, str) or not block_id.strip():
+                raise ValueError(f'blocks[{index}].block_id must be a non-empty string.')
+            block_id = block_id.strip()
+            if block_id in raw_by_id:
+                raise ValueError(f'duplicate Feishu block_id: {block_id!r}.')
+            raw_by_id[block_id] = raw
+            source_order.append(block_id)
+        return raw_by_id, source_order
+
     def ir_to_blocks(self, document: WriterDocument) -> List[NativeBlock]:
         if not isinstance(document, WriterDocument):
             raise TypeError(
@@ -187,8 +196,8 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 f'document must be a WriterDocument, got {type(document).__name__}.')
 
         handlers = {
-            'replace': self._replace_patch_to_operation,
-            'insert': self._insert_patch_to_operation,
+            'update': self._update_patch_to_operation,
+            'create': self._create_patch_to_operation,
             'delete': self._delete_patch_to_operation,
             'move': self._move_patch_to_operation,
         }
@@ -212,13 +221,35 @@ class FeishuWriterAdapter(WriterAdapterBase):
             if node_id is not None:
                 block.node_id = node_id
 
-        if operation is not None and operation.operation == 'move':
+        if operation is not None and operation.operation == 'create':
+            relations = (
+                operation_result.get('block_id_relations')
+                if isinstance(operation_result, dict) else None
+            )
+            if not isinstance(relations, list) or not relations:
+                raise ValueError('create operation did not return Feishu block ID relations.')
+            refreshed_by_block_id = {
+                block.provider_binding.get('block_id'): block
+                for block in refreshed_document.iter_blocks()
+                if isinstance(block.provider_binding.get('block_id'), str)
+            }
+            for relation in relations:
+                if not isinstance(relation, dict):
+                    continue
+                temporary_id = relation.get('temporary_block_id')
+                created_id = relation.get('block_id')
+                refreshed = refreshed_by_block_id.get(created_id)
+                if isinstance(temporary_id, str) and refreshed is not None:
+                    refreshed.node_id = temporary_id
+
+        if operation is not None and operation.operation in {'move', 'replace'}:
             relations = (
                 operation_result.get('block_id_relations')
                 if isinstance(operation_result, dict) else None
             )
             if not isinstance(relations, dict) or not relations:
-                raise ValueError('move operation did not return Feishu block ID relations.')
+                raise ValueError(
+                    f'{operation.operation} operation did not return Feishu block ID relations.')
             refreshed_by_block_id = {
                 block.provider_binding.get('block_id'): block
                 for block in refreshed_document.iter_blocks()
@@ -241,93 +272,86 @@ class FeishuWriterAdapter(WriterAdapterBase):
             block.references = deepcopy(previous.references)
         return WriterDocument.model_validate(refreshed_document.model_dump())
 
-    def _replace_patch_to_operation(
+    def _update_patch_to_operation(
         self,
         patch: PatchHunk,
         document: WriterDocument,
     ) -> NativePatchOperation:
-        '''Convert replace into a Feishu batch-update operation.'''
-
+        '''Convert a semantic block update into a Feishu update or replacement.'''
         block = document.block_by_id(patch.target_node_id)
         if block is None:
             raise ValueError(f'patch target node does not exist: {patch.target_node_id!r}.')
-        provider = block.provider_binding.get('provider')
-        if provider != self.provider:
-            raise ValueError(
-                f'patch target provider must be {self.provider!r}, got {provider!r}.')
-        block_id = block.provider_binding.get('block_id')
-        if not isinstance(block_id, str) or not block_id.strip():
-            raise ValueError('patch target does not have a Feishu block_id binding.')
+        if patch.block is None:
+            raise ValueError('update patch must provide block.')
+        block_id = self._require_feishu_binding(block, 'update target')
         raw_block = self._raw_payload(block)
-        block_type = raw_block.get('block_type')
-        if block_type not in _TEXT_BLOCK_TYPES or not block.editable:
+        original_type = raw_block.get('block_type')
+        if original_type not in _TEXT_BLOCK_TYPES or not block.editable:
             raise ValueError(
-                f'Feishu block type {block_type!r} does not support text replacement.')
-        if patch.new_text is None:
-            raise ValueError('replace patch must provide new_text.')
+                f'Feishu block type {original_type!r} does not support updates.')
 
-        replacement = patch.new_text
-        if patch.text_range is None:
-            if patch.old_text is not None and patch.old_text != block.content:
-                raise ValueError('patch old_text does not match the current block content.')
-        else:
-            start, end = patch.text_range
-            if start < 0 or end < start or end > len(block.content):
-                raise ValueError('patch text_range is outside the current block content.')
-            selected = block.content[start:end]
-            if patch.old_text is not None and patch.old_text != selected:
-                raise ValueError('patch old_text does not match the selected text range.')
-            replacement = f'{block.content[:start]}{replacement}{block.content[end:]}'
+        desired = block.model_copy(deep=True)
+        for field in (
+            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
+        ):
+            setattr(desired, field, deepcopy(getattr(patch.block, field)))
+        desired_raw = self._ir_block_to_raw(desired)
+        desired_type = desired_raw.get('block_type')
+
+        if desired_type != original_type:
+            _, parent, index = self._block_location(document, block.node_id)
+            content_field = _BLOCK_TYPE_FIELDS.get(desired_type)
+            if content_field is None:
+                raise ValueError(
+                    f'Feishu block type {desired_type!r} cannot replace a block.')
+            replacement_block = {
+                'block_type': desired_type,
+                content_field: deepcopy(desired_raw.get(content_field) or {}),
+            }
+            return NativePatchOperation(
+                operation='replace',
+                params={
+                    'parent_block_id': self._parent_block_id(document, block, parent),
+                    'source_block_id': block_id,
+                    'source_index': index,
+                    'replacement_block': replacement_block,
+                },
+            )
 
         return NativePatchOperation(
             operation='update',
             params={
                 'requests': [{
-                    'block_id': block_id.strip(),
+                    'block_id': block_id,
                     'update_text_elements': {
-                        'elements': self._replace_text_elements(
-                            raw_block, block.content, replacement),
+                        'elements': self._spans_to_elements(desired),
                     },
                 }],
             },
         )
 
-    def _insert_patch_to_operation(
+    def _create_patch_to_operation(
         self,
         patch: PatchHunk,
         document: WriterDocument,
     ) -> NativePatchOperation:
-        '''Convert insert into Feishu create_block parameters.'''
-        anchor_id = patch.anchor_node_id or patch.target_node_id
-        anchor, parent, anchor_index = self._block_location(document, anchor_id)
-        self._require_feishu_binding(anchor, 'insert anchor')
+        '''Convert a semantic block creation into Feishu descendant creation.'''
+        if patch.block is None or patch.index is None:
+            raise ValueError('create patch requires block and index.')
+        parent_block_id = document.provider_binding.get('document_id')
+        if patch.parent_node_id is not None:
+            parent = document.block_by_id(patch.parent_node_id)
+            if parent is None:
+                raise ValueError(
+                    f'create parent {patch.parent_node_id!r} is absent from document.')
+            parent_block_id = self._require_feishu_binding(parent, 'create parent')
+        if not isinstance(parent_block_id, str) or not parent_block_id:
+            raise ValueError('create patch does not have a Feishu parent binding.')
 
-        position = patch.position or 'after'
-        insert_index = anchor_index + (1 if position == 'after' else 0)
-        parent_block_id = self._parent_block_id(document, anchor, parent)
-
-        patch_blocks = patch.new_blocks
-        if not patch_blocks:
-            if patch.new_text is None:
-                raise ValueError('insert patch must provide new_blocks or new_text.')
-            patch_blocks = [PatchBlock(type='paragraph', content=patch.new_text)]
-
-        id_prefix = patch.hunk_id or f'{patch.target_node_id}::insert'
-        writer_blocks = [
-            WriterBlock(
-                node_id=f'{id_prefix}::{index}',
-                type=patch_block.type,
-                content=patch_block.content,
-                stage=document.stage,
-                authoring=patch_block.authoring,
-                numbering=deepcopy(patch_block.numbering),
-            )
-            for index, patch_block in enumerate(patch_blocks)
-        ]
         inserted_document = WriterDocument(
-            document_id=f'{document.document_id}::insert::{id_prefix}',
+            document_id=f'{document.document_id}::create::{patch.target_node_id}',
             stage=document.stage,
-            blocks=writer_blocks,
+            blocks=[patch.block.model_copy(deep=True)],
             provider_binding={
                 'provider': self.provider,
                 'document_id': document.provider_binding.get('document_id', ''),
@@ -339,7 +363,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
             operation='create',
             params={
                 'parent_block_id': parent_block_id,
-                'index': insert_index,
+                'index': patch.index,
                 'children_id': children_id,
                 'descendants': descendants,
             },
@@ -355,8 +379,6 @@ class FeishuWriterAdapter(WriterAdapterBase):
         self._require_feishu_binding(block, 'delete target')
         if block.type == 'document':
             raise ValueError('delete patch cannot remove the Feishu document block.')
-        if patch.old_text is not None and patch.old_text != block.content:
-            raise ValueError('patch old_text does not match the current block content.')
         return NativePatchOperation(
             operation='delete',
             params={
@@ -374,25 +396,25 @@ class FeishuWriterAdapter(WriterAdapterBase):
         '''Convert move into Feishu move_block parameters.'''
         source, source_parent, source_index = self._block_location(
             document, patch.target_node_id)
-        anchor, target_parent, anchor_index = self._block_location(
-            document, patch.anchor_node_id or '')
         source_block_id = self._require_feishu_binding(source, 'move source')
-        anchor_block_id = self._require_feishu_binding(anchor, 'move anchor')
         if source.type == 'document':
             raise ValueError('move patch cannot move the Feishu document block.')
-        if patch.old_text is not None and patch.old_text != source.content:
-            raise ValueError('patch old_text does not match the current block content.')
-        if self._subtree_contains(source, anchor.node_id):
-            raise ValueError('move patch anchor cannot be the source node or its descendant.')
+        if patch.index is None:
+            raise ValueError('move patch requires index.')
+        if patch.parent_node_id and self._subtree_contains(source, patch.parent_node_id):
+            raise ValueError('move target parent cannot be inside the source subtree.')
 
         source_parent_block_id = self._parent_block_id(document, source, source_parent)
-        target_parent_block_id = self._parent_block_id(document, anchor, target_parent)
-        target_index = anchor_index + (1 if patch.position == 'after' else 0)
-        if (
-            source_parent_block_id == target_parent_block_id
-            and source_index < anchor_index
-        ):
-            target_index -= 1
+        target_parent_block_id = document.provider_binding.get('document_id')
+        if patch.parent_node_id is not None:
+            target_parent = document.block_by_id(patch.parent_node_id)
+            if target_parent is None:
+                raise ValueError(
+                    f'move parent {patch.parent_node_id!r} is absent from document.')
+            target_parent_block_id = self._require_feishu_binding(
+                target_parent, 'move parent')
+        if not isinstance(target_parent_block_id, str) or not target_parent_block_id:
+            raise ValueError('move patch does not have a Feishu target parent binding.')
 
         return NativePatchOperation(
             operation='move',
@@ -401,9 +423,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 'source_block_id': source_block_id,
                 'source_index': source_index,
                 'target_parent_block_id': target_parent_block_id,
-                'target_index': target_index,
-                'target_anchor_block_id': anchor_block_id,
-                'position': patch.position,
+                'target_index': patch.index,
             },
         )
 
@@ -636,19 +656,28 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 if not isinstance(text, str):
                     text = ''
                 raw_style = text_run.get('text_element_style') or {}
-                styles = [
-                    ir_style for feishu_style, ir_style in _STYLE_TO_IR.items()
+                styles: Dict[str, Any] = {
+                    ir_style: True
+                    for feishu_style, ir_style in _STYLE_TO_IR.items()
                     if raw_style.get(feishu_style) is True
-                ]
+                }
+                styles.update({
+                    field: deepcopy(raw_style[field])
+                    for field in _VALUE_STYLE_FIELDS
+                    if field in raw_style
+                })
                 if isinstance(raw_style.get('link'), dict) and raw_style['link'].get('url'):
-                    styles.append('link')
+                    styles['link'] = {'url': raw_style['link']['url']}
                 spans.append(WriterSpan(text=text, style=styles))
                 continue
 
             for element_type, value in element.items():
                 text = cls._element_plain_text(value)
                 if text:
-                    spans.append(WriterSpan(text=text, style=[f'feishu:{element_type}']))
+                    spans.append(WriterSpan(
+                        text=text,
+                        style={'feishu:element_type': element_type},
+                    ))
                 break
 
         if spans:
@@ -672,15 +701,23 @@ class FeishuWriterAdapter(WriterAdapterBase):
             return cls._plain_text_elements(block.content)
         elements: List[Dict[str, Any]] = []
         for span in block.spans:
-            unsupported = [style for style in span.style if style.startswith('feishu:')]
-            if unsupported:
+            provider_element = span.style.get('feishu:element_type')
+            if provider_element:
                 raise ValueError(
-                    f'cannot reconstruct provider elements from span styles: {unsupported}.')
+                    f'cannot reconstruct provider element {provider_element!r} from WriterSpan.')
             raw_style = {
-                _STYLE_FROM_IR[style]: True
-                for style in span.style
-                if style in _STYLE_FROM_IR
+                feishu_style: True
+                for feishu_style, ir_style in _STYLE_TO_IR.items()
+                if span.style.get(ir_style) is True
             }
+            raw_style.update({
+                field: deepcopy(span.style[field])
+                for field in _VALUE_STYLE_FIELDS
+                if field in span.style
+            })
+            link = span.style.get('link')
+            if isinstance(link, dict) and isinstance(link.get('url'), str):
+                raw_style['link'] = {'url': link['url']}
             text_run: Dict[str, Any] = {'content': span.text}
             if raw_style:
                 text_run['text_element_style'] = raw_style

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from ...fs.supplier.feishu import FeishuFSBase
+from ..utils.feishu_docx import DOCX_BLOCK_TYPE_FIELDS, prepare_docx_descendants
 from ..data_models.revision import PatchBlock, PatchHunk
 from ..data_models.writer_ir import WriterBlock, WriterDocument, WriterSpan, WriterStage
 from .base import NativeBlock, NativePatchOperation, WriterAdapterBase
 
 
-_BLOCK_TYPE_FIELDS = FeishuFSBase._DOCX_BLOCK_TYPE_KEY
+_BLOCK_TYPE_FIELDS = DOCX_BLOCK_TYPE_FIELDS
 
 _BLOCK_TYPE_NAMES: Dict[int, str] = {
     1: 'document', 2: 'paragraph',
@@ -166,7 +166,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
         }
         return handlers[patch.modify_type](patch, document)
 
-    def merge_refreshed_document(
+    def merge_refreshed_document(  # noqa: C901
         self,
         previous_document: WriterDocument,
         refreshed_document: WriterDocument,
@@ -325,7 +325,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 'document_id': document.provider_binding.get('document_id', ''),
             },
         )
-        children_id, descendants = FeishuFSBase._prepare_docx_descendants(
+        children_id, descendants = prepare_docx_descendants(
             self.ir_to_blocks(inserted_document))
         return NativePatchOperation(
             operation='create',
@@ -368,7 +368,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
             document, patch.target_node_id)
         anchor, target_parent, anchor_index = self._block_location(
             document, patch.anchor_node_id or '')
-        self._require_feishu_binding(source, 'move source')
+        source_block_id = self._require_feishu_binding(source, 'move source')
         self._require_feishu_binding(anchor, 'move anchor')
         if source.type == 'document':
             raise ValueError('move patch cannot move the Feishu document block.')
@@ -397,7 +397,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 'document_id': document.provider_binding.get('document_id', ''),
             },
         )
-        children_id, descendants = FeishuFSBase._prepare_docx_descendants(
+        children_id, descendants = prepare_docx_descendants(
             self.ir_to_blocks(moved_document))
         if len(children_id) != 1:
             raise ValueError('move patch must produce exactly one root Feishu block.')
@@ -405,6 +405,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
             operation='move',
             params={
                 'source_parent_block_id': source_parent_block_id,
+                'source_block_id': source_block_id,
                 'source_index': source_index,
                 'target_parent_block_id': target_parent_block_id,
                 'target_index': target_index,
@@ -492,6 +493,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
             FeishuWriterAdapter._subtree_contains(child, node_id)
             for child in root.children
         )
+
     def _raw_block_to_ir(
         self,
         raw: NativeBlock,

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -181,6 +181,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
         refreshed_document: WriterDocument,
         patch: Optional[PatchHunk] = None,
         operation: Optional[NativePatchOperation] = None,
+        operation_result: Optional[Dict[str, Any]] = None,
     ) -> WriterDocument:
         previous_ids = {
             block.provider_binding.get('block_id'): block.node_id
@@ -192,45 +193,25 @@ class FeishuWriterAdapter(WriterAdapterBase):
             if node_id is not None:
                 block.node_id = node_id
 
-        if operation is not None and operation.operation == 'move' and patch is not None:
-            previous_root = previous_document.block_by_id(patch.target_node_id)
-            if previous_root is None:
-                raise ValueError(
-                    f'move target node disappeared before synchronization: {patch.target_node_id!r}.'
-                )
-            target_parent_id = operation.params.get('target_parent_block_id')
-            target_index = operation.params.get('target_index')
-            if not isinstance(target_parent_id, str) or not isinstance(target_index, int):
-                raise ValueError('move operation lacks a valid target parent or target index.')
-            target_parent = next(
-                (
-                    block for block in refreshed_document.iter_blocks()
-                    if block.provider_binding.get('block_id') == target_parent_id
-                ),
-                None,
+        if operation is not None and operation.operation == 'move':
+            relations = (
+                operation_result.get('block_id_relations')
+                if isinstance(operation_result, dict) else None
             )
-            if target_parent is not None:
-                target_children = target_parent.children
-            elif refreshed_document.provider_binding.get('document_id') == target_parent_id:
-                target_children = refreshed_document.blocks
-            else:
-                raise ValueError(
-                    f'refreshed document does not contain target parent block {target_parent_id!r}.')
-            if target_index < 0 or target_index >= len(target_children):
-                raise ValueError('moved block is absent from the refreshed target position.')
-
-            def restore_subtree(previous: WriterBlock, refreshed: WriterBlock) -> None:
-                if (
-                    previous.type != refreshed.type
-                    or previous.content != refreshed.content
-                    or len(previous.children) != len(refreshed.children)
-                ):
-                    raise ValueError('refreshed moved subtree does not match the source subtree.')
-                refreshed.node_id = previous.node_id
-                for previous_child, refreshed_child in zip(previous.children, refreshed.children):
-                    restore_subtree(previous_child, refreshed_child)
-
-            restore_subtree(previous_root, target_children[target_index])
+            if not isinstance(relations, dict) or not relations:
+                raise ValueError('move operation did not return Feishu block ID relations.')
+            refreshed_by_block_id = {
+                block.provider_binding.get('block_id'): block
+                for block in refreshed_document.iter_blocks()
+                if isinstance(block.provider_binding.get('block_id'), str)
+            }
+            for source_block_id, created_block_id in relations.items():
+                node_id = previous_ids.get(source_block_id)
+                refreshed = refreshed_by_block_id.get(created_block_id)
+                if node_id is None or refreshed is None:
+                    raise ValueError(
+                        'move block ID relations do not match the refreshed document.')
+                refreshed.node_id = node_id
 
         previous_blocks = {block.node_id: block for block in previous_document.iter_blocks()}
         for block in refreshed_document.iter_blocks():
@@ -377,7 +358,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
         anchor, target_parent, anchor_index = self._block_location(
             document, patch.anchor_node_id or '')
         source_block_id = self._require_feishu_binding(source, 'move source')
-        self._require_feishu_binding(anchor, 'move anchor')
+        anchor_block_id = self._require_feishu_binding(anchor, 'move anchor')
         if source.type == 'document':
             raise ValueError('move patch cannot move the Feishu document block.')
         if patch.old_text is not None and patch.old_text != source.content:
@@ -394,21 +375,6 @@ class FeishuWriterAdapter(WriterAdapterBase):
         ):
             target_index -= 1
 
-        id_prefix = patch.hunk_id or f'{patch.target_node_id}::move'
-        moved_root = self._clone_subtree_with_temporary_ids(source, id_prefix)
-        moved_document = WriterDocument(
-            document_id=f'{document.document_id}::move::{id_prefix}',
-            stage=document.stage,
-            blocks=[moved_root],
-            provider_binding={
-                'provider': self.provider,
-                'document_id': document.provider_binding.get('document_id', ''),
-            },
-        )
-        children_id, descendants = prepare_docx_descendants(
-            self.ir_to_blocks(moved_document))
-        if len(children_id) != 1:
-            raise ValueError('move patch must produce exactly one root Feishu block.')
         return NativePatchOperation(
             operation='move',
             params={
@@ -417,8 +383,8 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 'source_index': source_index,
                 'target_parent_block_id': target_parent_block_id,
                 'target_index': target_index,
-                'children_id': children_id,
-                'descendants': descendants,
+                'target_anchor_block_id': anchor_block_id,
+                'position': patch.position,
             },
         )
 
@@ -468,32 +434,6 @@ class FeishuWriterAdapter(WriterAdapterBase):
         if not isinstance(parent_block_id, str) or not parent_block_id.strip():
             raise ValueError('patch target does not have a Feishu parent block binding.')
         return parent_block_id.strip()
-
-    @classmethod
-    def _clone_subtree_with_temporary_ids(
-        self,
-        root: WriterBlock,
-        id_prefix: str,
-    ) -> WriterBlock:
-        cloned = root.model_copy(deep=True)
-        index = 0
-
-        def assign(block: WriterBlock) -> None:
-            nonlocal index
-            temporary_id = f'{id_prefix}::{index}'
-            index += 1
-            raw = deepcopy(self._raw_payload(block))
-            raw['block_id'] = temporary_id
-            raw.pop('parent_id', None)
-            raw.pop('children', None)
-            block.node_id = temporary_id
-            block.provider_binding = {}
-            block.provider_payload = {'raw_block': raw}
-            for child in block.children:
-                assign(child)
-
-        assign(cloned)
-        return cloned
 
     @staticmethod
     def _subtree_contains(root: WriterBlock, node_id: str) -> bool:

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -3,18 +3,13 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from ..data_models.revision import PatchHunk
+from ...fs.supplier.feishu import FeishuFSBase
+from ..data_models.revision import PatchBlock, PatchHunk
 from ..data_models.writer_ir import WriterBlock, WriterDocument, WriterSpan, WriterStage
 from .base import NativeBlock, NativePatchOperation, WriterAdapterBase
 
 
-_BLOCK_TYPE_FIELDS: Dict[int, str] = {
-    1: 'page', 2: 'text',
-    **{block_type: f'heading{block_type - 2}' for block_type in range(3, 12)},
-    12: 'bullet', 13: 'ordered', 14: 'code', 15: 'quote', 17: 'todo',
-    19: 'callout', 22: 'divider', 24: 'grid', 25: 'grid_column',
-    31: 'table', 32: 'table_cell', 34: 'quote_container',
-}
+_BLOCK_TYPE_FIELDS = FeishuFSBase._DOCX_BLOCK_TYPE_KEY
 
 _BLOCK_TYPE_NAMES: Dict[int, str] = {
     1: 'document', 2: 'paragraph',
@@ -39,6 +34,8 @@ _STYLE_TO_IR = {
 }
 _STYLE_FROM_IR = {value: key for key, value in _STYLE_TO_IR.items()}
 _ELEMENT_TEXT_FIELDS = ('content', 'title', 'name', 'text')
+
+
 class FeishuWriterAdapter(WriterAdapterBase):
     '''Convert between Feishu Docx blocks and Writer IR.'''
 
@@ -169,6 +166,73 @@ class FeishuWriterAdapter(WriterAdapterBase):
         }
         return handlers[patch.modify_type](patch, document)
 
+    def merge_refreshed_document(
+        self,
+        previous_document: WriterDocument,
+        refreshed_document: WriterDocument,
+        patch: Optional[PatchHunk] = None,
+        operation: Optional[NativePatchOperation] = None,
+    ) -> WriterDocument:
+        previous_ids = {
+            block.provider_binding.get('block_id'): block.node_id
+            for block in previous_document.iter_blocks()
+            if isinstance(block.provider_binding.get('block_id'), str)
+        }
+        for block in refreshed_document.iter_blocks():
+            node_id = previous_ids.get(block.provider_binding.get('block_id'))
+            if node_id is not None:
+                block.node_id = node_id
+
+        if operation is not None and operation.operation == 'move' and patch is not None:
+            previous_root = previous_document.block_by_id(patch.target_node_id)
+            if previous_root is None:
+                raise ValueError(
+                    f'move target node disappeared before synchronization: {patch.target_node_id!r}.'
+                )
+            target_parent_id = operation.params.get('target_parent_block_id')
+            target_index = operation.params.get('target_index')
+            if not isinstance(target_parent_id, str) or not isinstance(target_index, int):
+                raise ValueError('move operation lacks a valid target parent or target index.')
+            target_parent = next(
+                (
+                    block for block in refreshed_document.iter_blocks()
+                    if block.provider_binding.get('block_id') == target_parent_id
+                ),
+                None,
+            )
+            if target_parent is not None:
+                target_children = target_parent.children
+            elif refreshed_document.provider_binding.get('document_id') == target_parent_id:
+                target_children = refreshed_document.blocks
+            else:
+                raise ValueError(
+                    f'refreshed document does not contain target parent block {target_parent_id!r}.')
+            if target_index < 0 or target_index >= len(target_children):
+                raise ValueError('moved block is absent from the refreshed target position.')
+
+            def restore_subtree(previous: WriterBlock, refreshed: WriterBlock) -> None:
+                if (
+                    previous.type != refreshed.type
+                    or previous.content != refreshed.content
+                    or len(previous.children) != len(refreshed.children)
+                ):
+                    raise ValueError('refreshed moved subtree does not match the source subtree.')
+                refreshed.node_id = previous.node_id
+                for previous_child, refreshed_child in zip(previous.children, refreshed.children):
+                    restore_subtree(previous_child, refreshed_child)
+
+            restore_subtree(previous_root, target_children[target_index])
+
+        previous_blocks = {block.node_id: block for block in previous_document.iter_blocks()}
+        for block in refreshed_document.iter_blocks():
+            previous = previous_blocks.get(block.node_id)
+            if previous is None:
+                continue
+            block.status = previous.status
+            block.authoring = deepcopy(previous.authoring)
+            block.references = deepcopy(previous.references)
+        return WriterDocument.model_validate(refreshed_document.model_dump())
+
     def _replace_patch_to_operation(
         self,
         patch: PatchHunk,
@@ -225,28 +289,209 @@ class FeishuWriterAdapter(WriterAdapterBase):
         patch: PatchHunk,
         document: WriterDocument,
     ) -> NativePatchOperation:
-        '''Reserved for conversion to Feishu create_block parameters.'''
-        raise NotImplementedError(
-            'Feishu insert patch conversion to create_block is not implemented yet.')
+        '''Convert insert into Feishu create_block parameters.'''
+        anchor_id = patch.anchor_node_id or patch.target_node_id
+        anchor, parent, anchor_index = self._block_location(document, anchor_id)
+        self._require_feishu_binding(anchor, 'insert anchor')
+
+        position = patch.position or 'after'
+        insert_index = anchor_index + (1 if position == 'after' else 0)
+        parent_block_id = self._parent_block_id(document, anchor, parent)
+
+        patch_blocks = patch.new_blocks
+        if not patch_blocks:
+            if patch.new_text is None:
+                raise ValueError('insert patch must provide new_blocks or new_text.')
+            patch_blocks = [PatchBlock(type='paragraph', content=patch.new_text)]
+
+        id_prefix = patch.hunk_id or f'{patch.target_node_id}::insert'
+        writer_blocks = [
+            WriterBlock(
+                node_id=f'{id_prefix}::{index}',
+                type=patch_block.type,
+                content=patch_block.content,
+                stage=document.stage,
+                authoring=patch_block.authoring,
+                numbering=deepcopy(patch_block.numbering),
+            )
+            for index, patch_block in enumerate(patch_blocks)
+        ]
+        inserted_document = WriterDocument(
+            document_id=f'{document.document_id}::insert::{id_prefix}',
+            stage=document.stage,
+            blocks=writer_blocks,
+            provider_binding={
+                'provider': self.provider,
+                'document_id': document.provider_binding.get('document_id', ''),
+            },
+        )
+        children_id, descendants = FeishuFSBase._prepare_docx_descendants(
+            self.ir_to_blocks(inserted_document))
+        return NativePatchOperation(
+            operation='create',
+            params={
+                'parent_block_id': parent_block_id,
+                'index': insert_index,
+                'children_id': children_id,
+                'descendants': descendants,
+            },
+        )
 
     def _delete_patch_to_operation(
         self,
         patch: PatchHunk,
         document: WriterDocument,
     ) -> NativePatchOperation:
-        '''Reserved for conversion to Feishu delete_block parameters.'''
-        raise NotImplementedError(
-            'Feishu delete patch conversion to delete_block is not implemented yet.')
+        '''Convert delete into Feishu delete_block parameters.'''
+        block, parent, index = self._block_location(document, patch.target_node_id)
+        self._require_feishu_binding(block, 'delete target')
+        if block.type == 'document':
+            raise ValueError('delete patch cannot remove the Feishu document block.')
+        if patch.old_text is not None and patch.old_text != block.content:
+            raise ValueError('patch old_text does not match the current block content.')
+        return NativePatchOperation(
+            operation='delete',
+            params={
+                'parent_block_id': self._parent_block_id(document, block, parent),
+                'start_index': index,
+                'end_index': index + 1,
+            },
+        )
 
     def _move_patch_to_operation(
         self,
         patch: PatchHunk,
         document: WriterDocument,
     ) -> NativePatchOperation:
-        '''Reserved for conversion to Feishu move_block parameters.'''
-        raise NotImplementedError(
-            'Feishu move patch conversion to move_block is not implemented yet.')
+        '''Convert move into Feishu move_block parameters.'''
+        source, source_parent, source_index = self._block_location(
+            document, patch.target_node_id)
+        anchor, target_parent, anchor_index = self._block_location(
+            document, patch.anchor_node_id or '')
+        self._require_feishu_binding(source, 'move source')
+        self._require_feishu_binding(anchor, 'move anchor')
+        if source.type == 'document':
+            raise ValueError('move patch cannot move the Feishu document block.')
+        if patch.old_text is not None and patch.old_text != source.content:
+            raise ValueError('patch old_text does not match the current block content.')
+        if self._subtree_contains(source, anchor.node_id):
+            raise ValueError('move patch anchor cannot be the source node or its descendant.')
 
+        source_parent_block_id = self._parent_block_id(document, source, source_parent)
+        target_parent_block_id = self._parent_block_id(document, anchor, target_parent)
+        target_index = anchor_index + (1 if patch.position == 'after' else 0)
+        if (
+            source_parent_block_id == target_parent_block_id
+            and source_index < anchor_index
+        ):
+            target_index -= 1
+
+        id_prefix = patch.hunk_id or f'{patch.target_node_id}::move'
+        moved_root = self._clone_subtree_with_temporary_ids(source, id_prefix)
+        moved_document = WriterDocument(
+            document_id=f'{document.document_id}::move::{id_prefix}',
+            stage=document.stage,
+            blocks=[moved_root],
+            provider_binding={
+                'provider': self.provider,
+                'document_id': document.provider_binding.get('document_id', ''),
+            },
+        )
+        children_id, descendants = FeishuFSBase._prepare_docx_descendants(
+            self.ir_to_blocks(moved_document))
+        if len(children_id) != 1:
+            raise ValueError('move patch must produce exactly one root Feishu block.')
+        return NativePatchOperation(
+            operation='move',
+            params={
+                'source_parent_block_id': source_parent_block_id,
+                'source_index': source_index,
+                'target_parent_block_id': target_parent_block_id,
+                'target_index': target_index,
+                'children_id': children_id,
+                'descendants': descendants,
+            },
+        )
+
+    @staticmethod
+    def _block_location(
+        document: WriterDocument,
+        node_id: str,
+    ) -> Tuple[WriterBlock, Optional[WriterBlock], int]:
+        def find(
+            blocks: List[WriterBlock],
+            parent: Optional[WriterBlock],
+        ) -> Optional[Tuple[WriterBlock, Optional[WriterBlock], int]]:
+            for index, block in enumerate(blocks):
+                if block.node_id == node_id:
+                    return block, parent, index
+                nested = find(block.children, block)
+                if nested is not None:
+                    return nested
+            return None
+
+        location = find(document.blocks, None)
+        if location is None:
+            raise ValueError(f'patch target node does not exist: {node_id!r}.')
+        return location
+
+    def _require_feishu_binding(self, block: WriterBlock, label: str) -> str:
+        provider = block.provider_binding.get('provider')
+        if provider != self.provider:
+            raise ValueError(
+                f'{label} provider must be {self.provider!r}, got {provider!r}.')
+        block_id = block.provider_binding.get('block_id')
+        if not isinstance(block_id, str) or not block_id.strip():
+            raise ValueError(f'{label} does not have a Feishu block_id binding.')
+        return block_id.strip()
+
+    def _parent_block_id(
+        self,
+        document: WriterDocument,
+        block: WriterBlock,
+        parent: Optional[WriterBlock],
+    ) -> str:
+        if parent is not None:
+            return self._require_feishu_binding(parent, 'parent block')
+        parent_block_id = block.provider_binding.get('parent_block_id')
+        if not isinstance(parent_block_id, str) or not parent_block_id.strip():
+            parent_block_id = document.provider_binding.get('document_id')
+        if not isinstance(parent_block_id, str) or not parent_block_id.strip():
+            raise ValueError('patch target does not have a Feishu parent block binding.')
+        return parent_block_id.strip()
+
+    @classmethod
+    def _clone_subtree_with_temporary_ids(
+        self,
+        root: WriterBlock,
+        id_prefix: str,
+    ) -> WriterBlock:
+        cloned = root.model_copy(deep=True)
+        index = 0
+
+        def assign(block: WriterBlock) -> None:
+            nonlocal index
+            temporary_id = f'{id_prefix}::{index}'
+            index += 1
+            raw = deepcopy(self._raw_payload(block))
+            raw['block_id'] = temporary_id
+            raw.pop('parent_id', None)
+            raw.pop('children', None)
+            block.node_id = temporary_id
+            block.provider_binding = {}
+            block.provider_payload = {'raw_block': raw}
+            for child in block.children:
+                assign(child)
+
+        assign(cloned)
+        return cloned
+
+    @staticmethod
+    def _subtree_contains(root: WriterBlock, node_id: str) -> bool:
+        return root.node_id == node_id or any(
+            FeishuWriterAdapter._subtree_contains(child, node_id)
+            for child in root.children
+        )
     def _raw_block_to_ir(
         self,
         raw: NativeBlock,

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -5,7 +5,13 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..utils.feishu_docx import DOCX_BLOCK_TYPE_FIELDS, prepare_docx_descendants
 from ..data_models.revision import PatchHunk
-from ..data_models.writer_ir import WriterBlock, WriterDocument, WriterSpan, WriterStage
+from ..data_models.writer_ir import (
+    WRITER_BLOCK_MUTABLE_FIELDS,
+    WriterBlock,
+    WriterDocument,
+    WriterSpan,
+    WriterStage,
+)
 from .base import NativeBlock, NativePatchOperation, WriterAdapterBase
 
 
@@ -291,9 +297,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
                 f'Feishu block type {original_type!r} does not support updates.')
 
         desired = block.model_copy(deep=True)
-        for field in (
-            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
-        ):
+        for field in WRITER_BLOCK_MUTABLE_FIELDS:
             setattr(desired, field, deepcopy(getattr(patch.block, field)))
         desired_raw = self._ir_block_to_raw(desired)
         desired_type = desired_raw.get('block_type')

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -88,6 +88,15 @@ class FeishuWriterAdapter(WriterAdapterBase):
 
         nested_ids = {child_id for children in child_ids.values() for child_id in children}
         root_blocks = [writer_by_id[block_id] for block_id in source_order if block_id not in nested_ids]
+        resolved_title = title
+        if not resolved_title:
+            document_block = next((
+                writer_by_id[block_id]
+                for block_id in source_order
+                if raw_by_id[block_id].get('block_type') == 1
+            ), None)
+            if document_block is not None:
+                resolved_title = document_block.content
         binding: Dict[str, Any] = {
             'provider': self.provider,
             'document_id': external_document_id,
@@ -100,7 +109,7 @@ class FeishuWriterAdapter(WriterAdapterBase):
         return WriterDocument(
             document_id=self.make_document_id(external_document_id),
             stage=stage,
-            title=title,
+            title=resolved_title,
             blocks=root_blocks,
             revision=revision,
             metadata={'source_block_count': len(blocks)},

--- a/lazyllm/tools/writer/data_models/__init__.py
+++ b/lazyllm/tools/writer/data_models/__init__.py
@@ -9,7 +9,7 @@ from .context import (
     WritingContext,
 )
 from .planning import SectionInstruction, SectionInstructionList
-from .revision import Anchor, LocateResult, ModifyInstruction, ModifyPlan, PatchBlock, PatchHunk, PatchResult, PatchSet
+from .revision import LocateResult, ModifyInstruction, ModifyPlan, PatchHunk, PatchResult, PatchSet
 from .multimodal import MediaAsset, MediaAssetLibrary, VisualInstruction
 from .quality import AuditIssue, AuditResult, ReviewReport
 from .writer_ir import WriterAuthoring, WriterBlock, WriterConstraints, WriterDocument, WriterSpan, WriterStage
@@ -29,10 +29,8 @@ __all__ = [
     'WritingContext',
     'SectionInstruction',
     'SectionInstructionList',
-    'Anchor',
     'ModifyInstruction',
     'ModifyPlan',
-    'PatchBlock',
     'PatchHunk',
     'PatchResult',
     'PatchSet',

--- a/lazyllm/tools/writer/data_models/revision.py
+++ b/lazyllm/tools/writer/data_models/revision.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional
 from pydantic import BaseModel, Field, model_validator
-from .writer_ir import WriterAuthoring
+from .writer_ir import WriterBlock
 from ..utils.artifact import ArtifactModel
 
 
@@ -15,16 +15,8 @@ class LocateResult(ArtifactModel):
     meta: Dict[str, Any] = Field(default_factory=dict)
 
 
-ModifyType = Literal['insert', 'replace', 'delete', 'move']
+ModifyType = Literal['create', 'update', 'delete', 'move']
 PatchPosition = Literal['before', 'after']
-PatchBlockType = Literal['paragraph', 'heading', 'list_item', 'code', 'quote']
-
-
-class Anchor(BaseModel):
-    node_id: str
-    text_offset: Optional[int] = None
-    text_end: Optional[int] = None
-    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class ModifyInstruction(BaseModel):
@@ -54,44 +46,33 @@ class ModifyPlan(BaseModel):
     meta: Dict[str, Any] = Field(default_factory=dict)
 
 
-class PatchBlock(BaseModel):
-    '''Provider-neutral content for blocks created by an insert patch.'''
-
-    type: PatchBlockType
-    content: str = ''
-    numbering: Dict[str, Any] = Field(default_factory=dict)
-    authoring: Optional[WriterAuthoring] = None
-    meta: Dict[str, Any] = Field(default_factory=dict)
-
-    @model_validator(mode='after')
-    def validate_numbering(self) -> 'PatchBlock':
-        if self.type == 'heading':
-            level = self.numbering.get('level')
-            if not isinstance(level, int) or isinstance(level, bool) or not 1 <= level <= 9:
-                raise ValueError('heading requires numbering.level from 1 to 9')
-        elif self.type == 'list_item':
-            if not isinstance(self.numbering.get('ordered'), bool):
-                raise ValueError('list_item requires boolean numbering.ordered')
-        return self
-
-
 class PatchHunk(BaseModel):
     hunk_id: Optional[str] = None
     target_node_id: str
     modify_type: ModifyType
-    anchor: Optional[Anchor] = None
-    anchor_node_id: Optional[str] = None
-    text_range: Optional[Tuple[int, int]] = None
-    old_text: Optional[str] = None
-    new_text: Optional[str] = None
-    new_blocks: List[PatchBlock] = Field(default_factory=list)
-    position: Optional[PatchPosition] = None
+    block: Optional[WriterBlock] = None
+    parent_node_id: Optional[str] = None
+    index: Optional[int] = None
     meta: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode='after')
-    def validate_move(self) -> 'PatchHunk':
-        if self.modify_type == 'move' and (not self.anchor_node_id or not self.position):
-            raise ValueError('move requires anchor_node_id and position')
+    def validate_operation(self) -> 'PatchHunk':
+        if not self.target_node_id.strip():
+            raise ValueError('target_node_id must not be empty')
+        if self.modify_type in {'create', 'update'}:
+            if self.block is None:
+                raise ValueError(f'{self.modify_type} requires block')
+            if self.block.node_id != self.target_node_id:
+                raise ValueError(
+                    f'{self.modify_type} block.node_id must equal target_node_id')
+        elif self.block is not None:
+            raise ValueError(f'{self.modify_type} must not provide block')
+        if self.modify_type in {'create', 'move'}:
+            if self.index is None or self.index < 0:
+                raise ValueError(f'{self.modify_type} requires a non-negative index')
+        elif self.parent_node_id is not None or self.index is not None:
+            raise ValueError(
+                f'{self.modify_type} must not provide parent_node_id or index')
         return self
 
 

--- a/lazyllm/tools/writer/data_models/revision.py
+++ b/lazyllm/tools/writer/data_models/revision.py
@@ -8,6 +8,7 @@ from ..utils.artifact import ArtifactModel
 class LocateResult(ArtifactModel):
     task_id: Optional[str] = None
     doc_id: Optional[str] = None
+    target_title: bool = False
     target_node_ids: List[str] = Field(default_factory=list)
     target_reasons: Dict[str, str] = Field(default_factory=dict)
     summary: Optional[str] = None
@@ -46,6 +47,7 @@ class ModifyPlan(BaseModel):
     plan_id: Optional[str] = None
     task_id: Optional[str] = None
     scope: Literal['document', 'section', 'block', 'span']
+    title_instruction: Optional[str] = None
     target_node_ids: List[str] = Field(default_factory=list)
     instructions: List[ModifyInstruction] = Field(default_factory=list)
     summary: Optional[str] = None

--- a/lazyllm/tools/writer/data_models/revision.py
+++ b/lazyllm/tools/writer/data_models/revision.py
@@ -100,6 +100,40 @@ class PatchSet(ArtifactModel):
     hunks: List[PatchHunk] = Field(default_factory=list)
     meta: Dict[str, Any] = Field(default_factory=dict)
 
+    def execution_hunks(self) -> List[PatchHunk]:
+        '''Return hunks in an order that preserves repeated after-move order.
+
+        Moving several sibling blocks after the same anchor in their document
+        order would stack every later block directly behind the anchor and
+        reverse the group. Execute each consecutive group from tail to head so
+        the persisted document keeps the PatchSet's natural block order.
+        '''
+        ordered: List[PatchHunk] = []
+        index = 0
+        while index < len(self.hunks):
+            hunk = self.hunks[index]
+            if (
+                hunk.modify_type == 'move'
+                and hunk.position == 'after'
+                and hunk.anchor_node_id
+            ):
+                end = index + 1
+                while end < len(self.hunks):
+                    candidate = self.hunks[end]
+                    if not (
+                        candidate.modify_type == 'move'
+                        and candidate.position == 'after'
+                        and candidate.anchor_node_id == hunk.anchor_node_id
+                    ):
+                        break
+                    end += 1
+                ordered.extend(reversed(self.hunks[index:end]))
+                index = end
+                continue
+            ordered.append(hunk)
+            index += 1
+        return ordered
+
 
 class PatchResult(BaseModel):
     patch_id: Optional[str] = None

--- a/lazyllm/tools/writer/data_models/revision.py
+++ b/lazyllm/tools/writer/data_models/revision.py
@@ -100,40 +100,6 @@ class PatchSet(ArtifactModel):
     hunks: List[PatchHunk] = Field(default_factory=list)
     meta: Dict[str, Any] = Field(default_factory=dict)
 
-    def execution_hunks(self) -> List[PatchHunk]:
-        '''Return hunks in an order that preserves repeated after-move order.
-
-        Moving several sibling blocks after the same anchor in their document
-        order would stack every later block directly behind the anchor and
-        reverse the group. Execute each consecutive group from tail to head so
-        the persisted document keeps the PatchSet's natural block order.
-        '''
-        ordered: List[PatchHunk] = []
-        index = 0
-        while index < len(self.hunks):
-            hunk = self.hunks[index]
-            if (
-                hunk.modify_type == 'move'
-                and hunk.position == 'after'
-                and hunk.anchor_node_id
-            ):
-                end = index + 1
-                while end < len(self.hunks):
-                    candidate = self.hunks[end]
-                    if not (
-                        candidate.modify_type == 'move'
-                        and candidate.position == 'after'
-                        and candidate.anchor_node_id == hunk.anchor_node_id
-                    ):
-                        break
-                    end += 1
-                ordered.extend(reversed(self.hunks[index:end]))
-                index = end
-                continue
-            ordered.append(hunk)
-            index += 1
-        return ordered
-
 
 class PatchResult(BaseModel):
     patch_id: Optional[str] = None

--- a/lazyllm/tools/writer/data_models/writer_ir.py
+++ b/lazyllm/tools/writer/data_models/writer_ir.py
@@ -7,6 +7,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 WriterStage = Literal['outline', 'draft', 'final']
 
+WRITER_BLOCK_MUTABLE_FIELDS = ('type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references')
+WRITER_BLOCK_PROVIDER_MANAGED_FIELDS = ('provider_binding', 'provider_payload', 'editable')
+
 
 class WriterConstraints(BaseModel):
     '''Authoring requirements attached to a document block across all stages.'''
@@ -139,4 +142,5 @@ WriterDocument.model_rebuild()
 __all__ = [
     'WriterDocument', 'WriterBlock', 'WriterSpan', 'WriterStage',
     'WriterConstraints', 'WriterAuthoring',
+    'WRITER_BLOCK_MUTABLE_FIELDS', 'WRITER_BLOCK_PROVIDER_MANAGED_FIELDS',
 ]

--- a/lazyllm/tools/writer/data_models/writer_ir.py
+++ b/lazyllm/tools/writer/data_models/writer_ir.py
@@ -53,7 +53,7 @@ class WriterAuthoring(BaseModel):
 
 class WriterSpan(BaseModel):
     text: str = ''
-    style: List[str] = Field(default_factory=list)
+    style: Dict[str, Any] = Field(default_factory=dict)
 
 
 class WriterBlock(BaseModel):
@@ -87,6 +87,11 @@ class WriterBlock(BaseModel):
         if self.spans and ''.join(span.text for span in self.spans) != self.content:
             raise ValueError('content must equal the concatenated span text when spans are present')
         return self
+
+    def iter_blocks(self) -> Iterable['WriterBlock']:
+        yield self
+        for child in self.children:
+            yield from child.iter_blocks()
 
 
 WriterBlock.model_rebuild()

--- a/lazyllm/tools/writer/data_models/writer_ir.py
+++ b/lazyllm/tools/writer/data_models/writer_ir.py
@@ -45,16 +45,9 @@ class WriterAuthoring(BaseModel):
     # Provider/plugin extensions may add namespaced fields while the common contract
     # above remains validated.
     model_config = ConfigDict(extra='allow')
-
-    instruction: Optional[str] = None
     instruction_id: Optional[str] = None
     origin_node_id: Optional[str] = None
     constraints: WriterConstraints = Field(default_factory=WriterConstraints)
-    expected_blocks: List[str] = Field(default_factory=list)
-    pending_subtasks: List[str] = Field(default_factory=list)
-    revision_notes: List[str] = Field(default_factory=list)
-    visual_needs: List[Dict[str, Any]] = Field(default_factory=list)
-    source: Optional[str] = None
     meta: Dict[str, Any] = Field(default_factory=dict)
 
 
@@ -74,7 +67,6 @@ class WriterBlock(BaseModel):
     spans: List[WriterSpan] = Field(default_factory=list)
     children: List['WriterBlock'] = Field(default_factory=list)
     stage: WriterStage
-    status: str = ''
     authoring: Optional[WriterAuthoring] = None
     numbering: Dict[str, Any] = Field(default_factory=dict)
     references: List[Dict[str, Any]] = Field(default_factory=list)

--- a/lazyllm/tools/writer/prompts/drafting.py
+++ b/lazyllm/tools/writer/prompts/drafting.py
@@ -20,7 +20,7 @@ Requirements:
 - Do not invent facts that conflict with the writing context.
 - If previous_blocks are provided, keep continuity and avoid repeating their content.
 - Fill node_id for the section root and for each child (e.g. draft-<node>-1). The system will normalize ids if needed.
-- Leave spans, status, authoring, references, provider_binding and provider_payload empty.
+- Leave spans, authoring, references, provider_binding and provider_payload empty.
 
 Writing task:
 {task_json}

--- a/lazyllm/tools/writer/prompts/planning.py
+++ b/lazyllm/tools/writer/prompts/planning.py
@@ -6,11 +6,13 @@ Requirements:
 - Set document_id to the value given in document_id_hint below.
 - Generate at least 3 top-level blocks unless the task explicitly asks for fewer.
 - Each top-level block is a section. Use type="heading" for section blocks.
-- Put the section title in block.content, and place a concrete writing instruction in
-  block.authoring.instruction.
+- All user-visible outline text MUST use the same document tree contract as draft and final content:
+  put section titles in heading block.content, and put section descriptions and key points in
+  paragraph or list_item blocks under block.children.
+- block.authoring is only for non-visible planning and execution metadata.
 - Fill node_id for every block. Use stable ids such as section-1, section-2, section-1-1.
 - Use block.numbering.level for the heading level: 1 for top-level sections, incrementing for children.
-  Put child sections under block.children.
+  Put child sections under block.children as heading blocks alongside any visible description blocks.
 - Constraints live in block.authoring.constraints and may only use the fields defined by WriterConstraints:
   section_goal, required_points, fact_constraints, style_constraints, relation_constraints,
   min_words, max_words, pov, tone, must_include, must_avoid.
@@ -26,7 +28,7 @@ Requirements:
   applies to a section, leave fact_constraints empty.
 - Prefer the target document title or task intent as document.title.
 - Use the writing context and resource profiles as constraints, not as content to copy blindly.
-- Leave spans, status, provider_binding and provider_payload empty; the system manages them.
+- Leave spans, provider_binding and provider_payload empty; the system manages them.
 
 Writing task:
 {task_json}

--- a/lazyllm/tools/writer/prompts/quality.py
+++ b/lazyllm/tools/writer/prompts/quality.py
@@ -65,29 +65,30 @@ Writing context:
 VALIDATE_PATCH_SET_PROMPT = '''You are a PatchSet quality reviewer. Validate every hunk against the writing context before it is applied. Return an AuditResult.
 
 Each hunk includes:
-- target_node_id + old_text + new_text: the modification
+- modify_type + target_node_id
+- block: the complete target WriterBlock for create/update
+- parent_node_id + index: the destination for create/move
 
 Validation rules:
 
-1. FORMAT INTEGRITY (category=format): new_text must have:
+1. FORMAT INTEGRITY (category=format): block.content and block.spans must have:
    - Balanced markdown fences, valid heading levels, unbroken tables
    - No orphaned list markers, no unclosed link brackets
-   For hunks with modify_type='delete', new_text is expected to be empty — skip format checks.
+   For delete/move hunks without block, skip content format checks.
    Each violation → severity=medium, category=format.
 
-2. FACT CONSISTENCY (category=evidence): new_text vs locked facts in context.
+2. FACT CONSISTENCY (category=evidence): block.content vs locked facts in context.
    - Contradicts a locked fact → severity=high, category=evidence.
    - Unqualified factual claims → severity=medium, category=evidence.
 
-3. STYLE CONSISTENCY (category=style): new_text tone/pov/formality vs context.style_profile.
+3. STYLE CONSISTENCY (category=style): block.content and spans vs context.style_profile.
    - Significant deviation → severity=low, category=style.
 
-4. INTENT MATCH (category=coverage): Compare every hunk (diff old_text→new_text) against the user's original revision request below. Does the hunk fulfill what the user asked?
+4. INTENT MATCH (category=coverage): Compare every operation and target block against the user's original revision request below.
    - Hunk does not fulfill the request → severity=high, category=coverage.
    - Hunk partially addresses the request → severity=medium, category=coverage.
 
-5. CONTEXT CONTINUITY (category=relevance): replacing old_text with new_text must preserve semantic flow.
-   Judge this from the diff itself — does new_text fit the same contextual role as old_text?
+5. CONTEXT CONTINUITY (category=relevance): updated/created content must preserve semantic flow.
    - Abrupt tone/register shift → severity=medium, category=relevance.
    - Loss of key transitional phrases → severity=low, category=relevance.
 

--- a/lazyllm/tools/writer/prompts/revision.py
+++ b/lazyllm/tools/writer/prompts/revision.py
@@ -66,20 +66,26 @@ Writing context:
 '''
 
 
-GENERATE_PATCH_SET_PROMPT = '''You are a document revision executor. Given a complete WriterDocument, a modify plan, and the writing context, return the complete revised WriterDocument.
+GENERATE_PATCH_SET_PROMPT = '''You are a document patch generator. Given a WriterDocument, a ModifyPlan, and the writing context, return a PatchSet that applies the requested changes to the original document.
 
 Rules:
-- Return a complete WriterDocument, not a PatchSet.
-- Preserve document_id, stage, revision, metadata, provider_binding, and ui_editable.
-- Preserve node_id, provider_binding, provider_payload, and editable for every existing block.
-- update: change the requested user-visible block fields. Heading levels belong in
-  type="heading" and numbering.level. Inline formatting belongs in spans.
-- create: add complete WriterBlock objects at the requested positions. Assign each new
-  block a unique node_id beginning with "writer-new-" and leave provider_binding and
-  provider_payload empty.
-- delete: remove the requested block subtree.
-- move: move the existing WriterBlock without changing its node_id or provider fields.
-- If title_instruction is absent, preserve the title exactly.
+- Return only a PatchSet, never a complete WriterDocument.
+- target_doc_id must equal the supplied document_id.
+- Produce exactly one hunk for each ModifyInstruction, in the same order and with the
+  same modify_type.
+- update: target_node_id must be the existing target. Include a complete WriterBlock
+  with the same node_id, provider_binding, provider_payload, and editable values.
+  Change only requested user-visible fields. Heading levels belong in type="heading"
+  and numbering.level. Inline formatting belongs in spans.
+- create: target_node_id and block.node_id must be a new unique ID beginning with
+  "writer-new-". Include the complete new WriterBlock, parent_node_id, and index.
+  Leave provider_binding and provider_payload empty.
+- delete: target_node_id must be the existing target. Do not include block,
+  parent_node_id, or index.
+- move: target_node_id must be the existing target. Do not include block. Resolve the
+  requested destination to parent_node_id and index in the original document.
+- Set new_title only when title_instruction requests a title change; otherwise null.
+- Give every hunk a stable hunk_id. Do not copy or rewrite unrelated blocks.
 - Generated text must be complete and self-contained. Never produce placeholders or ellipsis-only output.
 - Respect the writing context: keep facts consistent (never alter locked facts), preserve terminology and style.
 - Do not invent facts that conflict with the writing context.

--- a/lazyllm/tools/writer/prompts/revision.py
+++ b/lazyllm/tools/writer/prompts/revision.py
@@ -8,8 +8,8 @@ Rules:
   title is WriterDocument.title, not a content block; do not select a document/root
   block merely to change the title.
 - If the request does not change the document title, set target_title to false.
-- For replace/delete, select the blocks whose content or existence changes.
-- For insert, select the existing block used as the insertion anchor.
+- For update/delete, select the blocks whose content, formatting, type, or existence changes.
+- For create, select the existing block used as the insertion anchor.
 - For move, select the block being moved. Do not select the destination block merely because it is the destination.
 - Select node_ids ONLY from the candidate list below. Never invent node_ids.
 - Be precise: do not select blocks that are unrelated to the request.
@@ -40,8 +40,8 @@ Rules:
   synthetic document/root block instruction.
 - For each target block, decide the modify_type and write a clear, specific instruction.
 - modify_type must be one of:
-  - insert: insert one or more brand-new blocks before or after the target block. The target block is the insertion anchor; set position to before or after.
-  - replace: replace the target block's content with a new version.
+  - create: insert one or more brand-new blocks before or after the target block. The target block is the insertion anchor; set position to before or after.
+  - update: update any user-visible field of the target block, including content, type, numbering, and spans.
   - delete: remove the target block.
   - move: move the target block before or after another existing block. Set anchor_node_id to the destination block and position to before or after.
 - instruction: a concise description of what change to make to that block, derived from task.query.
@@ -66,21 +66,20 @@ Writing context:
 '''
 
 
-GENERATE_PATCH_SET_PROMPT = '''You are a patch generator. Given a document, a modify plan, and the writing context, produce a PatchSet with concrete text changes.
+GENERATE_PATCH_SET_PROMPT = '''You are a document revision executor. Given a complete WriterDocument, a modify plan, and the writing context, return the complete revised WriterDocument.
 
 Rules:
-- If modify_plan.title_instruction is present, set new_title to the complete new
-  document title requested by that instruction. Otherwise leave new_title null.
-- A title-only revision must return hunks as an empty list.
-- For each ModifyInstruction, produce exactly one PatchHunk.
-- Each PatchHunk must have:
-  - target_node_id: copied from the corresponding ModifyInstruction.
-  - modify_type: copied from the corresponding ModifyInstruction.
-  - replace: set new_text to the FULL new content of the target block. Leave new_blocks empty.
-  - insert: set position from the instruction and put every complete new block in new_blocks. Leave new_text null. Use paragraph unless the requested structure clearly requires heading, list_item, code, or quote.
-  - delete: leave new_text null and new_blocks empty.
-  - move: copy anchor_node_id and position from the instruction. Leave new_text null and new_blocks empty.
-- Leave anchor and old_text null. The system fills conflict-checking fields from the source document.
+- Return a complete WriterDocument, not a PatchSet.
+- Preserve document_id, stage, revision, metadata, provider_binding, and ui_editable.
+- Preserve node_id, provider_binding, provider_payload, and editable for every existing block.
+- update: change the requested user-visible block fields. Heading levels belong in
+  type="heading" and numbering.level. Inline formatting belongs in spans.
+- create: add complete WriterBlock objects at the requested positions. Assign each new
+  block a unique node_id beginning with "writer-new-" and leave provider_binding and
+  provider_payload empty.
+- delete: remove the requested block subtree.
+- move: move the existing WriterBlock without changing its node_id or provider fields.
+- If title_instruction is absent, preserve the title exactly.
 - Generated text must be complete and self-contained. Never produce placeholders or ellipsis-only output.
 - Respect the writing context: keep facts consistent (never alter locked facts), preserve terminology and style.
 - Do not invent facts that conflict with the writing context.

--- a/lazyllm/tools/writer/prompts/revision.py
+++ b/lazyllm/tools/writer/prompts/revision.py
@@ -4,6 +4,10 @@ LOCATE_REVISION_TARGET_PROMPT = '''You are a revision target locator. Given a wr
 Rules:
 - Read task.query carefully — it contains the user's revision request.
 - Examine every document block and select the ones the revision acts on.
+- If the request changes the document title, set target_title to true. The document
+  title is WriterDocument.title, not a content block; do not select a document/root
+  block merely to change the title.
+- If the request does not change the document title, set target_title to false.
 - For replace/delete, select the blocks whose content or existence changes.
 - For insert, select the existing block used as the insertion anchor.
 - For move, select the block being moved. Do not select the destination block merely because it is the destination.
@@ -30,6 +34,10 @@ Candidate node_ids (select from these only):
 GENERATE_MODIFY_PLAN_PROMPT = '''You are a modify plan generator. Given a writing task, the located target blocks, and the writing context, produce a ModifyPlan.
 
 Rules:
+- If locate_result.target_title is true, set title_instruction to a clear instruction
+  describing the requested document-title change. Otherwise leave title_instruction null.
+- A document-title change is separate from block instructions and does not need a
+  synthetic document/root block instruction.
 - For each target block, decide the modify_type and write a clear, specific instruction.
 - modify_type must be one of:
   - insert: insert one or more brand-new blocks before or after the target block. The target block is the insertion anchor; set position to before or after.
@@ -61,6 +69,9 @@ Writing context:
 GENERATE_PATCH_SET_PROMPT = '''You are a patch generator. Given a document, a modify plan, and the writing context, produce a PatchSet with concrete text changes.
 
 Rules:
+- If modify_plan.title_instruction is present, set new_title to the complete new
+  document title requested by that instruction. Otherwise leave new_title null.
+- A title-only revision must return hunks as an empty list.
 - For each ModifyInstruction, produce exactly one PatchHunk.
 - Each PatchHunk must have:
   - target_node_id: copied from the corresponding ModifyInstruction.

--- a/lazyllm/tools/writer/tools/drafting_tools.py
+++ b/lazyllm/tools/writer/tools/drafting_tools.py
@@ -213,6 +213,10 @@ class WriterDraftingTools(WriterToolBase):
         draft_block.stage = 'draft'
         draft_block.type = 'heading'
         draft_block.content = instruction.section_title
+        level = instruction.meta.get('outline_node_level', 1)
+        if not isinstance(level, int) or isinstance(level, bool) or not 1 <= level <= 9:
+            level = 1
+        draft_block.numbering['level'] = level
 
         if not draft_block.children:
             draft_block.children.append(WriterBlock(

--- a/lazyllm/tools/writer/tools/drafting_tools.py
+++ b/lazyllm/tools/writer/tools/drafting_tools.py
@@ -228,10 +228,7 @@ class WriterDraftingTools(WriterToolBase):
             if not child.type.strip():
                 child.type = 'paragraph'
 
-        authoring_meta = {
-            'instruction_id': instruction.instruction_id,
-            'origin_node_id': instruction.outline_node_id,
-        }
+        authoring_meta = {}
         for key in ('outline_id', 'outline_title'):
             value = instruction.meta.get(key)
             if value is not None:
@@ -239,7 +236,6 @@ class WriterDraftingTools(WriterToolBase):
         draft_block.authoring = WriterAuthoring(
             instruction_id=instruction.instruction_id,
             origin_node_id=instruction.outline_node_id,
-            source='section_instruction',
             meta=authoring_meta,
         )
 

--- a/lazyllm/tools/writer/tools/drafting_tools.py
+++ b/lazyllm/tools/writer/tools/drafting_tools.py
@@ -12,7 +12,7 @@ from ..data_models.writer_ir import (
 )
 from ..data_models.planning import SectionInstruction, SectionInstructionList
 from ..prompts import GENERATE_DRAFT_SECTION_PROMPT
-from ..utils import to_prompt_json
+from ..utils import render_document_markdown, to_prompt_json
 
 
 class WriterDraftingTools(WriterToolBase):
@@ -133,7 +133,7 @@ class WriterDraftingTools(WriterToolBase):
 
         writing_context = self._unified_model(context, WritingContext)
         draft_document = self._unified_draft_document(draft, writing_context)
-        content = self._render_document_markdown(draft_document)
+        content = render_document_markdown(draft_document)
         final_document = WriterDocument(
             document_id=self._default_final_document_id(draft_document, writing_context),
             stage='final',
@@ -370,28 +370,6 @@ class WriterDraftingTools(WriterToolBase):
             total += len(block.children)
             total += self._count_draft_blocks(block.children)
         return total
-
-    def _render_document_markdown(self, document: WriterDocument) -> str:
-        parts: List[str] = []
-        if document.title:
-            parts.append(f'# {document.title.strip()}')
-        for block in document.blocks:
-            parts.extend(self._render_block_markdown(block, level=2))
-        return '\n\n'.join(part for part in parts if part).strip() + '\n'
-
-    def _render_block_markdown(self, block: WriterBlock, level: int) -> List[str]:
-        parts: List[str] = []
-        heading_level = min(max(level, 1), 6)
-        if block.type == 'heading':
-            if block.content.strip():
-                parts.append(f'{"#" * heading_level} {block.content.strip()}')
-        else:
-            content = block.content.strip()
-            if content:
-                parts.append(content)
-        for child in block.children:
-            parts.extend(self._render_block_markdown(child, heading_level + 1))
-        return parts
 
     def _first_block_authoring_meta(self, blocks: List[WriterBlock], key: str) -> Any:
         for block in blocks:

--- a/lazyllm/tools/writer/tools/planning_tools.py
+++ b/lazyllm/tools/writer/tools/planning_tools.py
@@ -274,7 +274,6 @@ class WriterPlanningTools(WriterToolBase):
         instruction.meta.update(
             {
                 'outline_node_level': block.numbering.get('level'),
-                'outline_node_instruction': block.authoring.instruction if block.authoring else None,
                 'outline_id': outline.document_id,
                 'outline_title': outline.title,
             }

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -208,10 +208,15 @@ class WriterResourceTools(WriterToolBase):
         persisted_document = source
         expected_title = patch.new_title if patch.new_title is not None else source.title
         title_updated = patch.new_title is not None and patch.new_title != source.title
+        normalized_fields: Dict[str, List[str]] = {}
         for hunk in patch.hunks:
             operation = adapter.patch_to_operation(hunk, persisted_document)
-            self._execute_native_operation(
+            operation_result = self._execute_native_operation(
                 fs, document_id, operation, persisted_document.revision)
+            if isinstance(operation_result, dict) \
+                    and isinstance(operation_result.get('normalized_fields'), list):
+                normalized_fields[hunk.hunk_id or hunk.target_node_id] = \
+                    operation_result['normalized_fields']
             applied_hunks.append(hunk.hunk_id or hunk.target_node_id)
             refreshed_document = self._read_persisted_document(
                 fs=fs,
@@ -229,6 +234,7 @@ class WriterResourceTools(WriterToolBase):
                     refreshed_document,
                     patch=hunk,
                     operation=operation,
+                    operation_result=operation_result,
                 )
                 if callable(merge_refreshed) else refreshed_document
             )
@@ -276,6 +282,7 @@ class WriterResourceTools(WriterToolBase):
                 'external_document_id': document_id,
                 'operation_count': len(applied_hunks) + int(title_updated),
                 'title_updated': title_updated,
+                'normalized_fields': normalized_fields,
             },
         )
         return self._save_artifacts(

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -296,6 +296,18 @@ class WriterResourceTools(WriterToolBase):
         protocol, real_path, fs, adapter, locator, document_id = \
             self._resolve_document_target(target, source_document=source)
 
+        def refresh(previous: WriterDocument, result: Any = None, **merge_kwargs) -> WriterDocument:
+            revision = result.get('document_revision_id') if isinstance(result, dict) else None
+            if revision is not None and not isinstance(revision, bool):
+                previous = previous.model_copy(update={'revision': str(revision)})
+            refreshed = self._read_persisted_document(
+                fs=fs, adapter=adapter, real_path=real_path, locator=locator,
+                document_id=document_id, source_document=previous,
+            )
+            merge = getattr(adapter, 'merge_refreshed_document', None)
+            return merge(previous, refreshed, operation_result=result, **merge_kwargs) \
+                if callable(merge) else refreshed
+
         applied_hunks: List[str] = []
         persisted_document = source
         expected_title = patch.new_title if patch.new_title is not None else source.title
@@ -310,58 +322,20 @@ class WriterResourceTools(WriterToolBase):
                 normalized_fields[hunk.hunk_id or hunk.target_node_id] = \
                     operation_result['normalized_fields']
             applied_hunks.append(hunk.hunk_id or hunk.target_node_id)
-            refreshed_document = self._read_persisted_document(
-                fs=fs,
-                adapter=adapter,
-                real_path=real_path,
-                locator=locator,
-                document_id=document_id,
-                source_document=persisted_document.model_copy(
-                    update={'title': expected_title}),
-            )
-            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
-            persisted_document = (
-                merge_refreshed(
-                    persisted_document,
-                    refreshed_document,
-                    patch=hunk,
-                    operation=operation,
-                    operation_result=operation_result,
-                )
-                if callable(merge_refreshed) else refreshed_document
+            persisted_document = refresh(
+                persisted_document.model_copy(update={'title': expected_title}),
+                operation_result, patch=hunk, operation=operation,
             )
 
         if title_updated:
-            self._update_document_title(
+            title_result = self._update_document_title(
                 fs, document_id, expected_title, persisted_document.revision)
-            refreshed_document = self._read_persisted_document(
-                fs=fs,
-                adapter=adapter,
-                real_path=real_path,
-                locator=locator,
-                document_id=document_id,
-                source_document=persisted_document.model_copy(
-                    update={'title': expected_title}),
-            )
-            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
-            persisted_document = (
-                merge_refreshed(persisted_document, refreshed_document)
-                if callable(merge_refreshed) else refreshed_document
+            persisted_document = refresh(
+                persisted_document.model_copy(update={'title': expected_title}),
+                title_result,
             )
         elif not patch.hunks:
-            refreshed_document = self._read_persisted_document(
-                fs=fs,
-                adapter=adapter,
-                real_path=real_path,
-                locator=locator,
-                document_id=document_id,
-                source_document=persisted_document,
-            )
-            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
-            persisted_document = (
-                merge_refreshed(persisted_document, refreshed_document)
-                if callable(merge_refreshed) else refreshed_document
-            )
+            persisted_document = refresh(persisted_document)
 
         patch_result = PatchResult(
             patch_id=patch.patch_id,
@@ -398,7 +372,7 @@ class WriterResourceTools(WriterToolBase):
         document_id: str,
         title: str,
         revision: Optional[str],
-    ) -> None:
+    ) -> Any:
         update_title = getattr(fs, 'update_document_title', None)
         if not callable(update_title):
             raise TypeError(f'{type(fs).__name__} does not support document title updates.')
@@ -406,7 +380,7 @@ class WriterResourceTools(WriterToolBase):
             revision_id = int(revision) if revision is not None else -1
         except (TypeError, ValueError):
             revision_id = -1
-        update_title(document_id, title, document_revision_id=revision_id)
+        return update_title(document_id, title, document_revision_id=revision_id)
 
     def _resolve_document_target(
         self,
@@ -459,7 +433,7 @@ class WriterResourceTools(WriterToolBase):
             stage=source_document.stage,
             title=source_document.title,
             uri=locator,
-            revision=None,
+            revision=source_document.revision,
         )
         document.metadata = {
             **deepcopy(source_document.metadata),

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -208,7 +208,7 @@ class WriterResourceTools(WriterToolBase):
         persisted_document = source
         expected_title = patch.new_title if patch.new_title is not None else source.title
         title_updated = patch.new_title is not None and patch.new_title != source.title
-        for hunk in patch.execution_hunks():
+        for hunk in patch.hunks:
             operation = adapter.patch_to_operation(hunk, persisted_document)
             self._execute_native_operation(
                 fs, document_id, operation, persisted_document.revision)
@@ -418,7 +418,8 @@ class WriterResourceTools(WriterToolBase):
 
         params = dict(operation.params)
         params.setdefault('document_id', document_id)
-        if operation.operation in {'update', 'delete'} and 'document_revision_id' not in params:
+        if operation.operation in {'create', 'update', 'delete', 'move'} \
+                and 'document_revision_id' not in params:
             try:
                 params['document_revision_id'] = int(revision) if revision is not None else -1
             except (TypeError, ValueError):

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -21,6 +21,7 @@ class WriterResourceTools(WriterToolBase):
     __public_apis__ = [
         'profile_resources',
         'document_to_docir',
+        'create_document',
         'write_to_document',
         'apply_patch_to_document',
     ]
@@ -160,6 +161,72 @@ class WriterResourceTools(WriterToolBase):
                 'adapter': protocol,
                 'document_id': document.document_id,
                 'stage': document.stage,
+            },
+        ).model_dump()
+
+    def create_document(
+        self,
+        title: str,
+        parent_uri: str = '',
+        adapter: str = 'feishu',
+    ) -> dict:
+        '''Create an empty provider document and return its normalized target artifact.'''
+        title = (title or '').strip()
+        if not title:
+            raise ValueError('title is required')
+        adapter = (adapter or '').strip().lower()
+        if not adapter:
+            raise ValueError('adapter is required')
+
+        import lazyllm.tools.fs.client as _fs_client
+        parent_locator = (parent_uri or '').strip() or f'{adapter}:/'
+        protocol, space_id, real_path = _fs_client.FS._parse(parent_locator)
+        if protocol != adapter:
+            raise ValueError(
+                f'parent URI protocol {protocol!r} does not match adapter {adapter!r}.')
+        fs = _fs_client.FS._get_or_create_fs(protocol, space_id, real_path)
+        create_document = getattr(fs, 'create_document', None)
+        if not callable(create_document):
+            raise TypeError(f'{type(fs).__name__} does not support create_document().')
+        created = create_document(title, real_path)
+        if not isinstance(created, dict):
+            raise TypeError('Document provider create_document() must return a dict.')
+
+        document_id = str(created.get('document_id') or '').strip()
+        created_path = str(created.get('path') or '').strip()
+        if not document_id or not created_path:
+            raise ValueError('Document provider returned an incomplete created document.')
+        effective_space_id = str(created.get('space_id') or '').strip()
+        internal_uri = (
+            f'{protocol}@{effective_space_id}:{created_path}'
+            if effective_space_id else f'{protocol}:{created_path}'
+        )
+        browser_url = str(created.get('browser_url') or '').strip()
+        target = TargetDocument(
+            doc_id=document_id,
+            uri=browser_url or internal_uri,
+            adapter=protocol,
+            title=str(created.get('title') or title),
+            meta={
+                'internal_uri': internal_uri,
+                'browser_url': browser_url,
+                'container': created.get('container') or '',
+                'parent_uri': (parent_uri or '').strip(),
+                'node_token': created.get('node_token') or '',
+                'space_id': effective_space_id,
+            },
+        )
+        return self._save_artifacts(
+            {'target_document': target},
+            step_name='create_document',
+            primary_key='target_document',
+            context_key=None,
+            summary='Created an empty provider document.',
+            counts={'documents': 1},
+            extra={
+                'adapter': protocol,
+                'document_id': document_id,
+                'uri': target.uri,
             },
         ).model_dump()
 

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -23,6 +23,8 @@ class WriterResourceTools(WriterToolBase):
         'document_to_docir',
         'create_document',
         'write_to_document',
+        'append_to_document',
+        'replace_document',
         'apply_patch_to_document',
     ]
 
@@ -231,7 +233,24 @@ class WriterResourceTools(WriterToolBase):
         ).model_dump()
 
     def write_to_document(self, content: Any, target_document: Any) -> dict:
-        '''Convert a final WriterDocument into native blocks and write them.'''
+        '''Backward-compatible alias for append_to_document().'''
+        return self.append_to_document(content, target_document)
+
+    def append_to_document(self, content: Any, target_document: Any) -> dict:
+        '''Append a final WriterDocument to an existing provider document.'''
+        return self._write_document(content, target_document, mode='append')
+
+    def replace_document(self, content: Any, target_document: Any) -> dict:
+        '''Replace an existing provider document with a final WriterDocument.'''
+        return self._write_document(content, target_document, mode='replace')
+
+    def _write_document(
+        self,
+        content: Any,
+        target_document: Any,
+        *,
+        mode: str,
+    ) -> dict:
         document = self._unified_model(content, WriterDocument)
         if document.stage != 'final':
             raise ValueError(f'content must have stage="final", got {document.stage!r}')
@@ -239,17 +258,23 @@ class WriterResourceTools(WriterToolBase):
         locator = self._target_locator(target, document)
 
         if not locator:
-            LOG.warning('write_to_document: no target document URI or doc_id, content not written to any platform')
+            LOG.warning(
+                '%s_to_document: no target document URI or doc_id, '
+                'content not written to any platform',
+                mode,
+            )
             return self._save_write_result('', '', '', 0)
 
         protocol, real_path, fs, adapter, locator, document_id = \
             self._resolve_document_target(target, source_document=document)
-        if not hasattr(fs, 'write_doc_blocks'):
-            raise TypeError(f'{type(fs).__name__} does not support structured document writes.')
+        method_name = 'replace_doc_blocks' if mode == 'replace' else 'write_doc_blocks'
+        write_blocks = getattr(fs, method_name, None)
+        if not callable(write_blocks):
+            raise TypeError(f'{type(fs).__name__} does not support {method_name}().')
         if document.title:
             self._update_document_title(fs, document_id, document.title, document.revision)
         native_blocks = adapter.ir_to_blocks(document)
-        fs.write_doc_blocks(document_id, native_blocks)
+        write_blocks(document_id, native_blocks)
         return self._save_write_result(document_id, protocol, locator, len(native_blocks))
 
     def apply_patch_to_document(
@@ -492,7 +517,7 @@ class WriterResourceTools(WriterToolBase):
 
         params = dict(operation.params)
         params.setdefault('document_id', document_id)
-        if operation.operation in {'create', 'update', 'delete', 'move'} \
+        if operation.operation in {'create', 'update', 'replace', 'delete', 'move'} \
                 and 'document_revision_id' not in params:
             try:
                 params['document_revision_id'] = int(revision) if revision is not None else -1

--- a/lazyllm/tools/writer/tools/resource_tools.py
+++ b/lazyllm/tools/writer/tools/resource_tools.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 from lazyllm import LOG
@@ -207,39 +208,61 @@ class WriterResourceTools(WriterToolBase):
         persisted_document = source
         expected_title = patch.new_title if patch.new_title is not None else source.title
         title_updated = patch.new_title is not None and patch.new_title != source.title
-        for hunk in patch.hunks:
+        for hunk in patch.execution_hunks():
             operation = adapter.patch_to_operation(hunk, persisted_document)
             self._execute_native_operation(
                 fs, document_id, operation, persisted_document.revision)
             applied_hunks.append(hunk.hunk_id or hunk.target_node_id)
-            persisted_document = self._read_persisted_document(
+            refreshed_document = self._read_persisted_document(
                 fs=fs,
                 adapter=adapter,
                 real_path=real_path,
                 locator=locator,
                 document_id=document_id,
-                source_document=source.model_copy(update={'title': expected_title}),
+                source_document=persisted_document.model_copy(
+                    update={'title': expected_title}),
+            )
+            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
+            persisted_document = (
+                merge_refreshed(
+                    persisted_document,
+                    refreshed_document,
+                    patch=hunk,
+                    operation=operation,
+                )
+                if callable(merge_refreshed) else refreshed_document
             )
 
         if title_updated:
             self._update_document_title(
                 fs, document_id, expected_title, persisted_document.revision)
-            persisted_document = self._read_persisted_document(
+            refreshed_document = self._read_persisted_document(
                 fs=fs,
                 adapter=adapter,
                 real_path=real_path,
                 locator=locator,
                 document_id=document_id,
-                source_document=source.model_copy(update={'title': expected_title}),
+                source_document=persisted_document.model_copy(
+                    update={'title': expected_title}),
+            )
+            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
+            persisted_document = (
+                merge_refreshed(persisted_document, refreshed_document)
+                if callable(merge_refreshed) else refreshed_document
             )
         elif not patch.hunks:
-            persisted_document = self._read_persisted_document(
+            refreshed_document = self._read_persisted_document(
                 fs=fs,
                 adapter=adapter,
                 real_path=real_path,
                 locator=locator,
                 document_id=document_id,
-                source_document=source.model_copy(update={'title': expected_title}),
+                source_document=persisted_document,
+            )
+            merge_refreshed = getattr(adapter, 'merge_refreshed_document', None)
+            persisted_document = (
+                merge_refreshed(persisted_document, refreshed_document)
+                if callable(merge_refreshed) else refreshed_document
             )
 
         patch_result = PatchResult(
@@ -339,10 +362,11 @@ class WriterResourceTools(WriterToolBase):
             uri=locator,
             revision=None,
         )
-        document.metadata.update({
+        document.metadata = {
+            **deepcopy(source_document.metadata),
             'block_count': len(latest_blocks),
             'source': source_document.metadata.get('source', {}),
-        })
+        }
         return document
 
     def _writer_adapter(self, protocol: str) -> WriterAdapterBase:

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -14,6 +14,8 @@ from ..data_models.revision import (
 )
 from ..data_models.task import WritingTask
 from ..data_models.writer_ir import (
+    WRITER_BLOCK_MUTABLE_FIELDS,
+    WRITER_BLOCK_PROVIDER_MANAGED_FIELDS,
     WriterBlock,
     WriterDocument,
 )
@@ -465,19 +467,18 @@ class WriterRevisionTools(WriterToolBase):
 
     @staticmethod
     def _same_mutable_block_fields(source: WriterBlock, revised: WriterBlock) -> bool:
-        fields = (
-            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
+        return all(
+            getattr(source, field) == getattr(revised, field)
+            for field in WRITER_BLOCK_MUTABLE_FIELDS
         )
-        return all(getattr(source, field) == getattr(revised, field) for field in fields)
 
     @staticmethod
     def _validate_preserved_block_fields(
         source: WriterBlock,
         revised: WriterBlock,
     ) -> None:
-        fields = ('provider_binding', 'provider_payload', 'editable')
         changed = [
-            field for field in fields
+            field for field in WRITER_BLOCK_PROVIDER_MANAGED_FIELDS
             if getattr(source, field) != getattr(revised, field)
         ]
         if changed:
@@ -536,17 +537,10 @@ class WriterRevisionTools(WriterToolBase):
 
     @classmethod
     def _visible_block(cls, block: WriterBlock) -> Dict[str, Any]:
-        return {
-            'node_id': block.node_id,
-            'type': block.type,
-            'content': block.content,
-            'spans': [span.model_dump() for span in block.spans],
-            'stage': block.stage,
-            'authoring': block.authoring.model_dump() if block.authoring else None,
-            'numbering': block.numbering,
-            'references': block.references,
-            'children': [cls._visible_block(child) for child in block.children],
-        }
+        visible = block.model_dump(include=set(WRITER_BLOCK_MUTABLE_FIELDS))
+        visible['node_id'] = block.node_id
+        visible['children'] = [cls._visible_block(child) for child in block.children]
+        return visible
 
     def _normalize_modify_plan(
         self,
@@ -640,9 +634,7 @@ class WriterRevisionTools(WriterToolBase):
         if target.node_id != revised.node_id:
             raise ValueError('update cannot change block node_id.')
         WriterRevisionTools._validate_preserved_block_fields(target, revised)
-        for field in (
-            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
-        ):
+        for field in WRITER_BLOCK_MUTABLE_FIELDS:
             setattr(target, field, deepcopy(getattr(revised, field)))
 
     @staticmethod

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .base import WriterToolBase
 from ..data_models.context import WritingContext
 from ..data_models.revision import (
-    Anchor,
     LocateResult,
     ModifyInstruction,
     ModifyPlan,
     PatchHunk,
     PatchResult,
-    PatchBlock,
     PatchSet,
 )
 from ..data_models.task import WritingTask
@@ -40,24 +39,7 @@ def apply_patch_to_ir(
 
     applied: List[str] = []
     for hunk in patch_set.hunks:
-        node_map = {block.node_id: block for block in revised_doc.iter_blocks()}
-        target = node_map[hunk.target_node_id]
-
-        if hunk.modify_type == 'replace':
-            target.content = hunk.new_text or ''
-            target.spans = []
-        elif hunk.modify_type == 'insert':
-            new_blocks = tools._build_inserted_blocks(revised_doc, hunk)
-            tools._insert_siblings(revised_doc, target, new_blocks, hunk.position or 'after')
-        elif hunk.modify_type == 'delete':
-            tools._remove_block(revised_doc, target)
-        elif hunk.modify_type == 'move':
-            anchor = node_map[hunk.anchor_node_id or '']
-            tools._remove_block(revised_doc, target)
-            tools._insert_siblings(revised_doc, anchor, [target], hunk.position or 'after')
-        else:
-            raise ValueError(f'unsupported modify_type: {hunk.modify_type!r}.')
-
+        tools._apply_patch_hunk(revised_doc, hunk)
         applied.append(hunk.hunk_id or hunk.target_node_id)
 
     revised_doc = WriterDocument.model_validate(revised_doc.model_dump())
@@ -84,6 +66,57 @@ class WriterRevisionTools(WriterToolBase):
         'build_patch_set_from_documents',
         'apply_patch',
     ]
+
+    def _apply_patch_hunk(
+        self,
+        document: WriterDocument,
+        hunk: PatchHunk,
+    ) -> None:
+        target = document.block_by_id(hunk.target_node_id)
+        if hunk.modify_type == 'update':
+            if target is None or hunk.block is None:
+                raise ValueError(
+                    f'update target {hunk.target_node_id!r} is absent from document.')
+            self._apply_block_update(target, hunk.block)
+            return
+        if hunk.modify_type == 'create':
+            self._apply_create_hunk(document, hunk)
+            return
+        if target is None:
+            raise ValueError(
+                f'{hunk.modify_type} target {hunk.target_node_id!r} is absent from document.')
+        self._remove_block(document, target)
+        if hunk.modify_type == 'delete':
+            return
+        if hunk.modify_type != 'move':
+            raise ValueError(f'unsupported modify_type: {hunk.modify_type!r}.')
+        if hunk.parent_node_id and self._subtree_has_id(target, hunk.parent_node_id):
+            raise ValueError('move target cannot be moved into its own subtree.')
+        siblings = self._children_for_parent(document, hunk.parent_node_id)
+        if hunk.index is None or hunk.index > len(siblings):
+            raise ValueError(
+                f'move index for {hunk.target_node_id!r} is outside its parent.')
+        siblings.insert(hunk.index, target)
+
+    def _apply_create_hunk(
+        self,
+        document: WriterDocument,
+        hunk: PatchHunk,
+    ) -> None:
+        if document.block_by_id(hunk.target_node_id) is not None:
+            raise ValueError(
+                f'create target {hunk.target_node_id!r} already exists in document.')
+        if hunk.block is None:
+            raise ValueError(f'create hunk {hunk.target_node_id!r} lacks block.')
+        siblings = self._children_for_parent(document, hunk.parent_node_id)
+        if hunk.index is None or hunk.index > len(siblings):
+            raise ValueError(
+                f'create index for {hunk.target_node_id!r} is outside its parent.')
+        new_ids = [block.node_id for block in hunk.block.iter_blocks()]
+        existing_ids = {block.node_id for block in document.iter_blocks()}
+        if len(new_ids) != len(set(new_ids)) or existing_ids.intersection(new_ids):
+            raise ValueError('create block subtree contains duplicate node_ids.')
+        siblings.insert(hunk.index, hunk.block.model_copy(deep=True))
 
     def build_patch_set_from_documents(
         self,
@@ -247,90 +280,21 @@ class WriterRevisionTools(WriterToolBase):
         plan = self._unified_model(modify_plan, ModifyPlan)
         writing_context = self._unified_model(context, WritingContext)
 
-        hunks: List[PatchHunk] = []
-        proposed_title: Optional[str] = None
-        if plan.instructions or plan.title_instruction:
-            block_map = {b.node_id: b for b in source_doc.iter_blocks()}
-            target_blocks, missing = self._resolve_target_blocks(block_map, plan.instructions)
-            if missing:
-                raise ValueError(f'modify_plan targets node_ids absent from document: {missing}.')
-
-            focused_doc = WriterDocument(
-                document_id=source_doc.document_id,
-                stage=source_doc.stage,
-                title=source_doc.title,
-                blocks=[b.model_copy(deep=True) for b in target_blocks],
-                ui_editable=False,
-            )
-
-            prompt = GENERATE_PATCH_SET_PROMPT.format(
-                document_json=to_prompt_json(focused_doc),
-                modify_plan_json=to_prompt_json(plan),
-                context_json=to_prompt_json(writing_context),
-            )
-            proposal = self._call_llm_structured(prompt, PatchSet)
-            proposed_title = self._normalize_proposed_title(
-                proposal.new_title, plan.title_instruction)
-
-            proposal_map: Dict[str, PatchHunk] = {
-                h.target_node_id: h for h in proposal.hunks if h.target_node_id
-            }
-            if len(proposal_map) != len(proposal.hunks):
-                raise ValueError('patch proposal contains duplicate or empty target_node_id values.')
-            expected_targets = {instruction.target_node_id for instruction in plan.instructions}
-            unexpected_targets = set(proposal_map) - expected_targets
-            if unexpected_targets:
-                raise ValueError(
-                    f'patch proposal contains targets absent from modify_plan: {sorted(unexpected_targets)}.'
-                )
-
-            for instr, block in zip(plan.instructions, target_blocks):
-                proposed = proposal_map.get(instr.target_node_id)
-                if proposed is None:
-                    raise ValueError(f'lack hunk for block {instr.target_node_id!r}.')
-                if proposed.modify_type != instr.modify_type:
-                    raise ValueError(
-                        f'patch hunk for {instr.target_node_id!r} changed modify_type '
-                        f'from {instr.modify_type!r} to {proposed.modify_type!r}.'
-                    )
-
-                position = instr.position or proposed.position
-                anchor_node_id = instr.anchor_node_id or proposed.anchor_node_id
-                if instr.modify_type == 'replace' and proposed.new_text is None:
-                    raise ValueError(f'lack new_text for block {instr.target_node_id!r}.')
-                if instr.modify_type == 'insert':
-                    position = position or 'after'
-                    if not proposed.new_blocks:
-                        raise ValueError(f'lack new_blocks for insert at {instr.target_node_id!r}.')
-                if instr.modify_type == 'move' and (not anchor_node_id or not position):
-                    raise ValueError(
-                        f'move for {instr.target_node_id!r} requires anchor_node_id and position.'
-                    )
-
-                hunks.append(PatchHunk(
-                    hunk_id=f'hunk-{instr.target_node_id}',
-                    target_node_id=instr.target_node_id,
-                    modify_type=instr.modify_type,
-                    anchor=Anchor(
-                        node_id=block.node_id,
-                    ),
-                    old_text=None if instr.modify_type == 'insert' else block.content,
-                    new_text=proposed.new_text if instr.modify_type == 'replace' else None,
-                    new_blocks=[item.model_copy(deep=True) for item in proposed.new_blocks]
-                    if instr.modify_type == 'insert' else [],
-                    anchor_node_id=anchor_node_id if instr.modify_type == 'move' else None,
-                    position=position if instr.modify_type in {'insert', 'move'} else None,
-                    meta={**proposed.meta, 'instruction': instr.instruction},
-                ))
-
-        self._chain_repeated_after_moves(hunks)
         patch_set = PatchSet(
             patch_id=f'patch-{source_doc.document_id or "document"}',
             target_doc_id=source_doc.document_id or '',
-            new_title=proposed_title if proposed_title != source_doc.title else None,
-            hunks=hunks,
             meta={'source': 'generate_patch_set'},
         )
+        if plan.instructions or plan.title_instruction:
+            prompt = GENERATE_PATCH_SET_PROMPT.format(
+                document_json=to_prompt_json(source_doc),
+                modify_plan_json=to_prompt_json(plan),
+                context_json=to_prompt_json(writing_context),
+            )
+            revised = self._call_llm_structured(prompt, WriterDocument)
+            self._validate_model_revision(source_doc, revised, plan)
+            patch_set = self._diff_documents(source_doc, revised)
+            patch_set.meta['source'] = 'generate_patch_set'
 
         result = self._save_artifacts(
             {'patch_set': patch_set},
@@ -338,7 +302,7 @@ class WriterRevisionTools(WriterToolBase):
             primary_key='patch_set',
             context_key=None,
             summary='Generated patch set.',
-            counts={'hunk_count': len(hunks)},
+            counts={'hunk_count': len(patch_set.hunks)},
             artifact_meta={
                 'document_id': source_doc.document_id,
                 'context_id': writing_context.context_id,
@@ -348,26 +312,6 @@ class WriterRevisionTools(WriterToolBase):
             },
         )
         return result.model_dump()
-
-    @staticmethod
-    def _chain_repeated_after_moves(hunks: List[PatchHunk]) -> None:
-        '''Keep move hunk order by advancing anchors within consecutive groups.'''
-        previous_anchor: Optional[str] = None
-        previous_target: Optional[str] = None
-        for hunk in hunks:
-            if (
-                hunk.modify_type == 'move'
-                and hunk.position == 'after'
-                and hunk.anchor_node_id
-            ):
-                if hunk.anchor_node_id == previous_anchor and previous_target is not None:
-                    hunk.anchor_node_id = previous_target
-                else:
-                    previous_anchor = hunk.anchor_node_id
-                previous_target = hunk.target_node_id
-            else:
-                previous_anchor = None
-                previous_target = None
 
     def apply_patch(
         self,
@@ -415,9 +359,6 @@ class WriterRevisionTools(WriterToolBase):
         common_ids = set(source_map) & set(revised_map)
         new_ids = set(revised_map) - set(source_map)
         deleted_ids = set(source_map) - set(revised_map)
-
-        source_layout = self._document_layout(source)
-        revised_layout = self._document_layout(revised)
         hunks: List[PatchHunk] = []
 
         for node_id in self._ordered_node_ids(revised):
@@ -425,59 +366,73 @@ class WriterRevisionTools(WriterToolBase):
                 continue
             old_block = source_map[node_id]
             new_block = revised_map[node_id]
-            self._validate_diffable_block(old_block, new_block)
-            if old_block.content != new_block.content:
+            self._validate_preserved_block_fields(old_block, new_block)
+            if not self._same_mutable_block_fields(old_block, new_block):
                 hunks.append(PatchHunk(
                     hunk_id=f'update-{node_id}',
                     target_node_id=node_id,
-                    modify_type='replace',
-                    old_text=old_block.content,
-                    new_text=new_block.content,
+                    modify_type='update',
+                    block=new_block.model_copy(deep=True),
                 ))
 
-        hunks.extend(self._build_move_hunks(
-            source, revised, source_layout, revised_layout, common_ids))
-
-        for group in self._new_block_groups(revised, new_ids):
-            anchor_id, position = self._insert_anchor(group, revised_layout, common_ids)
-            if anchor_id is None:
-                raise ValueError(
-                    'insert cannot be represented because the target sibling list '
-                    'has no existing block anchor.'
-                )
-            patch_blocks: List[PatchBlock] = []
-            for node_id in group:
-                block = revised_map[node_id]
-                if block.children:
-                    raise ValueError('inserting blocks with children is not supported yet.')
-                if block.spans and any(span.style for span in block.spans):
-                    raise ValueError('inserting styled spans is not supported yet.')
-                patch_blocks.append(PatchBlock(
-                    type=block.type,
-                    content=block.content,
-                    numbering=dict(block.numbering),
-                    authoring=block.authoring.model_copy(deep=True) if block.authoring else None,
-                ))
-            hunks.append(PatchHunk(
-                hunk_id=f'insert-{group[0]}',
-                target_node_id=anchor_id,
-                modify_type='insert',
-                position=position,
-                new_blocks=patch_blocks,
-            ))
-
+        source_layout = self._document_layout(source)
         top_level_deletes = {
             node_id for node_id in deleted_ids
             if source_layout[node_id][0] not in deleted_ids
         }
-        for node_id in self._ordered_node_ids(source):
+        working = source.model_copy(deep=True)
+        for node_id in reversed(self._ordered_node_ids(source)):
             if node_id in top_level_deletes:
-                hunks.append(PatchHunk(
+                hunk = PatchHunk(
                     hunk_id=f'delete-{node_id}',
                     target_node_id=node_id,
                     modify_type='delete',
-                    old_text=source_map[node_id].content,
-                ))
+                )
+                hunks.append(hunk)
+                target = working.block_by_id(node_id)
+                if target is not None:
+                    self._remove_block(working, target)
+
+        target_parents: List[Optional[str]] = [None]
+        target_parents.extend(self._ordered_node_ids(revised))
+        for parent_id in target_parents:
+            target_children = revised.blocks if parent_id is None \
+                else revised_map[parent_id].children
+            if parent_id is not None and working.block_by_id(parent_id) is None:
+                continue
+            for index, desired_child in enumerate(target_children):
+                current = working.block_by_id(desired_child.node_id)
+                if current is None:
+                    created = self._copy_new_subtree(desired_child, new_ids)
+                    self._validate_new_subtree(created)
+                    hunk = PatchHunk(
+                        hunk_id=f'create-{desired_child.node_id}',
+                        target_node_id=desired_child.node_id,
+                        modify_type='create',
+                        block=created,
+                        parent_node_id=parent_id,
+                        index=index,
+                    )
+                    hunks.append(hunk)
+                    self._children_for_parent(working, parent_id).insert(
+                        index, created.model_copy(deep=True))
+                    continue
+                if desired_child.node_id not in common_ids:
+                    continue
+                current_parent, current_index = self._block_parent_index(
+                    working, desired_child.node_id)
+                if current_parent == parent_id and current_index == index:
+                    continue
+                hunk = PatchHunk(
+                    hunk_id=f'move-{desired_child.node_id}',
+                    target_node_id=desired_child.node_id,
+                    modify_type='move',
+                    parent_node_id=parent_id,
+                    index=index,
+                )
+                hunks.append(hunk)
+                self._remove_block(working, current)
+                self._children_for_parent(working, parent_id).insert(index, current)
 
         patch = PatchSet(
             patch_id=f'patch-{source.document_id}',
@@ -486,7 +441,8 @@ class WriterRevisionTools(WriterToolBase):
             hunks=hunks,
             meta={'source': 'document_diff'},
         )
-        self._validate_patch(source, patch)
+        applied, _ = apply_patch_to_ir(source, patch)
+        self._assert_revision_applied(applied, revised)
         return patch
 
     @staticmethod
@@ -496,162 +452,101 @@ class WriterRevisionTools(WriterToolBase):
     @staticmethod
     def _document_layout(
         document: WriterDocument,
-    ) -> Dict[str, Tuple[Optional[str], List[str], int]]:
-        layout: Dict[str, Tuple[Optional[str], List[str], int]] = {}
+    ) -> Dict[str, Tuple[Optional[str], int]]:
+        layout: Dict[str, Tuple[Optional[str], int]] = {}
 
         def walk(blocks: List[WriterBlock], parent_id: Optional[str]) -> None:
-            sibling_ids = [block.node_id for block in blocks]
             for index, block in enumerate(blocks):
-                layout[block.node_id] = (parent_id, sibling_ids, index)
+                layout[block.node_id] = (parent_id, index)
                 walk(block.children, block.node_id)
 
         walk(document.blocks, None)
         return layout
 
-    def _build_move_hunks(
-        self,
-        source: WriterDocument,
-        revised: WriterDocument,
-        source_layout: Dict[str, Tuple[Optional[str], List[str], int]],
-        revised_layout: Dict[str, Tuple[Optional[str], List[str], int]],
-        common_ids: Set[str],
-    ) -> List[PatchHunk]:
-        current_parent = {
-            node_id: source_layout[node_id][0] for node_id in common_ids
-        }
-        current_lists: Dict[Optional[str], List[str]] = {}
-        for node_id in self._ordered_node_ids(source):
-            if node_id in common_ids:
-                current_lists.setdefault(current_parent[node_id], []).append(node_id)
-
-        target_parents: List[Optional[str]] = [None]
-        target_parents.extend(
-            node_id for node_id in self._ordered_node_ids(revised)
-            if any(
-                revised_layout[child_id][0] == node_id
-                for child_id in common_ids
-            )
-        )
-
-        hunks: List[PatchHunk] = []
-        for parent_id in target_parents:
-            target_order = [
-                node_id for node_id in common_ids
-                if revised_layout[node_id][0] == parent_id
-            ]
-            target_order.sort(key=lambda node_id: revised_layout[node_id][2])
-            current_lists.setdefault(parent_id, [])
-
-            for index, node_id in enumerate(target_order):
-                current = current_lists[parent_id]
-                previous_id = target_order[index - 1] if index else None
-                correctly_placed = (
-                    current_parent[node_id] == parent_id
-                    and node_id in current
-                    and (
-                        (previous_id is None and current.index(node_id) == 0)
-                        or (
-                            previous_id is not None
-                            and current.index(node_id) == current.index(previous_id) + 1
-                        )
-                    )
-                )
-                if correctly_placed:
-                    continue
-
-                if previous_id is not None:
-                    anchor_id, position = previous_id, 'after'
-                else:
-                    anchor_id = next(
-                        (
-                            sibling_id for sibling_id in target_order[index + 1:]
-                            if current_parent[sibling_id] == parent_id
-                        ),
-                        None,
-                    )
-                    position = 'before'
-                if anchor_id is None:
-                    raise ValueError(
-                        f'move for {node_id!r} cannot be represented because its target '
-                        'parent has no stable sibling anchor.'
-                    )
-
-                old_parent = current_parent[node_id]
-                current_lists[old_parent].remove(node_id)
-                target_list = current_lists[parent_id]
-                anchor_index = target_list.index(anchor_id)
-                insert_index = anchor_index + (1 if position == 'after' else 0)
-                target_list.insert(insert_index, node_id)
-                current_parent[node_id] = parent_id
-                hunks.append(PatchHunk(
-                    hunk_id=f'move-{node_id}',
-                    target_node_id=node_id,
-                    modify_type='move',
-                    anchor_node_id=anchor_id,
-                    position=position,
-                ))
-        return hunks
-
-    def _new_block_groups(
-        self,
-        document: WriterDocument,
-        new_ids: Set[str],
-    ) -> List[List[str]]:
-        groups: List[List[str]] = []
-
-        def walk(blocks: List[WriterBlock]) -> None:
-            current: List[str] = []
-            for block in blocks:
-                if block.node_id in new_ids:
-                    current.append(block.node_id)
-                else:
-                    if current:
-                        groups.append(current)
-                        current = []
-                    walk(block.children)
-            if current:
-                groups.append(current)
-
-        walk(document.blocks)
-        return groups
-
     @staticmethod
-    def _insert_anchor(
-        group: List[str],
-        layout: Dict[str, Tuple[Optional[str], List[str], int]],
-        common_ids: Set[str],
-    ) -> Tuple[Optional[str], Optional[str]]:
-        _, siblings, first_index = layout[group[0]]
-        last_index = layout[group[-1]][2]
-        for sibling_id in reversed(siblings[:first_index]):
-            if sibling_id in common_ids:
-                return sibling_id, 'after'
-        for sibling_id in siblings[last_index + 1:]:
-            if sibling_id in common_ids:
-                return sibling_id, 'before'
-        return None, None
-
-    @staticmethod
-    def _validate_diffable_block(source: WriterBlock, revised: WriterBlock) -> None:
+    def _same_mutable_block_fields(source: WriterBlock, revised: WriterBlock) -> bool:
         fields = (
-            'type', 'stage', 'authoring', 'numbering', 'references',
-            'provider_binding', 'provider_payload', 'editable',
+            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
         )
-        changed = [name for name in fields if getattr(source, name) != getattr(revised, name)]
+        return all(getattr(source, field) == getattr(revised, field) for field in fields)
+
+    @staticmethod
+    def _validate_preserved_block_fields(
+        source: WriterBlock,
+        revised: WriterBlock,
+    ) -> None:
+        fields = ('provider_binding', 'provider_payload', 'editable')
+        changed = [
+            field for field in fields
+            if getattr(source, field) != getattr(revised, field)
+        ]
         if changed:
             raise ValueError(
-                f'block {source.node_id!r} changes unsupported fields: {changed}.'
-            )
-        if source.content == revised.content and source.spans != revised.spans:
-            raise ValueError(
-                f'block {source.node_id!r} changes spans without changing text; '
-                'span-only patches are not supported yet.'
-            )
-        if source.content != revised.content and any(span.style for span in revised.spans):
-            raise ValueError(
-                f'block {source.node_id!r} contains edited styled spans; '
-                'styled span patches are not supported yet.'
-            )
+                f'block {source.node_id!r} changes provider-managed fields: {changed}.')
+
+    @classmethod
+    def _copy_new_subtree(
+        cls,
+        block: WriterBlock,
+        new_ids: Set[str],
+    ) -> WriterBlock:
+        copied = block.model_copy(deep=True)
+        copied.children = [
+            cls._copy_new_subtree(child, new_ids)
+            for child in block.children
+            if child.node_id in new_ids
+        ]
+        return copied
+
+    @staticmethod
+    def _validate_new_subtree(block: WriterBlock) -> None:
+        for item in block.iter_blocks():
+            if item.provider_binding or item.provider_payload:
+                raise ValueError(
+                    f'new block {item.node_id!r} must not contain provider-managed fields.')
+
+    def _block_parent_index(
+        self,
+        document: WriterDocument,
+        node_id: str,
+    ) -> Tuple[Optional[str], int]:
+        layout = self._document_layout(document)
+        if node_id not in layout:
+            raise ValueError(f'block {node_id!r} is absent from document.')
+        return layout[node_id]
+
+    @classmethod
+    def _assert_revision_applied(
+        cls,
+        applied: WriterDocument,
+        revised: WriterDocument,
+    ) -> None:
+        def visible(document: WriterDocument) -> Dict[str, Any]:
+            return {
+                'document_id': document.document_id,
+                'stage': document.stage,
+                'title': document.title,
+                'blocks': [
+                    cls._visible_block(block) for block in document.blocks
+                ],
+            }
+
+        if visible(applied) != visible(revised):
+            raise ValueError('generated patch does not reproduce the revised WriterDocument.')
+
+    @classmethod
+    def _visible_block(cls, block: WriterBlock) -> Dict[str, Any]:
+        return {
+            'node_id': block.node_id,
+            'type': block.type,
+            'content': block.content,
+            'spans': [span.model_dump() for span in block.spans],
+            'stage': block.stage,
+            'authoring': block.authoring.model_dump() if block.authoring else None,
+            'numbering': block.numbering,
+            'references': block.references,
+            'children': [cls._visible_block(child) for child in block.children],
+        }
 
     def _normalize_modify_plan(
         self,
@@ -686,7 +581,7 @@ class WriterRevisionTools(WriterToolBase):
                 raise ValueError(f'modify_plan has duplicate instruction for block {target_id!r}.')
             seen.add(target_id)
             instr.instruction_id = instr.instruction_id or f'instr-{target_id}'
-            if instr.modify_type == 'insert':
+            if instr.modify_type == 'create':
                 instr.position = instr.position or 'after'
             if instr.modify_type == 'move':
                 if instr.anchor_node_id not in valid_node_ids:
@@ -706,33 +601,23 @@ class WriterRevisionTools(WriterToolBase):
         return plan
 
     @staticmethod
-    def _normalize_proposed_title(
-        proposed_title: Optional[str],
-        title_instruction: Optional[str],
-    ) -> Optional[str]:
-        if title_instruction:
-            if not proposed_title or not proposed_title.strip():
-                raise ValueError('patch proposal lacks new_title for the title instruction.')
-            return proposed_title.strip()
-        if proposed_title is not None:
-            raise ValueError(
-                'patch proposal changes the document title without a title instruction.')
-        return None
-
-    def _resolve_target_blocks(
-        self,
-        block_map: Dict[str, WriterBlock],
-        instructions: List[ModifyInstruction],
-    ) -> Tuple[List[WriterBlock], List[str]]:
-        blocks: List[WriterBlock] = []
-        missing: List[str] = []
-        for instr in instructions:
-            block = block_map.get(instr.target_node_id)
-            if block is None:
-                missing.append(instr.target_node_id)
-            else:
-                blocks.append(block)
-        return blocks, missing
+    def _validate_model_revision(
+        source: WriterDocument,
+        revised: WriterDocument,
+        plan: ModifyPlan,
+    ) -> None:
+        if source.document_id != revised.document_id:
+            raise ValueError('model revision changed document_id.')
+        if source.stage != revised.stage:
+            raise ValueError('model revision changed document stage.')
+        if source.revision != revised.revision:
+            raise ValueError('model revision changed document revision.')
+        if source.provider_binding != revised.provider_binding:
+            raise ValueError('model revision changed document provider_binding.')
+        if plan.title_instruction is None and source.title != revised.title:
+            raise ValueError('model revision changed title without a title instruction.')
+        if plan.title_instruction is not None and not revised.title.strip():
+            raise ValueError('model revision produced an empty title.')
 
     def _validate_patch(self, document: WriterDocument, patch: PatchSet) -> None:
         if patch.target_doc_id != document.document_id:
@@ -741,7 +626,6 @@ class WriterRevisionTools(WriterToolBase):
                 f'document_id {document.document_id!r}.'
             )
 
-        node_map = {block.node_id: block for block in document.iter_blocks()}
         hunk_ids: set = set()
         for hunk in patch.hunks:
             if hunk.hunk_id:
@@ -749,114 +633,33 @@ class WriterRevisionTools(WriterToolBase):
                     raise ValueError(f'patch contains duplicate hunk_id {hunk.hunk_id!r}.')
                 hunk_ids.add(hunk.hunk_id)
 
-            self._validate_patch_hunk(node_map, hunk)
-
-        destructive_targets = {
-            hunk.target_node_id for hunk in patch.hunks
-            if hunk.modify_type == 'delete'
-        }
-        for hunk in patch.hunks:
-            if hunk.modify_type == 'move' and hunk.anchor_node_id in destructive_targets:
-                raise ValueError(
-                    f'move anchor {hunk.anchor_node_id!r} is also deleted or moved by this patch.'
-                )
-
-    def _validate_patch_hunk(
-        self,
-        node_map: Dict[str, WriterBlock],
-        hunk: PatchHunk,
-    ) -> None:
-        target_id = hunk.target_node_id
-        target = node_map.get(target_id)
-        if target is None:
-            raise ValueError(f'patch target {target_id!r} is absent from document.')
+    @staticmethod
+    def _apply_block_update(target: WriterBlock, revised: WriterBlock) -> None:
         if not target.editable:
-            raise ValueError(f'patch target {target_id!r} is not editable.')
-        if hunk.old_text is not None and target.content != hunk.old_text:
-            raise ValueError(f'patch old_text conflict for target {target_id!r}.')
+            raise ValueError(f'patch target {target.node_id!r} is not editable.')
+        if target.node_id != revised.node_id:
+            raise ValueError('update cannot change block node_id.')
+        WriterRevisionTools._validate_preserved_block_fields(target, revised)
+        for field in (
+            'type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references',
+        ):
+            setattr(target, field, deepcopy(getattr(revised, field)))
 
-        validators = {
-            'replace': self._validate_replace_hunk,
-            'insert': self._validate_insert_hunk,
-            'move': self._validate_move_hunk,
-        }
-        validator = validators.get(hunk.modify_type)
-        if validator:
-            validator(node_map, target, hunk)
-
-    def _validate_replace_hunk(
-        self,
-        node_map: Dict[str, WriterBlock],
-        target: WriterBlock,
-        hunk: PatchHunk,
-    ) -> None:
-        if hunk.new_text is None:
-            raise ValueError(f'replace hunk for {target.node_id!r} requires new_text.')
-
-    def _validate_insert_hunk(
-        self,
-        node_map: Dict[str, WriterBlock],
-        target: WriterBlock,
-        hunk: PatchHunk,
-    ) -> None:
-        if not hunk.new_blocks:
-            raise ValueError(f'insert hunk for {target.node_id!r} requires new_blocks.')
-        if hunk.position not in {'before', 'after'}:
-            raise ValueError(f'insert hunk for {target.node_id!r} requires position.')
-
-    def _validate_move_hunk(
-        self,
-        node_map: Dict[str, WriterBlock],
-        target: WriterBlock,
-        hunk: PatchHunk,
-    ) -> None:
-        anchor_id = hunk.anchor_node_id or ''
-        anchor = node_map.get(anchor_id)
-        if anchor is None:
-            raise ValueError(f'move anchor {anchor_id!r} is absent from document.')
-        if anchor is target:
-            raise ValueError('move target cannot be its own anchor.')
-        if hunk.position not in {'before', 'after'}:
-            raise ValueError(f'move hunk for {target.node_id!r} requires position.')
-        if self._contains_block(target, anchor):
-            raise ValueError('move target cannot be moved relative to one of its descendants.')
-
-    def _build_inserted_blocks(
-        self,
+    @staticmethod
+    def _children_for_parent(
         document: WriterDocument,
-        hunk: PatchHunk,
+        parent_node_id: Optional[str],
     ) -> List[WriterBlock]:
-        used_ids = {block.node_id for block in document.iter_blocks()}
-        base_id = hunk.hunk_id or f'hunk-{hunk.target_node_id}'
-        result: List[WriterBlock] = []
-        for index, patch_block in enumerate(hunk.new_blocks, start=1):
-            candidate = f'{base_id}::block-{index}'
-            suffix = 2
-            while candidate in used_ids:
-                candidate = f'{base_id}::block-{index}-{suffix}'
-                suffix += 1
-            used_ids.add(candidate)
-            result.append(WriterBlock(
-                node_id=candidate,
-                type=patch_block.type,
-                content=patch_block.content,
-                stage=document.stage,
-                authoring=patch_block.authoring.model_copy(deep=True)
-                if patch_block.authoring else None,
-                numbering=dict(patch_block.numbering),
-            ))
-        return result
+        if parent_node_id is None:
+            return document.blocks
+        parent = document.block_by_id(parent_node_id)
+        if parent is None:
+            raise ValueError(f'parent block {parent_node_id!r} is absent from document.')
+        return parent.children
 
-    def _insert_siblings(
-        self,
-        document: WriterDocument,
-        anchor: WriterBlock,
-        new_blocks: List[WriterBlock],
-        position: str,
-    ) -> None:
-        siblings = self._sibling_list(document, anchor)
-        index = siblings.index(anchor) + (1 if position == 'after' else 0)
-        siblings[index:index] = new_blocks
+    @staticmethod
+    def _subtree_has_id(block: WriterBlock, node_id: str) -> bool:
+        return any(item.node_id == node_id for item in block.iter_blocks())
 
     def _remove_block(self, document: WriterDocument, target: WriterBlock) -> None:
         self._sibling_list(document, target).remove(target)
@@ -886,9 +689,3 @@ class WriterRevisionTools(WriterToolBase):
             if deeper is not None:
                 return deeper
         return None
-
-    def _contains_block(self, candidate: WriterBlock, target: WriterBlock) -> bool:
-        return any(
-            child is target or self._contains_block(child, target)
-            for child in candidate.children
-        )

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -293,9 +293,9 @@ class WriterRevisionTools(WriterToolBase):
                 modify_plan_json=to_prompt_json(plan),
                 context_json=to_prompt_json(writing_context),
             )
-            revised = self._call_llm_structured(prompt, WriterDocument)
-            self._validate_model_revision(source_doc, revised, plan)
-            patch_set = self._diff_documents(source_doc, revised)
+            patch_set = self._call_llm_structured(prompt, PatchSet)
+            self._normalize_generated_patch(source_doc, plan, patch_set)
+            apply_patch_to_ir(source_doc, patch_set)
             patch_set.meta['source'] = 'generate_patch_set'
 
         result = self._save_artifacts(
@@ -314,6 +314,42 @@ class WriterRevisionTools(WriterToolBase):
             },
         )
         return result.model_dump()
+
+    def _normalize_generated_patch(
+        self,
+        document: WriterDocument,
+        plan: ModifyPlan,
+        patch: PatchSet,
+    ) -> None:
+        if patch.target_doc_id != document.document_id:
+            raise ValueError('generated patch targets a different document.')
+        if plan.title_instruction is None and patch.new_title is not None:
+            raise ValueError('generated patch changes title without a title instruction.')
+        if plan.title_instruction is not None and not (patch.new_title or '').strip():
+            raise ValueError('generated patch omits the requested title change.')
+        if len(patch.hunks) != len(plan.instructions):
+            raise ValueError('generated patch must contain one hunk per modify instruction.')
+
+        for instruction, hunk in zip(plan.instructions, patch.hunks):
+            if hunk.modify_type != instruction.modify_type:
+                raise ValueError(
+                    f'generated hunk type {hunk.modify_type!r} does not match '
+                    f'instruction type {instruction.modify_type!r}.'
+                )
+            if (
+                instruction.modify_type != 'create'
+                and hunk.target_node_id != instruction.target_node_id
+            ):
+                raise ValueError(
+                    f'generated hunk targets {hunk.target_node_id!r}, expected '
+                    f'{instruction.target_node_id!r}.'
+                )
+            hunk.hunk_id = hunk.hunk_id or (
+                f'{hunk.modify_type}-{hunk.target_node_id}'
+            )
+            hunk.meta['instruction_id'] = instruction.instruction_id
+
+        self._validate_patch(document, patch)
 
     def apply_patch(
         self,

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -39,7 +39,7 @@ def apply_patch_to_ir(
         revised_doc.title = patch_set.new_title
 
     applied: List[str] = []
-    for hunk in patch_set.hunks:
+    for hunk in patch_set.execution_hunks():
         node_map = {block.node_id: block for block in revised_doc.iter_blocks()}
         target = node_map[hunk.target_node_id]
 

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -126,9 +126,9 @@ class WriterRevisionTools(WriterToolBase):
         writing_context = self._unified_model(context, WritingContext)
         user_selection = writing_task.selection
 
-        valid_node_ids = {b.node_id for b in source_doc.iter_blocks()}
-        if not valid_node_ids:
-            raise ValueError('document must contain at least one block.')
+        valid_node_ids = {
+            block.node_id for block in source_doc.iter_blocks() if block.editable
+        }
 
         candidate_node_ids = valid_node_ids
         if user_selection and user_selection.block_ids:
@@ -165,11 +165,14 @@ class WriterRevisionTools(WriterToolBase):
             primary_key='locate_result',
             context_key=None,
             summary=(
-                'No revision target blocks located.'
-                if not locate_result.target_node_ids
-                else 'Located revision target blocks.'
+                'No revision targets located.'
+                if not locate_result.target_node_ids and not locate_result.target_title
+                else 'Located revision targets.'
             ),
-            counts={'target_node_count': len(locate_result.target_node_ids)},
+            counts={
+                'target_node_count': len(locate_result.target_node_ids),
+                'target_title': int(locate_result.target_title),
+            },
             artifact_meta={
                 'task_id': writing_task.task_id,
                 'document_id': source_doc.document_id,
@@ -193,7 +196,7 @@ class WriterRevisionTools(WriterToolBase):
         located = self._unified_model(locate_result, LocateResult)
         writing_context = self._unified_model(context, WritingContext)
 
-        if located.target_node_ids:
+        if located.target_node_ids or located.target_title:
             block_map = {b.node_id: b for b in source_doc.iter_blocks()}
             missing = [nid for nid in located.target_node_ids if nid not in block_map]
             if missing:
@@ -214,6 +217,7 @@ class WriterRevisionTools(WriterToolBase):
             writing_task,
             located.target_node_ids,
             {block.node_id for block in source_doc.iter_blocks()},
+            target_title=located.target_title,
         )
 
         result = self._save_artifacts(
@@ -245,7 +249,7 @@ class WriterRevisionTools(WriterToolBase):
 
         hunks: List[PatchHunk] = []
         proposed_title: Optional[str] = None
-        if plan.instructions:
+        if plan.instructions or plan.title_instruction:
             block_map = {b.node_id: b for b in source_doc.iter_blocks()}
             target_blocks, missing = self._resolve_target_blocks(block_map, plan.instructions)
             if missing:
@@ -265,7 +269,8 @@ class WriterRevisionTools(WriterToolBase):
                 context_json=to_prompt_json(writing_context),
             )
             proposal = self._call_llm_structured(prompt, PatchSet)
-            proposed_title = proposal.new_title
+            proposed_title = self._normalize_proposed_title(
+                proposal.new_title, plan.title_instruction)
 
             proposal_map: Dict[str, PatchHunk] = {
                 h.target_node_id: h for h in proposal.hunks if h.target_node_id
@@ -654,10 +659,18 @@ class WriterRevisionTools(WriterToolBase):
         task: WritingTask,
         located_node_ids: List[str],
         valid_node_ids: set,
+        *,
+        target_title: bool = False,
     ) -> ModifyPlan:
         plan.plan_id = plan.plan_id or f'plan-{task.task_id or "task"}'
         plan.task_id = task.task_id
         plan.target_node_ids = list(located_node_ids)
+        if target_title:
+            if not plan.title_instruction or not plan.title_instruction.strip():
+                raise ValueError('modify_plan requires title_instruction for a title target.')
+            plan.title_instruction = plan.title_instruction.strip()
+        elif plan.title_instruction is not None:
+            raise ValueError('modify_plan has title_instruction without a title target.')
 
         located_set = set(located_node_ids)
         seen: set = set()
@@ -691,6 +704,20 @@ class WriterRevisionTools(WriterToolBase):
             )
         plan.instructions = normalized
         return plan
+
+    @staticmethod
+    def _normalize_proposed_title(
+        proposed_title: Optional[str],
+        title_instruction: Optional[str],
+    ) -> Optional[str]:
+        if title_instruction:
+            if not proposed_title or not proposed_title.strip():
+                raise ValueError('patch proposal lacks new_title for the title instruction.')
+            return proposed_title.strip()
+        if proposed_title is not None:
+            raise ValueError(
+                'patch proposal changes the document title without a title instruction.')
+        return None
 
     def _resolve_target_blocks(
         self,

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -634,7 +634,7 @@ class WriterRevisionTools(WriterToolBase):
     @staticmethod
     def _validate_diffable_block(source: WriterBlock, revised: WriterBlock) -> None:
         fields = (
-            'type', 'stage', 'status', 'authoring', 'numbering', 'references',
+            'type', 'stage', 'authoring', 'numbering', 'references',
             'provider_binding', 'provider_payload', 'editable',
         )
         changed = [name for name in fields if getattr(source, name) != getattr(revised, name)]

--- a/lazyllm/tools/writer/tools/revision_tools.py
+++ b/lazyllm/tools/writer/tools/revision_tools.py
@@ -39,7 +39,7 @@ def apply_patch_to_ir(
         revised_doc.title = patch_set.new_title
 
     applied: List[str] = []
-    for hunk in patch_set.execution_hunks():
+    for hunk in patch_set.hunks:
         node_map = {block.node_id: block for block in revised_doc.iter_blocks()}
         target = node_map[hunk.target_node_id]
 
@@ -318,6 +318,7 @@ class WriterRevisionTools(WriterToolBase):
                     meta={**proposed.meta, 'instruction': instr.instruction},
                 ))
 
+        self._chain_repeated_after_moves(hunks)
         patch_set = PatchSet(
             patch_id=f'patch-{source_doc.document_id or "document"}',
             target_doc_id=source_doc.document_id or '',
@@ -342,6 +343,26 @@ class WriterRevisionTools(WriterToolBase):
             },
         )
         return result.model_dump()
+
+    @staticmethod
+    def _chain_repeated_after_moves(hunks: List[PatchHunk]) -> None:
+        '''Keep move hunk order by advancing anchors within consecutive groups.'''
+        previous_anchor: Optional[str] = None
+        previous_target: Optional[str] = None
+        for hunk in hunks:
+            if (
+                hunk.modify_type == 'move'
+                and hunk.position == 'after'
+                and hunk.anchor_node_id
+            ):
+                if hunk.anchor_node_id == previous_anchor and previous_target is not None:
+                    hunk.anchor_node_id = previous_target
+                else:
+                    previous_anchor = hunk.anchor_node_id
+                previous_target = hunk.target_node_id
+            else:
+                previous_anchor = None
+                previous_target = None
 
     def apply_patch(
         self,

--- a/lazyllm/tools/writer/utils/__init__.py
+++ b/lazyllm/tools/writer/utils/__init__.py
@@ -6,7 +6,7 @@ from .artifact import (
     load_artifact_json,
     save_artifact_json,
 )
-from .serialization import to_prompt_json
+from .serialization import render_document_markdown, to_prompt_json
 
 __all__ = [
     'SCHEMA_VERSION',
@@ -15,5 +15,6 @@ __all__ = [
     'ToolResult',
     'load_artifact_json',
     'save_artifact_json',
+    'render_document_markdown',
     'to_prompt_json',
 ]

--- a/lazyllm/tools/writer/utils/feishu_docx.py
+++ b/lazyllm/tools/writer/utils/feishu_docx.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 LazyAGI. All rights reserved.
+from typing import Any, Dict, List, Tuple
+
+
+DOCX_BLOCK_TYPE_FIELDS: Dict[int, str] = {
+    1: 'page', 2: 'text', 3: 'heading1', 4: 'heading2', 5: 'heading3', 6: 'heading4',
+    7: 'heading5', 8: 'heading6', 9: 'heading7', 10: 'heading8', 11: 'heading9',
+    12: 'bullet', 13: 'ordered', 14: 'code', 15: 'quote', 17: 'todo',
+    19: 'callout', 22: 'divider', 24: 'grid', 25: 'grid_column',
+    31: 'table', 32: 'table_cell', 34: 'quote_container',
+}
+
+
+def prepare_docx_descendants(
+    blocks: List[Dict[str, Any]],
+) -> Tuple[List[str], List[Dict[str, Any]]]:
+    '''Build Feishu descendant-create payloads from a flat block tree.'''
+    content_blocks = [block for block in blocks if block.get('block_type') != 1]
+    raw_by_id = {block['block_id']: block for block in content_blocks}
+    children_by_parent: Dict[str, List[str]] = {}
+    for block in content_blocks:
+        parent_id = block.get('parent_id')
+        if parent_id in raw_by_id:
+            children_by_parent.setdefault(parent_id, []).append(block['block_id'])
+
+    root_block_ids: List[str] = []
+    descendants: List[Dict[str, Any]] = []
+    for block in content_blocks:
+        block_id = block['block_id']
+        block_type = block.get('block_type')
+        content_key = DOCX_BLOCK_TYPE_FIELDS.get(block_type)
+        if content_key is None:
+            raise ValueError(
+                f'Feishu block type {block_type!r} is not supported for structured writing.')
+        content = block.get(content_key)
+        if block_type == 22 and content is None:
+            content = {}
+        content = dict(content)
+        if block_type == 31:
+            content.pop('cells', None)
+            content.pop('merge_info', None)
+            prop = dict(content.get('property') or {})
+            prop.pop('merge_info', None)
+            content['property'] = prop
+
+        descendant = {
+            'block_id': block_id,
+            'block_type': block_type,
+            content_key: content,
+        }
+        children = children_by_parent.get(block_id)
+        if children:
+            descendant['children'] = children
+        descendants.append(descendant)
+        if block.get('parent_id') not in raw_by_id:
+            root_block_ids.append(block_id)
+    return root_block_ids, descendants
+
+
+__all__ = ['DOCX_BLOCK_TYPE_FIELDS', 'prepare_docx_descendants']

--- a/lazyllm/tools/writer/utils/feishu_docx.py
+++ b/lazyllm/tools/writer/utils/feishu_docx.py
@@ -130,7 +130,7 @@ def normalize_docx_clone_content(
     return normalized, sorted(normalized_fields)
 
 
-def prepare_docx_clone_descendants(
+def prepare_docx_clone_descendants(  # noqa: C901
     blocks: List[Dict[str, Any]],
     root_block_id: str,
 ) -> Tuple[List[str], List[Dict[str, Any]], Dict[str, str], List[str]]:

--- a/lazyllm/tools/writer/utils/feishu_docx.py
+++ b/lazyllm/tools/writer/utils/feishu_docx.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2026 LazyAGI. All rights reserved.
-from typing import Any, Dict, List, Tuple
+from copy import deepcopy
+from typing import Any, Dict, List, Set, Tuple
 
 
 DOCX_BLOCK_TYPE_FIELDS: Dict[int, str] = {
@@ -8,6 +9,20 @@ DOCX_BLOCK_TYPE_FIELDS: Dict[int, str] = {
     12: 'bullet', 13: 'ordered', 14: 'code', 15: 'quote', 17: 'todo',
     19: 'callout', 22: 'divider', 24: 'grid', 25: 'grid_column',
     31: 'table', 32: 'table_cell', 34: 'quote_container',
+}
+
+_DOCX_DEFAULT_CLONE_FIELDS = {
+    'align': 1,
+    'done': False,
+    'folded': False,
+    'wrap': False,
+    'language': 1,
+    'indentation_level': 'NoIndent',
+    'bold': False,
+    'italic': False,
+    'strikethrough': False,
+    'underline': False,
+    'inline_code': False,
 }
 
 
@@ -57,4 +72,164 @@ def prepare_docx_descendants(
     return root_block_ids, descendants
 
 
-__all__ = ['DOCX_BLOCK_TYPE_FIELDS', 'prepare_docx_descendants']
+def _normalize_clone_value(value: Any, normalized_fields: Set[str], path: str = '') -> Any:
+    if isinstance(value, list):
+        normalized = [
+            _normalize_clone_value(item, normalized_fields, path)
+            for item in value
+        ]
+        return [item for item in normalized if item not in (None, {}, [])]
+    if not isinstance(value, dict):
+        return value
+
+    normalized: Dict[str, Any] = {}
+    for key, item in value.items():
+        field_path = f'{path}.{key}' if path else key
+        if key == 'comment_ids':
+            normalized_fields.add(field_path)
+            continue
+        if key == 'title' and path.endswith('mention_doc'):
+            normalized_fields.add(field_path)
+            continue
+        if path.endswith('elements') and key in {
+            'file', 'inline_block', 'undefined', 'undefined_element',
+        }:
+            normalized_fields.add(field_path)
+            continue
+        if key in _DOCX_DEFAULT_CLONE_FIELDS \
+                and item == _DOCX_DEFAULT_CLONE_FIELDS[key]:
+            normalized_fields.add(field_path)
+            continue
+        normalized_item = _normalize_clone_value(item, normalized_fields, field_path)
+        if normalized_item not in (None, {}, []):
+            normalized[key] = normalized_item
+    return normalized
+
+
+def normalize_docx_clone_content(
+    block_type: Any,
+    content: Any,
+) -> Tuple[Dict[str, Any], List[str]]:
+    normalized_fields: Set[str] = set()
+    normalized = _normalize_clone_value(
+        deepcopy(content) if isinstance(content, dict) else {},
+        normalized_fields,
+    )
+    if block_type == 31:
+        if normalized.pop('cells', None) is not None:
+            normalized_fields.add('table.cells')
+        if normalized.pop('merge_info', None) is not None:
+            normalized_fields.add('table.merge_info')
+        prop = dict(normalized.get('property') or {})
+        if prop.pop('merge_info', None) is not None:
+            normalized_fields.add('table.property.merge_info')
+        if prop:
+            normalized['property'] = prop
+        else:
+            normalized.pop('property', None)
+    return normalized, sorted(normalized_fields)
+
+
+def prepare_docx_clone_descendants(
+    blocks: List[Dict[str, Any]],
+    root_block_id: str,
+) -> Tuple[List[str], List[Dict[str, Any]], Dict[str, str], List[str]]:
+    raw_by_id = {
+        block.get('block_id'): block
+        for block in blocks
+        if isinstance(block, dict) and isinstance(block.get('block_id'), str)
+    }
+    if root_block_id not in raw_by_id:
+        raise ValueError(f'Feishu move source block {root_block_id!r} does not exist.')
+
+    children_by_parent: Dict[str, List[str]] = {}
+    for block_id, block in raw_by_id.items():
+        raw_children = block.get('children') or []
+        if not isinstance(raw_children, list):
+            raise TypeError(f'Feishu block {block_id!r}.children must be a list.')
+        missing_children = [
+            child_id for child_id in raw_children if child_id not in raw_by_id
+        ]
+        if missing_children:
+            raise ValueError(
+                f'Feishu move subtree is missing child blocks: {missing_children}.')
+        children = list(raw_children)
+        if children:
+            children_by_parent[block_id] = children
+    for block_id, block in raw_by_id.items():
+        parent_id = block.get('parent_id')
+        if parent_id in raw_by_id and block_id not in children_by_parent.get(parent_id, []):
+            children_by_parent.setdefault(parent_id, []).append(block_id)
+
+    ordered_ids: List[str] = []
+    visiting: Set[str] = set()
+    visited: Set[str] = set()
+
+    def visit(block_id: str) -> None:
+        if block_id in visiting:
+            raise ValueError(f'cycle detected in Feishu move subtree at {block_id!r}.')
+        if block_id in visited:
+            raise ValueError(
+                f'Feishu move subtree contains block {block_id!r} more than once.')
+        visiting.add(block_id)
+        ordered_ids.append(block_id)
+        for child_id in children_by_parent.get(block_id, []):
+            visit(child_id)
+        visiting.remove(block_id)
+        visited.add(block_id)
+
+    visit(root_block_id)
+    source_by_temporary_id = {
+        f'move-block-{index}': block_id
+        for index, block_id in enumerate(ordered_ids)
+    }
+    temporary_by_source_id = {
+        source_id: temporary_id
+        for temporary_id, source_id in source_by_temporary_id.items()
+    }
+
+    normalized_fields: Set[str] = set()
+    descendants: List[Dict[str, Any]] = []
+    for source_id in ordered_ids:
+        raw = raw_by_id[source_id]
+        block_type = raw.get('block_type')
+        content_key = DOCX_BLOCK_TYPE_FIELDS.get(block_type)
+        if content_key is None:
+            raise ValueError(
+                f'Feishu block type {block_type!r} cannot be cloned safely.')
+        content, fields = normalize_docx_clone_content(block_type, raw.get(content_key))
+        normalized_fields.update(f'{source_id}.{field}' for field in fields)
+        normalized_fields.update(
+            f'{source_id}.{field}'
+            for field in raw
+            if field not in {
+                'block_id', 'block_type', 'parent_id', 'children',
+                'plain_text', content_key,
+            }
+        )
+        descendant = {
+            'block_id': temporary_by_source_id[source_id],
+            'block_type': block_type,
+            content_key: content,
+        }
+        children = children_by_parent.get(source_id)
+        if children:
+            descendant['children'] = [
+                temporary_by_source_id[child_id] for child_id in children
+            ]
+        descendants.append(descendant)
+
+    return (
+        [temporary_by_source_id[root_block_id]],
+        descendants,
+        source_by_temporary_id,
+        sorted(normalized_fields),
+    )
+
+
+__all__ = [
+    'DOCX_BLOCK_TYPE_FIELDS',
+    'normalize_docx_clone_content',
+    'prepare_docx_clone_descendants',
+    'prepare_docx_descendants',
+]

--- a/lazyllm/tools/writer/utils/serialization.py
+++ b/lazyllm/tools/writer/utils/serialization.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import json
-from typing import Any
+from typing import Any, List
+
+from ..data_models.writer_ir import WriterBlock, WriterDocument
 
 
 def to_prompt_json(value: Any) -> str:
@@ -10,3 +12,27 @@ def to_prompt_json(value: Any) -> str:
         return str(obj)
 
     return json.dumps(value, ensure_ascii=False, indent=2, default=default)
+
+
+def render_document_markdown(document: WriterDocument) -> str:
+    parts: List[str] = []
+    if document.title:
+        parts.append(f'# {document.title.strip()}')
+    for block in document.blocks:
+        parts.extend(_render_block_markdown(block, level=2))
+    return '\n\n'.join(part for part in parts if part).strip() + '\n'
+
+
+def _render_block_markdown(block: WriterBlock, level: int) -> List[str]:
+    parts: List[str] = []
+    heading_level = min(max(level, 1), 6)
+    if block.type == 'heading':
+        if block.content.strip():
+            parts.append(f'{"#" * heading_level} {block.content.strip()}')
+    else:
+        content = block.content.strip()
+        if content:
+            parts.append(content)
+    for child in block.children:
+        parts.extend(_render_block_markdown(child, heading_level + 1))
+    return parts

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -86,6 +86,94 @@ class TestSpaceIdDynamic(unittest.TestCase):
             self.assertIs(type(instance), FeishuFS)
 
 
+class TestMoveBlock(unittest.TestCase):
+
+    @staticmethod
+    def _make_fs():
+        fs = object.__new__(FeishuFS)
+        fs._create_descendant_blocks = MagicMock(
+            return_value={'document_revision_id': 11})
+        fs._batch_delete_child_blocks = MagicMock(
+            return_value={'document_revision_id': 12})
+        return fs
+
+    @staticmethod
+    def _children(include_source=True):
+        children = []
+        if include_source:
+            children.append({
+                'block_id': 'source', 'block_type': 2,
+                'text': {'elements': [{'text_run': {'content': 'source'}}]},
+            })
+        children.append({
+            'block_id': 'anchor', 'block_type': 2,
+            'text': {'elements': [{'text_run': {'content': 'anchor'}}]},
+        })
+        children.append({
+            'block_id': 'created', 'block_type': 2,
+            'text': {'elements': [{'text_run': {'content': 'source'}}]},
+        })
+        return children
+
+    @staticmethod
+    def _move(fs):
+        return fs.move_block(
+            document_id='doc-1',
+            source_parent_block_id='doc-1',
+            source_block_id='source',
+            source_index=0,
+            target_parent_block_id='doc-1',
+            target_index=1,
+            children_id=['temporary-root'],
+            descendants=[{
+                'block_id': 'temporary-root', 'block_type': 2,
+                'text': {'elements': [{'text_run': {'content': 'source'}}]},
+            }],
+            document_revision_id=10,
+        )
+
+    def test_move_creates_verifies_and_deletes_with_revisions(self):
+        fs = self._make_fs()
+        fs._get_docx_children = MagicMock(return_value=self._children())
+
+        result = self._move(fs)
+
+        self.assertEqual(result['delete']['document_revision_id'], 12)
+        self.assertEqual(
+            fs._create_descendant_blocks.call_args.kwargs['document_revision_id'], 10)
+        delete_call = fs._batch_delete_child_blocks.call_args
+        self.assertEqual(delete_call.args[2:4], (0, 1))
+        self.assertEqual(delete_call.kwargs['document_revision_id'], 11)
+
+    def test_move_rolls_back_created_copy_when_source_delete_fails(self):
+        fs = self._make_fs()
+        fs._get_docx_children = MagicMock(side_effect=[
+            self._children(), self._children(),
+        ])
+        fs._batch_delete_child_blocks.side_effect = [
+            RuntimeError('source delete failed'), {'document_revision_id': 12},
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, 'target copy was rolled back'):
+            self._move(fs)
+
+        rollback_call = fs._batch_delete_child_blocks.call_args_list[1]
+        self.assertEqual(rollback_call.args[2:4], (2, 3))
+        self.assertEqual(rollback_call.kwargs['document_revision_id'], 11)
+
+    def test_move_accepts_delete_timeout_when_source_is_already_gone(self):
+        fs = self._make_fs()
+        fs._get_docx_children = MagicMock(side_effect=[
+            self._children(), self._children(include_source=False),
+        ])
+        fs._batch_delete_child_blocks.side_effect = RuntimeError('timeout')
+
+        result = self._move(fs)
+
+        self.assertEqual(result['delete']['status'], 'confirmed_after_error')
+        self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
+
+
 class TestEffectiveSpaceId(unittest.TestCase):
 
     def _make_wiki_fs(self, space_id: str = '') -> FeishuWikiFS:

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -88,23 +88,38 @@ class TestSpaceIdDynamic(unittest.TestCase):
 
 class TestMoveBlock(unittest.TestCase):
 
-    @staticmethod
-    def _make_fs():
+    @classmethod
+    def _make_fs(cls):
         fs = object.__new__(FeishuFS)
-        fs._create_descendant_blocks = MagicMock(return_value={'document_revision_id': 11})
+        fs._create_descendant_blocks = MagicMock(return_value={
+            'document_revision_id': 11,
+            'block_id_relations': [{
+                'temporary_block_id': 'move-block-0',
+                'block_id': 'created',
+            }],
+        })
         fs._batch_delete_child_blocks = MagicMock(return_value={'document_revision_id': 12})
+        fs._get_doc_blocks_raw = MagicMock(side_effect=[
+            [cls._block('source', 'source', parent_id='doc-1')],
+            [cls._block('created', 'source', parent_id='doc-1')],
+        ])
         return fs
 
     @staticmethod
-    def _block(block_id, content):
-        return {
+    def _block(block_id, content, **extra):
+        block = {
             'block_id': block_id, 'block_type': 2,
             'text': {'elements': [{'text_run': {'content': content}}]},
         }
+        block.update(extra)
+        return block
 
     @classmethod
     def _children(cls, include_source=True):
-        children = [cls._block('anchor', 'anchor'), cls._block('created', 'source')]
+        children = [
+            cls._block('anchor', 'anchor'),
+            cls._block('created', 'source'),
+        ]
         return [cls._block('source', 'source')] + children if include_source else children
 
     @staticmethod
@@ -116,20 +131,30 @@ class TestMoveBlock(unittest.TestCase):
             source_index=0,
             target_parent_block_id='doc-1',
             target_index=1,
-            children_id=['temporary-root'],
-            descendants=[TestMoveBlock._block('temporary-root', 'source')],
+            target_anchor_block_id='anchor',
+            position='after',
             document_revision_id=10,
         )
 
     def test_move_creates_verifies_and_deletes_with_revisions(self):
         fs = self._make_fs()
-        fs._get_docx_children = MagicMock(return_value=self._children())
+        fs._get_docx_children = MagicMock(side_effect=[
+            self._children(),
+            self._children(),
+        ])
 
         result = self._move(fs)
 
         self.assertEqual(result['delete']['document_revision_id'], 12)
+        self.assertEqual(result['block_id_relations'], {'source': 'created'})
         self.assertEqual(
             fs._create_descendant_blocks.call_args.kwargs['document_revision_id'], 10)
+        descendants = fs._create_descendant_blocks.call_args.args[4]
+        self.assertEqual(descendants[0]['block_type'], 2)
+        self.assertEqual(
+            descendants[0]['text']['elements'][0]['text_run']['content'],
+            'source',
+        )
         delete_call = fs._batch_delete_child_blocks.call_args
         self.assertEqual(
             (delete_call.args[2:4], delete_call.kwargs['document_revision_id']),
@@ -138,8 +163,19 @@ class TestMoveBlock(unittest.TestCase):
 
     def test_move_rolls_back_created_copy_when_source_delete_fails(self):
         fs = self._make_fs()
+        fs._get_doc_blocks_raw.side_effect = [
+            [self._block('source', 'source', parent_id='doc-1')],
+            [self._block('created', 'source', parent_id='doc-1')],
+            [
+                self._block('source', 'source', parent_id='doc-1'),
+                self._block('created', 'source', parent_id='doc-1'),
+            ],
+        ]
         fs._get_docx_children = MagicMock(side_effect=[
-            self._children(), self._children(),
+            self._children(),
+            self._children(),
+            self._children(),
+            self._children(),
         ])
         fs._batch_delete_child_blocks.side_effect = [
             RuntimeError('source delete failed'), {'document_revision_id': 12},
@@ -156,14 +192,90 @@ class TestMoveBlock(unittest.TestCase):
 
     def test_move_accepts_delete_timeout_when_source_is_already_gone(self):
         fs = self._make_fs()
+        fs._get_doc_blocks_raw.side_effect = [
+            [self._block('source', 'source', parent_id='doc-1')],
+            [self._block('created', 'source', parent_id='doc-1')],
+            [self._block('created', 'source', parent_id='doc-1')],
+        ]
         fs._get_docx_children = MagicMock(side_effect=[
-            self._children(), self._children(include_source=False),
+            self._children(),
+            self._children(),
+            self._children(include_source=False),
         ])
         fs._batch_delete_child_blocks.side_effect = RuntimeError('timeout')
 
         result = self._move(fs)
 
         self.assertEqual(result['delete']['status'], 'confirmed_after_error')
+        self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
+
+    def test_move_rolls_back_when_nested_format_verification_fails(self):
+        fs = self._make_fs()
+        source = self._block(
+            'source',
+            'source',
+            parent_id='doc-1',
+            text={
+                'style': {'align': 2},
+                'elements': [{
+                    'text_run': {
+                        'content': 'source',
+                        'text_element_style': {'bold': True},
+                    },
+                }],
+            },
+        )
+        created = self._block('created', 'source', parent_id='doc-1')
+        fs._get_doc_blocks_raw.side_effect = [[source], [created]]
+        fs._get_docx_children = MagicMock(side_effect=[
+            self._children(),
+            self._children(),
+        ])
+
+        with self.assertRaisesRegex(RuntimeError, 'verification failed'):
+            self._move(fs)
+
+        self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
+
+    def test_move_verifies_every_child_block_before_deleting_source(self):
+        fs = self._make_fs()
+        fs._create_descendant_blocks.return_value = {
+            'document_revision_id': 11,
+            'block_id_relations': [
+                {
+                    'temporary_block_id': 'move-block-0',
+                    'block_id': 'created',
+                },
+                {
+                    'temporary_block_id': 'move-block-1',
+                    'block_id': 'created-child',
+                },
+            ],
+        }
+        source = self._block(
+            'source', 'source', parent_id='doc-1', children=['source-child'])
+        source_child = self._block(
+            'source-child', 'child', parent_id='source')
+        created = self._block(
+            'created', 'source', parent_id='doc-1', children=['created-child'])
+        created_child = {
+            'block_id': 'created-child',
+            'block_type': 3,
+            'parent_id': 'created',
+            'heading1': {'elements': [{'text_run': {'content': 'child'}}]},
+        }
+        fs._get_doc_blocks_raw.side_effect = [
+            [source, source_child],
+            [created, created_child],
+        ]
+        fs._get_docx_children = MagicMock(side_effect=[
+            self._children(),
+            self._children(),
+        ])
+
+        with self.assertRaisesRegex(RuntimeError, 'verification failed'):
+            self._move(fs)
+
         self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
 
 

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -89,7 +89,12 @@ class TestSpaceIdDynamic(unittest.TestCase):
 class TestMoveBlock(unittest.TestCase):
 
     @classmethod
-    def _make_fs(cls):
+    def _make_fs(
+        cls,
+        *,
+        delete_error=False,
+        source_exists_after_error=True,
+    ):
         fs = object.__new__(FeishuFS)
         fs._create_descendant_blocks = MagicMock(return_value={
             'document_revision_id': 11,
@@ -99,10 +104,21 @@ class TestMoveBlock(unittest.TestCase):
             }],
         })
         fs._batch_delete_child_blocks = MagicMock(return_value={'document_revision_id': 12})
-        fs._get_doc_blocks_raw = MagicMock(side_effect=[
+        raw_reads = [
             [cls._block('source', 'source', parent_id='doc-1')],
             [cls._block('created', 'source', parent_id='doc-1')],
-        ])
+        ]
+        if delete_error:
+            raw_reads.append(
+                [cls._block('source', 'source'), cls._block('created', 'source')]
+                if source_exists_after_error else [cls._block('created', 'source')]
+            )
+            fs._batch_delete_child_blocks.side_effect = (
+                [RuntimeError('source delete failed'), {'document_revision_id': 12}]
+                if source_exists_after_error else RuntimeError('timeout')
+            )
+        fs._get_doc_blocks_raw = MagicMock(side_effect=raw_reads)
+        fs._get_docx_children = MagicMock(return_value=cls._children())
         return fs
 
     @staticmethod
@@ -123,12 +139,12 @@ class TestMoveBlock(unittest.TestCase):
         return [cls._block('source', 'source')] + children if include_source else children
 
     @staticmethod
-    def _move(fs):
+    def _move(fs, source_index=0):
         return fs.move_block(
             document_id='doc-1',
             source_parent_block_id='doc-1',
             source_block_id='source',
-            source_index=0,
+            source_index=source_index,
             target_parent_block_id='doc-1',
             target_index=1,
             document_revision_id=10,
@@ -136,14 +152,11 @@ class TestMoveBlock(unittest.TestCase):
 
     def test_move_creates_verifies_and_deletes_with_revisions(self):
         fs = self._make_fs()
-        fs._get_docx_children = MagicMock(side_effect=[
-            self._children(),
-            self._children(),
-        ])
 
         result = self._move(fs)
 
         self.assertEqual(result['delete']['document_revision_id'], 12)
+        self.assertEqual(result['document_revision_id'], 12)
         self.assertEqual(
             fs._create_descendant_blocks.call_args.kwargs['document_revision_id'], 10)
         delete_call = fs._batch_delete_child_blocks.call_args
@@ -151,26 +164,11 @@ class TestMoveBlock(unittest.TestCase):
             (delete_call.args[2:4], delete_call.kwargs['document_revision_id']),
             ((0, 1), 11),
         )
+        with self.assertRaisesRegex(ValueError, 'current provider layout'):
+            self._move(self._make_fs(), source_index=1)
 
     def test_move_rolls_back_created_copy_when_source_delete_fails(self):
-        fs = self._make_fs()
-        fs._get_doc_blocks_raw.side_effect = [
-            [self._block('source', 'source', parent_id='doc-1')],
-            [self._block('created', 'source', parent_id='doc-1')],
-            [
-                self._block('source', 'source', parent_id='doc-1'),
-                self._block('created', 'source', parent_id='doc-1'),
-            ],
-        ]
-        fs._get_docx_children = MagicMock(side_effect=[
-            self._children(),
-            self._children(),
-            self._children(),
-            self._children(),
-        ])
-        fs._batch_delete_child_blocks.side_effect = [
-            RuntimeError('source delete failed'), {'document_revision_id': 12},
-        ]
+        fs = self._make_fs(delete_error=True)
 
         with self.assertRaisesRegex(RuntimeError, 'target copy was rolled back'):
             self._move(fs)
@@ -182,22 +180,15 @@ class TestMoveBlock(unittest.TestCase):
         )
 
     def test_move_accepts_delete_timeout_when_source_is_already_gone(self):
-        fs = self._make_fs()
-        fs._get_doc_blocks_raw.side_effect = [
-            [self._block('source', 'source', parent_id='doc-1')],
-            [self._block('created', 'source', parent_id='doc-1')],
-            [self._block('created', 'source', parent_id='doc-1')],
-        ]
-        fs._get_docx_children = MagicMock(side_effect=[
-            self._children(),
-            self._children(),
-            self._children(include_source=False),
-        ])
-        fs._batch_delete_child_blocks.side_effect = RuntimeError('timeout')
+        fs = self._make_fs(
+            delete_error=True,
+            source_exists_after_error=False,
+        )
 
         result = self._move(fs)
 
         self.assertEqual(result['delete']['status'], 'confirmed_after_error')
+        self.assertEqual(result['document_revision_id'], -1)
         self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
 
 

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -521,15 +521,13 @@ class TestFeishuNeedsWiki(unittest.TestCase):
             self.assertTrue(_feishu_needs_wiki(None, f'/{prefix}token'))
 
     def test_plain_path_no_space_no_config(self):
-        mock_config = MagicMock()
-        mock_config.get = MagicMock(return_value=None)
         with patch('lazyllm.tools.fs.client.globals') as mock_globals:
-            mock_globals.config = mock_config
+            mock_globals.config = {'feishu_wiki_space_id': None}
             self.assertFalse(_feishu_needs_wiki(None, '/folder/file'))
 
     def test_plain_path_with_globals_config(self):
         with patch('lazyllm.tools.fs.client.globals') as mock_globals:
-            mock_globals.config.get = MagicMock(return_value='wikcnFromGlobals')
+            mock_globals.config = {'feishu_wiki_space_id': 'wikcnFromGlobals'}
             self.assertTrue(_feishu_needs_wiki(None, '/folder/file'))
 
 

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -146,15 +146,8 @@ class TestMoveBlock(unittest.TestCase):
         result = self._move(fs)
 
         self.assertEqual(result['delete']['document_revision_id'], 12)
-        self.assertEqual(result['block_id_relations'], {'source': 'created'})
         self.assertEqual(
             fs._create_descendant_blocks.call_args.kwargs['document_revision_id'], 10)
-        descendants = fs._create_descendant_blocks.call_args.args[4]
-        self.assertEqual(descendants[0]['block_type'], 2)
-        self.assertEqual(
-            descendants[0]['text']['elements'][0]['text_run']['content'],
-            'source',
-        )
         delete_call = fs._batch_delete_child_blocks.call_args
         self.assertEqual(
             (delete_call.args[2:4], delete_call.kwargs['document_revision_id']),
@@ -207,75 +200,6 @@ class TestMoveBlock(unittest.TestCase):
         result = self._move(fs)
 
         self.assertEqual(result['delete']['status'], 'confirmed_after_error')
-        self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
-
-    def test_move_rolls_back_when_nested_format_verification_fails(self):
-        fs = self._make_fs()
-        source = self._block(
-            'source',
-            'source',
-            parent_id='doc-1',
-            text={
-                'style': {'align': 2},
-                'elements': [{
-                    'text_run': {
-                        'content': 'source',
-                        'text_element_style': {'bold': True},
-                    },
-                }],
-            },
-        )
-        created = self._block('created', 'source', parent_id='doc-1')
-        fs._get_doc_blocks_raw.side_effect = [[source], [created]]
-        fs._get_docx_children = MagicMock(side_effect=[
-            self._children(),
-            self._children(),
-        ])
-
-        with self.assertRaisesRegex(RuntimeError, 'verification failed'):
-            self._move(fs)
-
-        self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
-
-    def test_move_verifies_every_child_block_before_deleting_source(self):
-        fs = self._make_fs()
-        fs._create_descendant_blocks.return_value = {
-            'document_revision_id': 11,
-            'block_id_relations': [
-                {
-                    'temporary_block_id': 'move-block-0',
-                    'block_id': 'created',
-                },
-                {
-                    'temporary_block_id': 'move-block-1',
-                    'block_id': 'created-child',
-                },
-            ],
-        }
-        source = self._block(
-            'source', 'source', parent_id='doc-1', children=['source-child'])
-        source_child = self._block(
-            'source-child', 'child', parent_id='source')
-        created = self._block(
-            'created', 'source', parent_id='doc-1', children=['created-child'])
-        created_child = {
-            'block_id': 'created-child',
-            'block_type': 3,
-            'parent_id': 'created',
-            'heading1': {'elements': [{'text_run': {'content': 'child'}}]},
-        }
-        fs._get_doc_blocks_raw.side_effect = [
-            [source, source_child],
-            [created, created_child],
-        ]
-        fs._get_docx_children = MagicMock(side_effect=[
-            self._children(),
-            self._children(),
-        ])
-
-        with self.assertRaisesRegex(RuntimeError, 'verification failed'):
-            self._move(fs)
-
         self.assertEqual(fs._batch_delete_child_blocks.call_count, 1)
 
 

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -131,8 +131,6 @@ class TestMoveBlock(unittest.TestCase):
             source_index=0,
             target_parent_block_id='doc-1',
             target_index=1,
-            target_anchor_block_id='anchor',
-            position='after',
             document_revision_id=10,
         )
 

--- a/tests/basic_tests/Tools/test_feishu_fs_url.py
+++ b/tests/basic_tests/Tools/test_feishu_fs_url.py
@@ -91,29 +91,21 @@ class TestMoveBlock(unittest.TestCase):
     @staticmethod
     def _make_fs():
         fs = object.__new__(FeishuFS)
-        fs._create_descendant_blocks = MagicMock(
-            return_value={'document_revision_id': 11})
-        fs._batch_delete_child_blocks = MagicMock(
-            return_value={'document_revision_id': 12})
+        fs._create_descendant_blocks = MagicMock(return_value={'document_revision_id': 11})
+        fs._batch_delete_child_blocks = MagicMock(return_value={'document_revision_id': 12})
         return fs
 
     @staticmethod
-    def _children(include_source=True):
-        children = []
-        if include_source:
-            children.append({
-                'block_id': 'source', 'block_type': 2,
-                'text': {'elements': [{'text_run': {'content': 'source'}}]},
-            })
-        children.append({
-            'block_id': 'anchor', 'block_type': 2,
-            'text': {'elements': [{'text_run': {'content': 'anchor'}}]},
-        })
-        children.append({
-            'block_id': 'created', 'block_type': 2,
-            'text': {'elements': [{'text_run': {'content': 'source'}}]},
-        })
-        return children
+    def _block(block_id, content):
+        return {
+            'block_id': block_id, 'block_type': 2,
+            'text': {'elements': [{'text_run': {'content': content}}]},
+        }
+
+    @classmethod
+    def _children(cls, include_source=True):
+        children = [cls._block('anchor', 'anchor'), cls._block('created', 'source')]
+        return [cls._block('source', 'source')] + children if include_source else children
 
     @staticmethod
     def _move(fs):
@@ -125,10 +117,7 @@ class TestMoveBlock(unittest.TestCase):
             target_parent_block_id='doc-1',
             target_index=1,
             children_id=['temporary-root'],
-            descendants=[{
-                'block_id': 'temporary-root', 'block_type': 2,
-                'text': {'elements': [{'text_run': {'content': 'source'}}]},
-            }],
+            descendants=[TestMoveBlock._block('temporary-root', 'source')],
             document_revision_id=10,
         )
 
@@ -142,8 +131,10 @@ class TestMoveBlock(unittest.TestCase):
         self.assertEqual(
             fs._create_descendant_blocks.call_args.kwargs['document_revision_id'], 10)
         delete_call = fs._batch_delete_child_blocks.call_args
-        self.assertEqual(delete_call.args[2:4], (0, 1))
-        self.assertEqual(delete_call.kwargs['document_revision_id'], 11)
+        self.assertEqual(
+            (delete_call.args[2:4], delete_call.kwargs['document_revision_id']),
+            ((0, 1), 11),
+        )
 
     def test_move_rolls_back_created_copy_when_source_delete_fails(self):
         fs = self._make_fs()
@@ -157,9 +148,11 @@ class TestMoveBlock(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, 'target copy was rolled back'):
             self._move(fs)
 
-        rollback_call = fs._batch_delete_child_blocks.call_args_list[1]
-        self.assertEqual(rollback_call.args[2:4], (2, 3))
-        self.assertEqual(rollback_call.kwargs['document_revision_id'], 11)
+        rollback = fs._batch_delete_child_blocks.call_args_list[1]
+        self.assertEqual(
+            (rollback.args[2:4], rollback.kwargs['document_revision_id']),
+            ((2, 3), 11),
+        )
 
     def test_move_accepts_delete_timeout_when_source_is_already_gone(self):
         fs = self._make_fs()

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -1,16 +1,15 @@
 from copy import deepcopy
 
-import pytest
-
 from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
-from lazyllm.tools.writer.data_models import PatchBlock, PatchHunk
+from lazyllm.tools.writer.data_models import PatchHunk, WriterBlock, WriterSpan
 from lazyllm.tools.writer.utils.feishu_docx import prepare_docx_clone_descendants
 
 
 def _block(block_id, content, *, parent='doc-1', children=None, heading=False):
     field = 'heading1' if heading else 'text'
     block = {
-        'block_id': block_id, 'block_type': 3 if heading else 2,
+        'block_id': block_id,
+        'block_type': 3 if heading else 2,
         'parent_id': parent,
         field: {'elements': [{'text_run': {'content': content}}]},
     }
@@ -28,71 +27,111 @@ def _move_blocks():
     ]
 
 
-def test_insert_and_delete_build_native_operations():
+def test_create_and_delete_build_native_operations():
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_move_blocks()[:2], external_document_id='doc-1')
-    heading, paragraph = document.blocks[0], document.blocks[0].children[0]
+    paragraph = document.blocks[0].children[0]
+    created = WriterBlock(
+        node_id='new-block',
+        type='paragraph',
+        content='新增段落',
+        spans=[WriterSpan(text='新增段落', style={'bold': True})],
+        stage='final',
+    )
 
     create = adapter.patch_to_operation(PatchHunk(
-        hunk_id='insert-1', target_node_id=heading.node_id,
-        modify_type='insert', position='after',
-        new_blocks=[PatchBlock(type='paragraph', content='新增段落')],
+        target_node_id=created.node_id,
+        modify_type='create',
+        block=created,
+        parent_node_id=None,
+        index=1,
     ), document)
     assert create.operation == 'create'
     assert (create.params['parent_block_id'], create.params['index']) == ('doc-1', 1)
-    assert create.params['descendants'][0]['block_type'] == 2
+    assert create.params['descendants'][0]['text']['elements'][0][
+        'text_run']['text_element_style'] == {'bold': True}
 
     delete = adapter.patch_to_operation(PatchHunk(
-        target_node_id=paragraph.node_id, modify_type='delete',
-        old_text=paragraph.content,
+        target_node_id=paragraph.node_id,
+        modify_type='delete',
     ), document)
     assert delete.operation == 'delete'
     assert delete.params == {
-        'parent_block_id': 'heading-1', 'start_index': 0, 'end_index': 1}
+        'parent_block_id': 'heading-1',
+        'start_index': 0,
+        'end_index': 1,
+    }
 
 
-@pytest.mark.parametrize(
-    ('source_path', 'anchor_path', 'position', 'expected'),
-    [
-        ((0,), (1,), 'after', ('doc-1', 0, 'doc-1', 1)),
-        ((0, 0), (1, 0), 'before', ('heading-1', 0, 'heading-2', 0)),
-    ],
-)
-def test_move_builds_same_and_cross_parent_operations(
-    source_path, anchor_path, position, expected,
-):
+def test_update_maps_styles_and_block_type_changes():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(
+        [_block('paragraph-1', '段落一')],
+        external_document_id='doc-1',
+    )
+    source = document.blocks[0]
+
+    styled = source.model_copy(deep=True)
+    styled.spans[0].style = {
+        'bold': True,
+        'text_color': 5,
+        'background_color': 2,
+        'font_size': 16,
+    }
+    update = adapter.patch_to_operation(PatchHunk(
+        target_node_id=source.node_id,
+        modify_type='update',
+        block=styled,
+    ), document)
+    assert update.operation == 'update'
+    assert update.params['requests'][0]['update_text_elements']['elements'][0][
+        'text_run']['text_element_style'] == styled.spans[0].style
+
+    heading = styled.model_copy(deep=True)
+    heading.type = 'heading'
+    heading.numbering = {'level': 4}
+    replace = adapter.patch_to_operation(PatchHunk(
+        target_node_id=source.node_id,
+        modify_type='update',
+        block=heading,
+    ), document)
+    assert replace.operation == 'replace'
+    assert replace.params['replacement_block']['block_type'] == 6
+    assert 'heading4' in replace.params['replacement_block']
+
+
+def test_move_uses_parent_and_final_index():
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_move_blocks(), external_document_id='doc-1')
+    source = document.blocks[0].children[0]
+    target_parent = document.blocks[1]
 
-    def locate(path):
-        root = document.blocks[path[0]]
-        return root if len(path) == 1 else root.children[path[1]]
-
-    source, anchor = locate(source_path), locate(anchor_path)
     operation = adapter.patch_to_operation(PatchHunk(
-        hunk_id='move-1', target_node_id=source.node_id, modify_type='move',
-        anchor_node_id=anchor.node_id, position=position,
+        target_node_id=source.node_id,
+        modify_type='move',
+        parent_node_id=target_parent.node_id,
+        index=1,
     ), document)
 
     assert operation.operation == 'move'
-    assert operation.params['source_block_id'] == source.provider_binding['block_id']
-    assert tuple(operation.params[key] for key in (
-        'source_parent_block_id', 'source_index',
-        'target_parent_block_id', 'target_index',
-    )) == expected
-    assert operation.params['target_anchor_block_id'] == \
-        anchor.provider_binding['block_id']
-    assert operation.params['position'] == position
-    assert 'descendants' not in operation.params
+    assert operation.params == {
+        'source_parent_block_id': 'heading-1',
+        'source_block_id': 'paragraph-1',
+        'source_index': 0,
+        'target_parent_block_id': 'heading-2',
+        'target_index': 1,
+    }
 
 
 def test_merge_refreshed_move_restores_writer_identity():
     adapter = FeishuWriterAdapter()
     previous = adapter.blocks_to_ir(_move_blocks(), external_document_id='doc-1')
-    source, anchor = previous.blocks
+    source = previous.blocks[0]
     patch = PatchHunk(
-        hunk_id='move-1', target_node_id=source.node_id, modify_type='move',
-        anchor_node_id=anchor.node_id, position='after',
+        target_node_id=source.node_id,
+        modify_type='move',
+        parent_node_id=None,
+        index=1,
     )
     operation = adapter.patch_to_operation(patch, previous)
 
@@ -136,6 +175,5 @@ def test_move_clone_descendants_preserve_raw_format_and_children():
         'move-block-0': 'heading-1',
         'move-block-1': 'paragraph-1',
     }
-    assert [block['block_type'] for block in descendants] == [3, 2]
     assert descendants[0]['heading1'] == blocks[0]['heading1']
     assert descendants[0]['children'] == ['move-block-1']

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -120,84 +120,22 @@ def test_merge_refreshed_move_restores_writer_identity():
     assert moved.provider_binding['block_id'] == 'moved-heading'
 
 
-def test_move_clone_descendants_preserve_raw_format_and_normalize_known_fields():
-    blocks = [
-        {
-            'block_id': 'heading',
-            'block_type': 3,
-            'parent_id': 'doc-1',
-            'children': ['paragraph'],
-            'heading1': {
-                'style': {'align': 2, 'folded': True},
-                'elements': [{
-                    'text_run': {
-                        'content': '标题',
-                        'text_element_style': {
-                            'bold': True,
-                            'text_color': 5,
-                            'comment_ids': ['comment-1'],
-                        },
-                    },
-                }],
-            },
-        },
-        {
-            'block_id': 'paragraph',
-            'block_type': 2,
-            'parent_id': 'heading',
-            'text': {
-                'elements': [
-                    {
-                        'mention_doc': {
-                            'token': 'doc-token',
-                            'obj_type': 22,
-                            'title': '只读标题',
-                        },
-                    },
-                    {
-                        'file': {
-                            'file_token': 'file-token',
-                            'source_block_id': 'paragraph',
-                        },
-                    },
-                ],
-            },
-        },
-    ]
+def test_move_clone_descendants_preserve_raw_format_and_children():
+    blocks = _move_blocks()[:2]
+    blocks[0]['heading1']['style'] = {'align': 2}
+    blocks[0]['heading1']['elements'][0]['text_run']['text_element_style'] = {
+        'bold': True,
+        'text_color': 5,
+    }
 
-    children_id, descendants, source_by_temporary_id, normalized_fields = \
-        prepare_docx_clone_descendants(blocks, 'heading')
+    children_id, descendants, id_map, _ = \
+        prepare_docx_clone_descendants(blocks, 'heading-1')
 
     assert children_id == ['move-block-0']
-    assert source_by_temporary_id == {
-        'move-block-0': 'heading',
-        'move-block-1': 'paragraph',
+    assert id_map == {
+        'move-block-0': 'heading-1',
+        'move-block-1': 'paragraph-1',
     }
-    assert descendants[0]['block_type'] == 3
-    assert descendants[0]['heading1']['style'] == {'align': 2, 'folded': True}
-    assert descendants[0]['heading1']['elements'][0]['text_run'] == {
-        'content': '标题',
-        'text_element_style': {'bold': True, 'text_color': 5},
-    }
+    assert [block['block_type'] for block in descendants] == [3, 2]
+    assert descendants[0]['heading1'] == blocks[0]['heading1']
     assert descendants[0]['children'] == ['move-block-1']
-    assert descendants[1]['text']['elements'][0]['mention_doc'] == {
-        'token': 'doc-token',
-        'obj_type': 22,
-    }
-    assert 'heading.elements.text_run.text_element_style.comment_ids' \
-        in normalized_fields
-    assert 'paragraph.elements.mention_doc.title' in normalized_fields
-    assert 'paragraph.elements.file' in normalized_fields
-
-
-def test_move_clone_descendants_reject_incomplete_source_subtree():
-    with pytest.raises(ValueError, match='missing child blocks'):
-        prepare_docx_clone_descendants(
-            [{
-                'block_id': 'heading',
-                'block_type': 3,
-                'children': ['missing-child'],
-                'heading1': {'elements': []},
-            }],
-            'heading',
-        )

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -4,6 +4,7 @@ import pytest
 
 from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
 from lazyllm.tools.writer.data_models import PatchBlock, PatchHunk
+from lazyllm.tools.writer.utils.feishu_docx import prepare_docx_clone_descendants
 
 
 def _block(block_id, content, *, parent='doc-1', children=None, heading=False):
@@ -79,7 +80,10 @@ def test_move_builds_same_and_cross_parent_operations(
         'source_parent_block_id', 'source_index',
         'target_parent_block_id', 'target_index',
     )) == expected
-    assert len(operation.params['children_id']) == 1
+    assert operation.params['target_anchor_block_id'] == \
+        anchor.provider_binding['block_id']
+    assert operation.params['position'] == position
+    assert 'descendants' not in operation.params
 
 
 def test_merge_refreshed_move_restores_writer_identity():
@@ -100,7 +104,100 @@ def test_merge_refreshed_move_restores_writer_identity():
     refreshed = adapter.blocks_to_ir(refreshed_raw, external_document_id='doc-1')
 
     moved = adapter.merge_refreshed_document(
-        previous, refreshed, patch=patch, operation=operation).blocks[1]
+        previous,
+        refreshed,
+        patch=patch,
+        operation=operation,
+        operation_result={
+            'block_id_relations': {
+                'heading-1': 'moved-heading',
+                'paragraph-1': 'moved-paragraph',
+            },
+        },
+    ).blocks[1]
     assert moved.node_id == source.node_id
     assert moved.children[0].node_id == source.children[0].node_id
     assert moved.provider_binding['block_id'] == 'moved-heading'
+
+
+def test_move_clone_descendants_preserve_raw_format_and_normalize_known_fields():
+    blocks = [
+        {
+            'block_id': 'heading',
+            'block_type': 3,
+            'parent_id': 'doc-1',
+            'children': ['paragraph'],
+            'heading1': {
+                'style': {'align': 2, 'folded': True},
+                'elements': [{
+                    'text_run': {
+                        'content': '标题',
+                        'text_element_style': {
+                            'bold': True,
+                            'text_color': 5,
+                            'comment_ids': ['comment-1'],
+                        },
+                    },
+                }],
+            },
+        },
+        {
+            'block_id': 'paragraph',
+            'block_type': 2,
+            'parent_id': 'heading',
+            'text': {
+                'elements': [
+                    {
+                        'mention_doc': {
+                            'token': 'doc-token',
+                            'obj_type': 22,
+                            'title': '只读标题',
+                        },
+                    },
+                    {
+                        'file': {
+                            'file_token': 'file-token',
+                            'source_block_id': 'paragraph',
+                        },
+                    },
+                ],
+            },
+        },
+    ]
+
+    children_id, descendants, source_by_temporary_id, normalized_fields = \
+        prepare_docx_clone_descendants(blocks, 'heading')
+
+    assert children_id == ['move-block-0']
+    assert source_by_temporary_id == {
+        'move-block-0': 'heading',
+        'move-block-1': 'paragraph',
+    }
+    assert descendants[0]['block_type'] == 3
+    assert descendants[0]['heading1']['style'] == {'align': 2, 'folded': True}
+    assert descendants[0]['heading1']['elements'][0]['text_run'] == {
+        'content': '标题',
+        'text_element_style': {'bold': True, 'text_color': 5},
+    }
+    assert descendants[0]['children'] == ['move-block-1']
+    assert descendants[1]['text']['elements'][0]['mention_doc'] == {
+        'token': 'doc-token',
+        'obj_type': 22,
+    }
+    assert 'heading.elements.text_run.text_element_style.comment_ids' \
+        in normalized_fields
+    assert 'paragraph.elements.mention_doc.title' in normalized_fields
+    assert 'paragraph.elements.file' in normalized_fields
+
+
+def test_move_clone_descendants_reject_incomplete_source_subtree():
+    with pytest.raises(ValueError, match='missing child blocks'):
+        prepare_docx_clone_descendants(
+            [{
+                'block_id': 'heading',
+                'block_type': 3,
+                'children': ['missing-child'],
+                'heading1': {'elements': []},
+            }],
+            'heading',
+        )

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -2,61 +2,9 @@ from copy import deepcopy
 
 import pytest
 
-from lazyllm.tools.writer.adapter.base import NativePatchOperation, WriterAdapterBase
 from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
-from lazyllm.tools.writer.data_models import (
-    PatchBlock,
-    PatchHunk,
-    WriterBlock,
-    WriterDocument,
-    WriterSpan,
-)
-
-
-class _DummyAdapter(WriterAdapterBase):
-    provider = 'dummy'
-
-    def blocks_to_ir(self, blocks, **kwargs):
-        raise NotImplementedError
-
-    def ir_to_blocks(self, document):
-        raise NotImplementedError
-
-    def patch_to_operation(self, patch, document):
-        raise NotImplementedError
-
-def test_writer_adapter_ids_are_stable_and_provider_scoped():
-    document_id = _DummyAdapter.make_document_id('external-document')
-    node_id = _DummyAdapter.make_node_id('external-document', 'external-block')
-
-    assert document_id == _DummyAdapter.make_document_id('external-document')
-    assert node_id == _DummyAdapter.make_node_id('external-document', 'external-block')
-    assert document_id.startswith('writer-doc-')
-    assert node_id.startswith('writer-node-')
-    assert node_id != _DummyAdapter.make_node_id('another-document', 'external-block')
-    assert node_id != _DummyAdapter.make_node_id('external-document', 'another-block')
-
-
-@pytest.mark.parametrize('value', ['', '   ', None])
-def test_writer_adapter_rejects_empty_external_ids(value):
-    with pytest.raises(ValueError, match='external_document_id must be a non-empty string'):
-        _DummyAdapter.make_document_id(value)
-
-    with pytest.raises(ValueError, match='external_block_id must be a non-empty string'):
-        _DummyAdapter.make_node_id('external-document', value)
-
-
-def test_writer_adapter_requires_provider_name():
-    class MissingProviderAdapter(_DummyAdapter):
-        provider = ''
-
-    with pytest.raises(ValueError, match='provider must be a non-empty string'):
-        MissingProviderAdapter.make_document_id('external-document')
-
-
-def test_writer_adapter_base_is_abstract():
-    with pytest.raises(TypeError):
-        WriterAdapterBase()
+from lazyllm.tools.writer.data_models import PatchBlock, PatchHunk, WriterSpan
+from lazyllm.tools.writer.utils.feishu_docx import prepare_docx_descendants
 
 
 def _raw_blocks():
@@ -129,201 +77,51 @@ def _move_raw_blocks():
     ]
 
 
-def test_blocks_to_ir_preserves_hierarchy_bindings_and_payload():
+def test_feishu_round_trip_preserves_hierarchy_styles_and_unknown_payload():
     raw_blocks = _raw_blocks()
-    document = FeishuWriterAdapter().blocks_to_ir(
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(
         raw_blocks,
         external_document_id='doc-1',
-        title='测试文档',
         uri='feishu:/test',
         revision='12',
     )
 
-    assert document.document_id == FeishuWriterAdapter.make_document_id('doc-1')
-    assert document.provider_binding == {
-        'provider': 'feishu',
-        'document_id': 'doc-1',
-        'uri': 'feishu:/test',
-        'revision': '12',
-    }
-    assert [block.type for block in document.blocks] == ['heading', 'feishu_unknown']
-
-    heading = document.blocks[0]
+    heading, unknown = document.blocks
     paragraph = heading.children[0]
-    assert heading.node_id == FeishuWriterAdapter.make_node_id('doc-1', 'heading-1')
-    assert heading.numbering == {'level': 1}
+    assert [heading.type, paragraph.type, unknown.type] == [
+        'heading', 'paragraph', 'feishu_unknown']
     assert heading.spans == [WriterSpan(text='标题', style=['strong'])]
     assert paragraph.content == '查看 设计文档'
     assert paragraph.spans[-1].style == ['feishu:mention_doc']
-    assert paragraph.provider_binding['block_id'] == 'paragraph-1'
-    assert document.blocks[1].editable is False
+    assert unknown.editable is False
 
     raw_blocks[0]['future_field']['kept'] = False
-    assert heading.provider_payload['raw_block']['future_field']['kept'] is True
-
-
-def test_blocks_to_ir_rejects_duplicate_ids_and_cycles():
-    adapter = FeishuWriterAdapter()
-    duplicate = [_raw_blocks()[0], deepcopy(_raw_blocks()[0])]
-    with pytest.raises(ValueError, match='duplicate Feishu block_id'):
-        adapter.blocks_to_ir(duplicate, external_document_id='doc-1')
-
-    cycle = [
-        {'block_id': 'a', 'block_type': 2, 'children': ['b'], 'text': {'elements': []}},
-        {'block_id': 'b', 'block_type': 2, 'children': ['a'], 'text': {'elements': []}},
-    ]
-    with pytest.raises(ValueError, match='cycle detected'):
-        adapter.blocks_to_ir(cycle, external_document_id='doc-1')
-
-
-def test_ir_to_blocks_preserves_raw_fields_and_hierarchy():
-    adapter = FeishuWriterAdapter()
-    raw_blocks = _raw_blocks()
-    document = adapter.blocks_to_ir(raw_blocks, external_document_id='doc-1')
-
     converted = adapter.ir_to_blocks(document)
-
-    assert converted[0]['block_id'] == 'heading-1'
-    assert 'children' not in converted[0]
     assert converted[0]['future_field'] == {'kept': True}
-    assert converted[0]['heading1'] == raw_blocks[0]['heading1']
     assert converted[1]['parent_id'] == 'heading-1'
-    assert converted[1]['text'] == raw_blocks[1]['text']
     assert converted[2]['future_block'] == {'opaque': True}
 
 
-def test_ir_to_blocks_converts_new_blocks_and_styles():
-    document = WriterDocument(
-        document_id='internal-doc',
-        stage='final',
-        blocks=[
-            WriterBlock(
-                node_id='heading-node',
-                type='heading',
-                content='标题',
-                spans=[WriterSpan(text='标题', style=['strong'])],
-                stage='final',
-                numbering={'level': 2},
-                children=[
-                    WriterBlock(
-                        node_id='list-node',
-                        type='list_item',
-                        content='条目',
-                        stage='final',
-                        numbering={'ordered': True},
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    converted = FeishuWriterAdapter().ir_to_blocks(document)
-
-    assert converted == [
-        {
-            'block_type': 4,
-            'heading2': {
-                'elements': [{
-                    'text_run': {
-                        'content': '标题',
-                        'text_element_style': {'bold': True},
-                    },
-                }],
-            },
-            'plain_text': '标题',
-            'block_id': 'heading-node',
-        },
-        {
-            'block_type': 13,
-            'ordered': {'elements': [{'text_run': {'content': '条目'}}]},
-            'plain_text': '条目',
-            'block_id': 'list-node',
-            'parent_id': 'heading-node',
-        },
-    ]
+@pytest.mark.parametrize(
+    'blocks, message',
+    [
+        (lambda: [_raw_blocks()[0], deepcopy(_raw_blocks()[0])], 'duplicate Feishu block_id'),
+        (
+            lambda: [
+                {'block_id': 'a', 'block_type': 2, 'children': ['b'], 'text': {}},
+                {'block_id': 'b', 'block_type': 2, 'children': ['a'], 'text': {}},
+            ],
+            'cycle detected',
+        ),
+    ],
+)
+def test_blocks_to_ir_rejects_invalid_relations(blocks, message):
+    with pytest.raises(ValueError, match=message):
+        FeishuWriterAdapter().blocks_to_ir(blocks(), external_document_id='doc-1')
 
 
-def test_fs_prepare_descendants_is_the_only_writer_of_children():
-    pytest.importorskip('fsspec')
-    from lazyllm.tools.fs.supplier.feishu import FeishuFSBase
-
-    document = WriterDocument(
-        document_id='internal-doc',
-        stage='final',
-        blocks=[
-            WriterBlock(
-                node_id='parent',
-                type='paragraph',
-                content='父块',
-                stage='final',
-                children=[
-                    WriterBlock(
-                        node_id='child',
-                        type='paragraph',
-                        content='子块',
-                        stage='final',
-                    ),
-                ],
-            ),
-        ],
-    )
-
-    blocks = FeishuWriterAdapter().ir_to_blocks(document)
-    assert 'children' not in blocks[0]
-    assert blocks[1]['parent_id'] == 'parent'
-
-    roots, descendants = FeishuFSBase._prepare_docx_descendants(blocks)
-    assert roots == ['parent']
-    assert descendants[0]['children'] == ['child']
-
-
-def test_ir_to_blocks_rebuilds_modified_text_and_rejects_modified_unknown_block():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    document.blocks[0].content = '新标题'
-    document.blocks[0].spans = []
-
-    converted = adapter.ir_to_blocks(document)
-    assert converted[0]['heading1']['elements'] == [
-        {'text_run': {'content': '新标题'}},
-    ]
-    assert converted[0]['heading1']['style'] == {'align': 1}
-
-    document.blocks[1].content = '修改未来块'
-    with pytest.raises(ValueError, match='non-editable Feishu block'):
-        adapter.ir_to_blocks(document)
-
-
-def test_replace_patch_resolves_internal_node_to_feishu_block():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    target = document.blocks[0]
-    patch = PatchHunk(
-        target_node_id=target.node_id,
-        modify_type='replace',
-        old_text='标题',
-        new_text='新标题',
-    )
-
-    expected_requests = [{
-        'block_id': 'heading-1',
-        'update_text_elements': {
-            'elements': [{
-                'text_run': {
-                    'content': '新标题',
-                    'text_element_style': {'bold': True},
-                },
-            }],
-        },
-    }]
-
-    assert adapter.patch_to_operation(patch, document) == NativePatchOperation(
-        operation='update',
-        params={'requests': expected_requests},
-    )
-
-
-def test_insert_patch_builds_create_operation_after_target():
+def test_insert_builds_descendant_payload_for_position_and_content():
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
     patch = PatchHunk(
@@ -338,51 +136,31 @@ def test_insert_patch_builds_create_operation_after_target():
     )
 
     operation = adapter.patch_to_operation(patch, document)
-
     assert operation.operation == 'create'
     assert operation.params['parent_block_id'] == 'doc-1'
     assert operation.params['index'] == 1
     assert operation.params['children_id'] == ['insert-1::0', 'insert-1::1']
-    assert operation.params['descendants'] == [
-        {
-            'block_type': 2,
-            'text': {'elements': [{'text_run': {'content': '新增段落'}}]},
-            'block_id': 'insert-1::0',
-        },
-        {
-            'block_type': 4,
-            'heading2': {'elements': [{'text_run': {'content': '新增标题'}}]},
-            'block_id': 'insert-1::1',
-        },
-    ]
+    assert [item['block_type'] for item in operation.params['descendants']] == [2, 4]
 
 
-def test_insert_patch_supports_anchor_position_and_new_text_fallback():
+def test_insert_new_text_uses_nested_anchor():
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
     paragraph = document.blocks[0].children[0]
-    patch = PatchHunk(
+    operation = adapter.patch_to_operation(PatchHunk(
         target_node_id=document.blocks[0].node_id,
         anchor_node_id=paragraph.node_id,
         modify_type='insert',
         position='before',
         new_text='兼容新增段落',
-    )
+    ), document)
 
-    operation = adapter.patch_to_operation(patch, document)
-
-    assert operation.operation == 'create'
-    assert operation.params['parent_block_id'] == 'heading-1'
-    assert operation.params['index'] == 0
-    assert operation.params['children_id'] == [operation.params['descendants'][0]['block_id']]
-    assert operation.params['descendants'][0]['block_type'] == 2
-    assert (
-        operation.params['descendants'][0]['text']['elements'][0]['text_run']['content']
-        == '兼容新增段落'
-    )
+    assert (operation.params['parent_block_id'], operation.params['index']) == ('heading-1', 0)
+    assert operation.params['descendants'][0]['text']['elements'][0]['text_run'][
+        'content'] == '兼容新增段落'
 
 
-def test_delete_patch_builds_delete_operation_and_validates_old_text():
+def test_delete_builds_range_and_rejects_stale_text():
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
     paragraph = document.blocks[0].children[0]
@@ -392,134 +170,112 @@ def test_delete_patch_builds_delete_operation_and_validates_old_text():
         old_text=paragraph.content,
     )
 
-    assert adapter.patch_to_operation(patch, document) == NativePatchOperation(
-        operation='delete',
-        params={
-            'parent_block_id': 'heading-1',
-            'start_index': 0,
-            'end_index': 1,
-        },
-    )
-
-    stale = patch.model_copy(update={'old_text': '过期内容'})
+    operation = adapter.patch_to_operation(patch, document)
+    assert operation.operation == 'delete'
+    assert operation.params == {
+        'parent_block_id': 'heading-1', 'start_index': 0, 'end_index': 1}
     with pytest.raises(ValueError, match='old_text does not match'):
-        adapter.patch_to_operation(stale, document)
+        adapter.patch_to_operation(
+            patch.model_copy(update={'old_text': '过期内容'}), document)
 
 
-def test_move_patch_builds_same_parent_operation_with_remapped_subtree_ids():
+@pytest.mark.parametrize(
+    ('source_path', 'anchor_path', 'position', 'expected'),
+    [
+        ((0,), (1,), 'after', ('doc-1', 0, 'doc-1', 1)),
+        ((0, 0), (1, 0), 'before', ('heading-1', 0, 'heading-2', 0)),
+    ],
+)
+def test_move_builds_same_and_cross_parent_plans(
+    source_path, anchor_path, position, expected,
+):
     adapter = FeishuWriterAdapter()
     document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
-    source, anchor = document.blocks
-    patch = PatchHunk(
+
+    def locate(path):
+        block = document.blocks[path[0]]
+        return block if len(path) == 1 else block.children[path[1]]
+
+    source, anchor = locate(source_path), locate(anchor_path)
+    operation = adapter.patch_to_operation(PatchHunk(
+        hunk_id='move-1',
+        target_node_id=source.node_id,
+        modify_type='move',
+        anchor_node_id=anchor.node_id,
+        position=position,
+    ), document)
+
+    params = operation.params
+    assert operation.operation == 'move'
+    assert params['source_block_id'] == source.provider_binding['block_id']
+    assert (
+        params['source_parent_block_id'], params['source_index'],
+        params['target_parent_block_id'], params['target_index'],
+    ) == expected
+    assert len(params['children_id']) == 1
+    assert params['descendants'][0]['block_type'] == source.provider_payload[
+        'raw_block']['block_type']
+
+
+def test_move_rejects_anchor_in_source_subtree():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    source = document.blocks[0]
+    with pytest.raises(ValueError, match='anchor cannot be the source node or its descendant'):
+        adapter.patch_to_operation(PatchHunk(
+            target_node_id=source.node_id,
+            modify_type='move',
+            anchor_node_id=source.children[0].node_id,
+            position='after',
+        ), document)
+
+
+def test_merge_refreshed_move_restores_writer_identity_with_new_feishu_ids():
+    adapter = FeishuWriterAdapter()
+    previous = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    source, anchor = previous.blocks
+    operation = adapter.patch_to_operation(PatchHunk(
         hunk_id='move-1',
         target_node_id=source.node_id,
         modify_type='move',
         anchor_node_id=anchor.node_id,
         position='after',
-        old_text=source.content,
+    ), previous)
+    refreshed_raw = deepcopy(_move_raw_blocks()[2:])
+    moved_raw = deepcopy(_move_raw_blocks()[:2])
+    moved_raw[0]['block_id'] = 'moved-heading'
+    moved_raw[0]['children'] = ['moved-paragraph']
+    moved_raw[1]['block_id'] = 'moved-paragraph'
+    moved_raw[1]['parent_id'] = 'moved-heading'
+    refreshed = adapter.blocks_to_ir(
+        refreshed_raw + moved_raw, external_document_id='doc-1')
+
+    merged = adapter.merge_refreshed_document(
+        previous,
+        refreshed,
+        patch=PatchHunk(
+            target_node_id=source.node_id,
+            modify_type='move',
+            anchor_node_id=anchor.node_id,
+            position='after',
+        ),
+        operation=operation,
     )
+    moved = merged.blocks[1]
+    assert moved.node_id == source.node_id
+    assert moved.children[0].node_id == source.children[0].node_id
+    assert moved.provider_binding['block_id'] == 'moved-heading'
 
-    operation = adapter.patch_to_operation(patch, document)
 
-    assert operation.operation == 'move'
-    assert operation.params['source_parent_block_id'] == 'doc-1'
-    assert operation.params['source_index'] == 0
-    assert operation.params['target_parent_block_id'] == 'doc-1'
-    assert operation.params['target_index'] == 1
-    assert operation.params['children_id'] == ['move-1::0']
-    assert operation.params['descendants'] == [
+def test_public_codec_builds_hierarchy_without_fs_dependency():
+    roots, descendants = prepare_docx_descendants([
+        {'block_id': 'parent', 'block_type': 2, 'text': {'elements': []}},
         {
-            'block_id': 'move-1::0',
-            'block_type': 3,
-            'heading1': {'elements': [{'text_run': {'content': '章节一'}}]},
-            'children': ['move-1::1'],
-        },
-        {
-            'block_id': 'move-1::1',
+            'block_id': 'child',
+            'parent_id': 'parent',
             'block_type': 2,
-            'text': {'elements': [{'text_run': {'content': '段落一'}}]},
+            'text': {'elements': []},
         },
-    ]
-
-
-def test_move_patch_builds_cross_parent_operation():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
-    source = document.blocks[0].children[0]
-    anchor = document.blocks[1].children[0]
-    patch = PatchHunk(
-        target_node_id=source.node_id,
-        modify_type='move',
-        anchor_node_id=anchor.node_id,
-        position='before',
-    )
-
-    operation = adapter.patch_to_operation(patch, document)
-
-    assert operation.operation == 'move'
-    assert operation.params['source_parent_block_id'] == 'heading-1'
-    assert operation.params['source_index'] == 0
-    assert operation.params['target_parent_block_id'] == 'heading-2'
-    assert operation.params['target_index'] == 0
-    assert len(operation.params['children_id']) == 1
-    assert operation.params['descendants'][0]['text']['elements'][0]['text_run']['content'] == '段落一'
-
-
-def test_move_patch_rejects_anchor_in_source_subtree_and_stale_text():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
-    source = document.blocks[0]
-    descendant = source.children[0]
-
-    into_self = PatchHunk(
-        target_node_id=source.node_id,
-        modify_type='move',
-        anchor_node_id=descendant.node_id,
-        position='after',
-    )
-    with pytest.raises(ValueError, match='anchor cannot be the source node or its descendant'):
-        adapter.patch_to_operation(into_self, document)
-
-    stale = PatchHunk(
-        target_node_id=source.node_id,
-        modify_type='move',
-        anchor_node_id=document.blocks[1].node_id,
-        position='before',
-        old_text='过期内容',
-    )
-    with pytest.raises(ValueError, match='old_text does not match'):
-        adapter.patch_to_operation(stale, document)
-
-
-def test_replace_patch_supports_text_range_and_rejects_stale_patch():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    target = document.blocks[0].children[0]
-
-    ranged = PatchHunk(
-        target_node_id=target.node_id,
-        modify_type='replace',
-        text_range=(0, 2),
-        old_text='查看',
-        new_text='阅读',
-    )
-    operation = adapter.patch_to_operation(ranged, document)
-    elements = operation.params['requests'][0]['update_text_elements']['elements']
-    assert elements == [
-        {
-            'text_run': {
-                'content': '阅读 ',
-                'text_element_style': {'italic': True},
-            },
-        },
-        {'mention_doc': {'token': 'doc-ref', 'title': '设计文档'}},
-    ]
-
-    stale = PatchHunk(
-        target_node_id=target.node_id,
-        modify_type='replace',
-        old_text='过期内容',
-        new_text='新内容',
-    )
-    with pytest.raises(ValueError, match='old_text does not match'):
-        adapter.patch_to_operation(stale, document)
+    ])
+    assert roots == ['parent']
+    assert descendants[0]['children'] == ['child']

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -3,180 +3,51 @@ from copy import deepcopy
 import pytest
 
 from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
-from lazyllm.tools.writer.data_models import PatchBlock, PatchHunk, WriterSpan
-from lazyllm.tools.writer.utils.feishu_docx import prepare_docx_descendants
+from lazyllm.tools.writer.data_models import PatchBlock, PatchHunk
 
 
-def _raw_blocks():
+def _block(block_id, content, *, parent='doc-1', children=None, heading=False):
+    field = 'heading1' if heading else 'text'
+    block = {
+        'block_id': block_id, 'block_type': 3 if heading else 2,
+        'parent_id': parent,
+        field: {'elements': [{'text_run': {'content': content}}]},
+    }
+    if children:
+        block['children'] = children
+    return block
+
+
+def _move_blocks():
     return [
-        {
-            'block_id': 'heading-1',
-            'block_type': 3,
-            'parent_id': 'doc-1',
-            'children': ['paragraph-1'],
-            'heading1': {
-                'elements': [{
-                    'text_run': {
-                        'content': '标题',
-                        'text_element_style': {'bold': True},
-                    },
-                }],
-                'style': {'align': 1},
-            },
-            'future_field': {'kept': True},
-        },
-        {
-            'block_id': 'paragraph-1',
-            'block_type': 2,
-            'parent_id': 'heading-1',
-            'text': {
-                'elements': [
-                    {'text_run': {'content': '查看 ', 'text_element_style': {'italic': True}}},
-                    {'mention_doc': {'token': 'doc-ref', 'title': '设计文档'}},
-                ],
-            },
-        },
-        {
-            'block_id': 'future-1',
-            'block_type': 999,
-            'parent_id': 'doc-1',
-            'future_block': {'opaque': True},
-            'plain_text': '未来块',
-        },
+        _block('heading-1', '章节一', children=['paragraph-1'], heading=True),
+        _block('paragraph-1', '段落一', parent='heading-1'),
+        _block('heading-2', '章节二', children=['paragraph-2'], heading=True),
+        _block('paragraph-2', '段落二', parent='heading-2'),
     ]
 
 
-def _move_raw_blocks():
-    return [
-        {
-            'block_id': 'heading-1',
-            'block_type': 3,
-            'parent_id': 'doc-1',
-            'children': ['paragraph-1'],
-            'heading1': {'elements': [{'text_run': {'content': '章节一'}}]},
-        },
-        {
-            'block_id': 'paragraph-1',
-            'block_type': 2,
-            'parent_id': 'heading-1',
-            'text': {'elements': [{'text_run': {'content': '段落一'}}]},
-        },
-        {
-            'block_id': 'heading-2',
-            'block_type': 3,
-            'parent_id': 'doc-1',
-            'children': ['paragraph-2'],
-            'heading1': {'elements': [{'text_run': {'content': '章节二'}}]},
-        },
-        {
-            'block_id': 'paragraph-2',
-            'block_type': 2,
-            'parent_id': 'heading-2',
-            'text': {'elements': [{'text_run': {'content': '段落二'}}]},
-        },
-    ]
-
-
-def test_feishu_round_trip_preserves_hierarchy_styles_and_unknown_payload():
-    raw_blocks = _raw_blocks()
+def test_insert_and_delete_build_native_operations():
     adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(
-        raw_blocks,
-        external_document_id='doc-1',
-        uri='feishu:/test',
-        revision='12',
-    )
+    document = adapter.blocks_to_ir(_move_blocks()[:2], external_document_id='doc-1')
+    heading, paragraph = document.blocks[0], document.blocks[0].children[0]
 
-    heading, unknown = document.blocks
-    paragraph = heading.children[0]
-    assert [heading.type, paragraph.type, unknown.type] == [
-        'heading', 'paragraph', 'feishu_unknown']
-    assert heading.spans == [WriterSpan(text='标题', style=['strong'])]
-    assert paragraph.content == '查看 设计文档'
-    assert paragraph.spans[-1].style == ['feishu:mention_doc']
-    assert unknown.editable is False
-
-    raw_blocks[0]['future_field']['kept'] = False
-    converted = adapter.ir_to_blocks(document)
-    assert converted[0]['future_field'] == {'kept': True}
-    assert converted[1]['parent_id'] == 'heading-1'
-    assert converted[2]['future_block'] == {'opaque': True}
-
-
-@pytest.mark.parametrize(
-    'blocks, message',
-    [
-        (lambda: [_raw_blocks()[0], deepcopy(_raw_blocks()[0])], 'duplicate Feishu block_id'),
-        (
-            lambda: [
-                {'block_id': 'a', 'block_type': 2, 'children': ['b'], 'text': {}},
-                {'block_id': 'b', 'block_type': 2, 'children': ['a'], 'text': {}},
-            ],
-            'cycle detected',
-        ),
-    ],
-)
-def test_blocks_to_ir_rejects_invalid_relations(blocks, message):
-    with pytest.raises(ValueError, match=message):
-        FeishuWriterAdapter().blocks_to_ir(blocks(), external_document_id='doc-1')
-
-
-def test_insert_builds_descendant_payload_for_position_and_content():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    patch = PatchHunk(
-        hunk_id='insert-1',
-        target_node_id=document.blocks[0].node_id,
-        modify_type='insert',
-        position='after',
-        new_blocks=[
-            PatchBlock(type='paragraph', content='新增段落'),
-            PatchBlock(type='heading', content='新增标题', numbering={'level': 2}),
-        ],
-    )
-
-    operation = adapter.patch_to_operation(patch, document)
-    assert operation.operation == 'create'
-    assert operation.params['parent_block_id'] == 'doc-1'
-    assert operation.params['index'] == 1
-    assert operation.params['children_id'] == ['insert-1::0', 'insert-1::1']
-    assert [item['block_type'] for item in operation.params['descendants']] == [2, 4]
-
-
-def test_insert_new_text_uses_nested_anchor():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    paragraph = document.blocks[0].children[0]
-    operation = adapter.patch_to_operation(PatchHunk(
-        target_node_id=document.blocks[0].node_id,
-        anchor_node_id=paragraph.node_id,
-        modify_type='insert',
-        position='before',
-        new_text='兼容新增段落',
+    create = adapter.patch_to_operation(PatchHunk(
+        hunk_id='insert-1', target_node_id=heading.node_id,
+        modify_type='insert', position='after',
+        new_blocks=[PatchBlock(type='paragraph', content='新增段落')],
     ), document)
+    assert create.operation == 'create'
+    assert (create.params['parent_block_id'], create.params['index']) == ('doc-1', 1)
+    assert create.params['descendants'][0]['block_type'] == 2
 
-    assert (operation.params['parent_block_id'], operation.params['index']) == ('heading-1', 0)
-    assert operation.params['descendants'][0]['text']['elements'][0]['text_run'][
-        'content'] == '兼容新增段落'
-
-
-def test_delete_builds_range_and_rejects_stale_text():
-    adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
-    paragraph = document.blocks[0].children[0]
-    patch = PatchHunk(
-        target_node_id=paragraph.node_id,
-        modify_type='delete',
+    delete = adapter.patch_to_operation(PatchHunk(
+        target_node_id=paragraph.node_id, modify_type='delete',
         old_text=paragraph.content,
-    )
-
-    operation = adapter.patch_to_operation(patch, document)
-    assert operation.operation == 'delete'
-    assert operation.params == {
+    ), document)
+    assert delete.operation == 'delete'
+    assert delete.params == {
         'parent_block_id': 'heading-1', 'start_index': 0, 'end_index': 1}
-    with pytest.raises(ValueError, match='old_text does not match'):
-        adapter.patch_to_operation(
-            patch.model_copy(update={'old_text': '过期内容'}), document)
 
 
 @pytest.mark.parametrize(
@@ -186,96 +57,50 @@ def test_delete_builds_range_and_rejects_stale_text():
         ((0, 0), (1, 0), 'before', ('heading-1', 0, 'heading-2', 0)),
     ],
 )
-def test_move_builds_same_and_cross_parent_plans(
+def test_move_builds_same_and_cross_parent_operations(
     source_path, anchor_path, position, expected,
 ):
     adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    document = adapter.blocks_to_ir(_move_blocks(), external_document_id='doc-1')
 
     def locate(path):
-        block = document.blocks[path[0]]
-        return block if len(path) == 1 else block.children[path[1]]
+        root = document.blocks[path[0]]
+        return root if len(path) == 1 else root.children[path[1]]
 
     source, anchor = locate(source_path), locate(anchor_path)
     operation = adapter.patch_to_operation(PatchHunk(
-        hunk_id='move-1',
-        target_node_id=source.node_id,
-        modify_type='move',
-        anchor_node_id=anchor.node_id,
-        position=position,
+        hunk_id='move-1', target_node_id=source.node_id, modify_type='move',
+        anchor_node_id=anchor.node_id, position=position,
     ), document)
 
-    params = operation.params
     assert operation.operation == 'move'
-    assert params['source_block_id'] == source.provider_binding['block_id']
-    assert (
-        params['source_parent_block_id'], params['source_index'],
-        params['target_parent_block_id'], params['target_index'],
-    ) == expected
-    assert len(params['children_id']) == 1
-    assert params['descendants'][0]['block_type'] == source.provider_payload[
-        'raw_block']['block_type']
+    assert operation.params['source_block_id'] == source.provider_binding['block_id']
+    assert tuple(operation.params[key] for key in (
+        'source_parent_block_id', 'source_index',
+        'target_parent_block_id', 'target_index',
+    )) == expected
+    assert len(operation.params['children_id']) == 1
 
 
-def test_move_rejects_anchor_in_source_subtree():
+def test_merge_refreshed_move_restores_writer_identity():
     adapter = FeishuWriterAdapter()
-    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
-    source = document.blocks[0]
-    with pytest.raises(ValueError, match='anchor cannot be the source node or its descendant'):
-        adapter.patch_to_operation(PatchHunk(
-            target_node_id=source.node_id,
-            modify_type='move',
-            anchor_node_id=source.children[0].node_id,
-            position='after',
-        ), document)
-
-
-def test_merge_refreshed_move_restores_writer_identity_with_new_feishu_ids():
-    adapter = FeishuWriterAdapter()
-    previous = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    previous = adapter.blocks_to_ir(_move_blocks(), external_document_id='doc-1')
     source, anchor = previous.blocks
-    operation = adapter.patch_to_operation(PatchHunk(
-        hunk_id='move-1',
-        target_node_id=source.node_id,
-        modify_type='move',
-        anchor_node_id=anchor.node_id,
-        position='after',
-    ), previous)
-    refreshed_raw = deepcopy(_move_raw_blocks()[2:])
-    moved_raw = deepcopy(_move_raw_blocks()[:2])
-    moved_raw[0]['block_id'] = 'moved-heading'
-    moved_raw[0]['children'] = ['moved-paragraph']
-    moved_raw[1]['block_id'] = 'moved-paragraph'
-    moved_raw[1]['parent_id'] = 'moved-heading'
-    refreshed = adapter.blocks_to_ir(
-        refreshed_raw + moved_raw, external_document_id='doc-1')
-
-    merged = adapter.merge_refreshed_document(
-        previous,
-        refreshed,
-        patch=PatchHunk(
-            target_node_id=source.node_id,
-            modify_type='move',
-            anchor_node_id=anchor.node_id,
-            position='after',
-        ),
-        operation=operation,
+    patch = PatchHunk(
+        hunk_id='move-1', target_node_id=source.node_id, modify_type='move',
+        anchor_node_id=anchor.node_id, position='after',
     )
-    moved = merged.blocks[1]
+    operation = adapter.patch_to_operation(patch, previous)
+
+    refreshed_raw = deepcopy(_move_blocks()[2:] + _move_blocks()[:2])
+    refreshed_raw[2]['block_id'] = 'moved-heading'
+    refreshed_raw[2]['children'] = ['moved-paragraph']
+    refreshed_raw[3]['block_id'] = 'moved-paragraph'
+    refreshed_raw[3]['parent_id'] = 'moved-heading'
+    refreshed = adapter.blocks_to_ir(refreshed_raw, external_document_id='doc-1')
+
+    moved = adapter.merge_refreshed_document(
+        previous, refreshed, patch=patch, operation=operation).blocks[1]
     assert moved.node_id == source.node_id
     assert moved.children[0].node_id == source.children[0].node_id
     assert moved.provider_binding['block_id'] == 'moved-heading'
-
-
-def test_public_codec_builds_hierarchy_without_fs_dependency():
-    roots, descendants = prepare_docx_descendants([
-        {'block_id': 'parent', 'block_type': 2, 'text': {'elements': []}},
-        {
-            'block_id': 'child',
-            'parent_id': 'parent',
-            'block_type': 2,
-            'text': {'elements': []},
-        },
-    ])
-    assert roots == ['parent']
-    assert descendants[0]['children'] == ['child']

--- a/tests/basic_tests/Tools/test_writer_adapter.py
+++ b/tests/basic_tests/Tools/test_writer_adapter.py
@@ -1,0 +1,525 @@
+from copy import deepcopy
+
+import pytest
+
+from lazyllm.tools.writer.adapter.base import NativePatchOperation, WriterAdapterBase
+from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
+from lazyllm.tools.writer.data_models import (
+    PatchBlock,
+    PatchHunk,
+    WriterBlock,
+    WriterDocument,
+    WriterSpan,
+)
+
+
+class _DummyAdapter(WriterAdapterBase):
+    provider = 'dummy'
+
+    def blocks_to_ir(self, blocks, **kwargs):
+        raise NotImplementedError
+
+    def ir_to_blocks(self, document):
+        raise NotImplementedError
+
+    def patch_to_operation(self, patch, document):
+        raise NotImplementedError
+
+def test_writer_adapter_ids_are_stable_and_provider_scoped():
+    document_id = _DummyAdapter.make_document_id('external-document')
+    node_id = _DummyAdapter.make_node_id('external-document', 'external-block')
+
+    assert document_id == _DummyAdapter.make_document_id('external-document')
+    assert node_id == _DummyAdapter.make_node_id('external-document', 'external-block')
+    assert document_id.startswith('writer-doc-')
+    assert node_id.startswith('writer-node-')
+    assert node_id != _DummyAdapter.make_node_id('another-document', 'external-block')
+    assert node_id != _DummyAdapter.make_node_id('external-document', 'another-block')
+
+
+@pytest.mark.parametrize('value', ['', '   ', None])
+def test_writer_adapter_rejects_empty_external_ids(value):
+    with pytest.raises(ValueError, match='external_document_id must be a non-empty string'):
+        _DummyAdapter.make_document_id(value)
+
+    with pytest.raises(ValueError, match='external_block_id must be a non-empty string'):
+        _DummyAdapter.make_node_id('external-document', value)
+
+
+def test_writer_adapter_requires_provider_name():
+    class MissingProviderAdapter(_DummyAdapter):
+        provider = ''
+
+    with pytest.raises(ValueError, match='provider must be a non-empty string'):
+        MissingProviderAdapter.make_document_id('external-document')
+
+
+def test_writer_adapter_base_is_abstract():
+    with pytest.raises(TypeError):
+        WriterAdapterBase()
+
+
+def _raw_blocks():
+    return [
+        {
+            'block_id': 'heading-1',
+            'block_type': 3,
+            'parent_id': 'doc-1',
+            'children': ['paragraph-1'],
+            'heading1': {
+                'elements': [{
+                    'text_run': {
+                        'content': '标题',
+                        'text_element_style': {'bold': True},
+                    },
+                }],
+                'style': {'align': 1},
+            },
+            'future_field': {'kept': True},
+        },
+        {
+            'block_id': 'paragraph-1',
+            'block_type': 2,
+            'parent_id': 'heading-1',
+            'text': {
+                'elements': [
+                    {'text_run': {'content': '查看 ', 'text_element_style': {'italic': True}}},
+                    {'mention_doc': {'token': 'doc-ref', 'title': '设计文档'}},
+                ],
+            },
+        },
+        {
+            'block_id': 'future-1',
+            'block_type': 999,
+            'parent_id': 'doc-1',
+            'future_block': {'opaque': True},
+            'plain_text': '未来块',
+        },
+    ]
+
+
+def _move_raw_blocks():
+    return [
+        {
+            'block_id': 'heading-1',
+            'block_type': 3,
+            'parent_id': 'doc-1',
+            'children': ['paragraph-1'],
+            'heading1': {'elements': [{'text_run': {'content': '章节一'}}]},
+        },
+        {
+            'block_id': 'paragraph-1',
+            'block_type': 2,
+            'parent_id': 'heading-1',
+            'text': {'elements': [{'text_run': {'content': '段落一'}}]},
+        },
+        {
+            'block_id': 'heading-2',
+            'block_type': 3,
+            'parent_id': 'doc-1',
+            'children': ['paragraph-2'],
+            'heading1': {'elements': [{'text_run': {'content': '章节二'}}]},
+        },
+        {
+            'block_id': 'paragraph-2',
+            'block_type': 2,
+            'parent_id': 'heading-2',
+            'text': {'elements': [{'text_run': {'content': '段落二'}}]},
+        },
+    ]
+
+
+def test_blocks_to_ir_preserves_hierarchy_bindings_and_payload():
+    raw_blocks = _raw_blocks()
+    document = FeishuWriterAdapter().blocks_to_ir(
+        raw_blocks,
+        external_document_id='doc-1',
+        title='测试文档',
+        uri='feishu:/test',
+        revision='12',
+    )
+
+    assert document.document_id == FeishuWriterAdapter.make_document_id('doc-1')
+    assert document.provider_binding == {
+        'provider': 'feishu',
+        'document_id': 'doc-1',
+        'uri': 'feishu:/test',
+        'revision': '12',
+    }
+    assert [block.type for block in document.blocks] == ['heading', 'feishu_unknown']
+
+    heading = document.blocks[0]
+    paragraph = heading.children[0]
+    assert heading.node_id == FeishuWriterAdapter.make_node_id('doc-1', 'heading-1')
+    assert heading.numbering == {'level': 1}
+    assert heading.spans == [WriterSpan(text='标题', style=['strong'])]
+    assert paragraph.content == '查看 设计文档'
+    assert paragraph.spans[-1].style == ['feishu:mention_doc']
+    assert paragraph.provider_binding['block_id'] == 'paragraph-1'
+    assert document.blocks[1].editable is False
+
+    raw_blocks[0]['future_field']['kept'] = False
+    assert heading.provider_payload['raw_block']['future_field']['kept'] is True
+
+
+def test_blocks_to_ir_rejects_duplicate_ids_and_cycles():
+    adapter = FeishuWriterAdapter()
+    duplicate = [_raw_blocks()[0], deepcopy(_raw_blocks()[0])]
+    with pytest.raises(ValueError, match='duplicate Feishu block_id'):
+        adapter.blocks_to_ir(duplicate, external_document_id='doc-1')
+
+    cycle = [
+        {'block_id': 'a', 'block_type': 2, 'children': ['b'], 'text': {'elements': []}},
+        {'block_id': 'b', 'block_type': 2, 'children': ['a'], 'text': {'elements': []}},
+    ]
+    with pytest.raises(ValueError, match='cycle detected'):
+        adapter.blocks_to_ir(cycle, external_document_id='doc-1')
+
+
+def test_ir_to_blocks_preserves_raw_fields_and_hierarchy():
+    adapter = FeishuWriterAdapter()
+    raw_blocks = _raw_blocks()
+    document = adapter.blocks_to_ir(raw_blocks, external_document_id='doc-1')
+
+    converted = adapter.ir_to_blocks(document)
+
+    assert converted[0]['block_id'] == 'heading-1'
+    assert 'children' not in converted[0]
+    assert converted[0]['future_field'] == {'kept': True}
+    assert converted[0]['heading1'] == raw_blocks[0]['heading1']
+    assert converted[1]['parent_id'] == 'heading-1'
+    assert converted[1]['text'] == raw_blocks[1]['text']
+    assert converted[2]['future_block'] == {'opaque': True}
+
+
+def test_ir_to_blocks_converts_new_blocks_and_styles():
+    document = WriterDocument(
+        document_id='internal-doc',
+        stage='final',
+        blocks=[
+            WriterBlock(
+                node_id='heading-node',
+                type='heading',
+                content='标题',
+                spans=[WriterSpan(text='标题', style=['strong'])],
+                stage='final',
+                numbering={'level': 2},
+                children=[
+                    WriterBlock(
+                        node_id='list-node',
+                        type='list_item',
+                        content='条目',
+                        stage='final',
+                        numbering={'ordered': True},
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    converted = FeishuWriterAdapter().ir_to_blocks(document)
+
+    assert converted == [
+        {
+            'block_type': 4,
+            'heading2': {
+                'elements': [{
+                    'text_run': {
+                        'content': '标题',
+                        'text_element_style': {'bold': True},
+                    },
+                }],
+            },
+            'plain_text': '标题',
+            'block_id': 'heading-node',
+        },
+        {
+            'block_type': 13,
+            'ordered': {'elements': [{'text_run': {'content': '条目'}}]},
+            'plain_text': '条目',
+            'block_id': 'list-node',
+            'parent_id': 'heading-node',
+        },
+    ]
+
+
+def test_fs_prepare_descendants_is_the_only_writer_of_children():
+    pytest.importorskip('fsspec')
+    from lazyllm.tools.fs.supplier.feishu import FeishuFSBase
+
+    document = WriterDocument(
+        document_id='internal-doc',
+        stage='final',
+        blocks=[
+            WriterBlock(
+                node_id='parent',
+                type='paragraph',
+                content='父块',
+                stage='final',
+                children=[
+                    WriterBlock(
+                        node_id='child',
+                        type='paragraph',
+                        content='子块',
+                        stage='final',
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    blocks = FeishuWriterAdapter().ir_to_blocks(document)
+    assert 'children' not in blocks[0]
+    assert blocks[1]['parent_id'] == 'parent'
+
+    roots, descendants = FeishuFSBase._prepare_docx_descendants(blocks)
+    assert roots == ['parent']
+    assert descendants[0]['children'] == ['child']
+
+
+def test_ir_to_blocks_rebuilds_modified_text_and_rejects_modified_unknown_block():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    document.blocks[0].content = '新标题'
+    document.blocks[0].spans = []
+
+    converted = adapter.ir_to_blocks(document)
+    assert converted[0]['heading1']['elements'] == [
+        {'text_run': {'content': '新标题'}},
+    ]
+    assert converted[0]['heading1']['style'] == {'align': 1}
+
+    document.blocks[1].content = '修改未来块'
+    with pytest.raises(ValueError, match='non-editable Feishu block'):
+        adapter.ir_to_blocks(document)
+
+
+def test_replace_patch_resolves_internal_node_to_feishu_block():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    target = document.blocks[0]
+    patch = PatchHunk(
+        target_node_id=target.node_id,
+        modify_type='replace',
+        old_text='标题',
+        new_text='新标题',
+    )
+
+    expected_requests = [{
+        'block_id': 'heading-1',
+        'update_text_elements': {
+            'elements': [{
+                'text_run': {
+                    'content': '新标题',
+                    'text_element_style': {'bold': True},
+                },
+            }],
+        },
+    }]
+
+    assert adapter.patch_to_operation(patch, document) == NativePatchOperation(
+        operation='update',
+        params={'requests': expected_requests},
+    )
+
+
+def test_insert_patch_builds_create_operation_after_target():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    patch = PatchHunk(
+        hunk_id='insert-1',
+        target_node_id=document.blocks[0].node_id,
+        modify_type='insert',
+        position='after',
+        new_blocks=[
+            PatchBlock(type='paragraph', content='新增段落'),
+            PatchBlock(type='heading', content='新增标题', numbering={'level': 2}),
+        ],
+    )
+
+    operation = adapter.patch_to_operation(patch, document)
+
+    assert operation.operation == 'create'
+    assert operation.params['parent_block_id'] == 'doc-1'
+    assert operation.params['index'] == 1
+    assert operation.params['children_id'] == ['insert-1::0', 'insert-1::1']
+    assert operation.params['descendants'] == [
+        {
+            'block_type': 2,
+            'text': {'elements': [{'text_run': {'content': '新增段落'}}]},
+            'block_id': 'insert-1::0',
+        },
+        {
+            'block_type': 4,
+            'heading2': {'elements': [{'text_run': {'content': '新增标题'}}]},
+            'block_id': 'insert-1::1',
+        },
+    ]
+
+
+def test_insert_patch_supports_anchor_position_and_new_text_fallback():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    paragraph = document.blocks[0].children[0]
+    patch = PatchHunk(
+        target_node_id=document.blocks[0].node_id,
+        anchor_node_id=paragraph.node_id,
+        modify_type='insert',
+        position='before',
+        new_text='兼容新增段落',
+    )
+
+    operation = adapter.patch_to_operation(patch, document)
+
+    assert operation.operation == 'create'
+    assert operation.params['parent_block_id'] == 'heading-1'
+    assert operation.params['index'] == 0
+    assert operation.params['children_id'] == [operation.params['descendants'][0]['block_id']]
+    assert operation.params['descendants'][0]['block_type'] == 2
+    assert (
+        operation.params['descendants'][0]['text']['elements'][0]['text_run']['content']
+        == '兼容新增段落'
+    )
+
+
+def test_delete_patch_builds_delete_operation_and_validates_old_text():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    paragraph = document.blocks[0].children[0]
+    patch = PatchHunk(
+        target_node_id=paragraph.node_id,
+        modify_type='delete',
+        old_text=paragraph.content,
+    )
+
+    assert adapter.patch_to_operation(patch, document) == NativePatchOperation(
+        operation='delete',
+        params={
+            'parent_block_id': 'heading-1',
+            'start_index': 0,
+            'end_index': 1,
+        },
+    )
+
+    stale = patch.model_copy(update={'old_text': '过期内容'})
+    with pytest.raises(ValueError, match='old_text does not match'):
+        adapter.patch_to_operation(stale, document)
+
+
+def test_move_patch_builds_same_parent_operation_with_remapped_subtree_ids():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    source, anchor = document.blocks
+    patch = PatchHunk(
+        hunk_id='move-1',
+        target_node_id=source.node_id,
+        modify_type='move',
+        anchor_node_id=anchor.node_id,
+        position='after',
+        old_text=source.content,
+    )
+
+    operation = adapter.patch_to_operation(patch, document)
+
+    assert operation.operation == 'move'
+    assert operation.params['source_parent_block_id'] == 'doc-1'
+    assert operation.params['source_index'] == 0
+    assert operation.params['target_parent_block_id'] == 'doc-1'
+    assert operation.params['target_index'] == 1
+    assert operation.params['children_id'] == ['move-1::0']
+    assert operation.params['descendants'] == [
+        {
+            'block_id': 'move-1::0',
+            'block_type': 3,
+            'heading1': {'elements': [{'text_run': {'content': '章节一'}}]},
+            'children': ['move-1::1'],
+        },
+        {
+            'block_id': 'move-1::1',
+            'block_type': 2,
+            'text': {'elements': [{'text_run': {'content': '段落一'}}]},
+        },
+    ]
+
+
+def test_move_patch_builds_cross_parent_operation():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    source = document.blocks[0].children[0]
+    anchor = document.blocks[1].children[0]
+    patch = PatchHunk(
+        target_node_id=source.node_id,
+        modify_type='move',
+        anchor_node_id=anchor.node_id,
+        position='before',
+    )
+
+    operation = adapter.patch_to_operation(patch, document)
+
+    assert operation.operation == 'move'
+    assert operation.params['source_parent_block_id'] == 'heading-1'
+    assert operation.params['source_index'] == 0
+    assert operation.params['target_parent_block_id'] == 'heading-2'
+    assert operation.params['target_index'] == 0
+    assert len(operation.params['children_id']) == 1
+    assert operation.params['descendants'][0]['text']['elements'][0]['text_run']['content'] == '段落一'
+
+
+def test_move_patch_rejects_anchor_in_source_subtree_and_stale_text():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_move_raw_blocks(), external_document_id='doc-1')
+    source = document.blocks[0]
+    descendant = source.children[0]
+
+    into_self = PatchHunk(
+        target_node_id=source.node_id,
+        modify_type='move',
+        anchor_node_id=descendant.node_id,
+        position='after',
+    )
+    with pytest.raises(ValueError, match='anchor cannot be the source node or its descendant'):
+        adapter.patch_to_operation(into_self, document)
+
+    stale = PatchHunk(
+        target_node_id=source.node_id,
+        modify_type='move',
+        anchor_node_id=document.blocks[1].node_id,
+        position='before',
+        old_text='过期内容',
+    )
+    with pytest.raises(ValueError, match='old_text does not match'):
+        adapter.patch_to_operation(stale, document)
+
+
+def test_replace_patch_supports_text_range_and_rejects_stale_patch():
+    adapter = FeishuWriterAdapter()
+    document = adapter.blocks_to_ir(_raw_blocks(), external_document_id='doc-1')
+    target = document.blocks[0].children[0]
+
+    ranged = PatchHunk(
+        target_node_id=target.node_id,
+        modify_type='replace',
+        text_range=(0, 2),
+        old_text='查看',
+        new_text='阅读',
+    )
+    operation = adapter.patch_to_operation(ranged, document)
+    elements = operation.params['requests'][0]['update_text_elements']['elements']
+    assert elements == [
+        {
+            'text_run': {
+                'content': '阅读 ',
+                'text_element_style': {'italic': True},
+            },
+        },
+        {'mention_doc': {'token': 'doc-ref', 'title': '设计文档'}},
+    ]
+
+    stale = PatchHunk(
+        target_node_id=target.node_id,
+        modify_type='replace',
+        old_text='过期内容',
+        new_text='新内容',
+    )
+    with pytest.raises(ValueError, match='old_text does not match'):
+        adapter.patch_to_operation(stale, document)

--- a/tests/basic_tests/Tools/test_writer_data_model.py
+++ b/tests/basic_tests/Tools/test_writer_data_model.py
@@ -24,7 +24,7 @@ def _make_writer_document():
         node_id='block-1',
         type='paragraph',
         content='正文内容',
-        spans=[WriterSpan(text='正文内容', style=['strong'])],
+        spans=[WriterSpan(text='正文内容', style={'bold': True})],
         stage='draft',
         provider_binding={'provider': 'feishu', 'block_id': 'external-1'},
         provider_payload={'raw_type': 'paragraph'},
@@ -58,7 +58,7 @@ def test_writer_document_roundtrip_preserves_nested_ir_fields():
 
     assert restored.document_id == document.document_id
     assert restored.provider_binding['document_id'] == 'external-doc-1'
-    assert restored.blocks[0].children[0].spans[0].style == ['strong']
+    assert restored.blocks[0].children[0].spans[0].style == {'bold': True}
     assert restored.blocks[0].children[0].provider_payload == {'raw_type': 'paragraph'}
 
 

--- a/tests/basic_tests/Tools/test_writer_revision_tools.py
+++ b/tests/basic_tests/Tools/test_writer_revision_tools.py
@@ -41,6 +41,13 @@ def _context():
     return WritingContext(context_id='context-1', doc_id='doc-1', query='revise')
 
 
+def _move_hunk(source, anchor):
+    return PatchHunk(
+        hunk_id=f'move-{source}', target_node_id=source, modify_type='move',
+        anchor_node_id=anchor, position='after',
+    )
+
+
 def _revised_document(result):
     path = result['metadata']['artifact_paths']['revised_document']
     return load_artifact_json(path, WriterDocument)
@@ -242,20 +249,13 @@ def test_apply_patch_rejects_move_into_descendant():
 
 def test_patchset_hunks_execute_in_declared_order():
     document = WriterDocument(
-        document_id='doc-1',
-        stage='final',
+        document_id='doc-1', stage='final',
         blocks=[_block(node_id, node_id) for node_id in 'ABCD'],
     )
-    patch = PatchSet(target_doc_id='doc-1', hunks=[
-        PatchHunk(
-            hunk_id='move-B', target_node_id='B', modify_type='move',
-            anchor_node_id='A', position='after',
-        ),
-        PatchHunk(
-            hunk_id='move-C', target_node_id='C', modify_type='move',
-            anchor_node_id='A', position='after',
-        ),
-    ])
+    patch = PatchSet(
+        target_doc_id='doc-1',
+        hunks=[_move_hunk('B', 'A'), _move_hunk('C', 'A')],
+    )
 
     revised, result = apply_patch_to_ir(document, patch)
     assert [block.node_id for block in revised.blocks] == ['A', 'C', 'B', 'D']
@@ -263,20 +263,7 @@ def test_patchset_hunks_execute_in_declared_order():
 
 
 def test_patch_generation_chains_repeated_after_move_anchors():
-    hunks = [
-        PatchHunk(
-            target_node_id='B', modify_type='move',
-            anchor_node_id='A', position='after',
-        ),
-        PatchHunk(
-            target_node_id='C', modify_type='move',
-            anchor_node_id='A', position='after',
-        ),
-        PatchHunk(
-            target_node_id='D', modify_type='move',
-            anchor_node_id='A', position='after',
-        ),
-    ]
+    hunks = [_move_hunk(source, 'A') for source in 'BCD']
 
     WriterRevisionTools._chain_repeated_after_moves(hunks)
     assert [hunk.anchor_node_id for hunk in hunks] == ['A', 'B', 'C']

--- a/tests/basic_tests/Tools/test_writer_revision_tools.py
+++ b/tests/basic_tests/Tools/test_writer_revision_tools.py
@@ -9,7 +9,7 @@ from lazyllm.tools.writer.data_models.revision import (
     PatchSet,
 )
 from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
-from lazyllm.tools.writer.tools.revision_tools import WriterRevisionTools
+from lazyllm.tools.writer.tools.revision_tools import WriterRevisionTools, apply_patch_to_ir
 from lazyllm.tools.writer.utils import load_artifact_json
 
 
@@ -238,3 +238,45 @@ def test_apply_patch_rejects_move_into_descendant():
             WriterRevisionTools(artifact_store=directory).apply_patch(
                 document, patch_set, _context(),
             )
+
+
+def test_patchset_hunks_execute_in_declared_order():
+    document = WriterDocument(
+        document_id='doc-1',
+        stage='final',
+        blocks=[_block(node_id, node_id) for node_id in 'ABCD'],
+    )
+    patch = PatchSet(target_doc_id='doc-1', hunks=[
+        PatchHunk(
+            hunk_id='move-B', target_node_id='B', modify_type='move',
+            anchor_node_id='A', position='after',
+        ),
+        PatchHunk(
+            hunk_id='move-C', target_node_id='C', modify_type='move',
+            anchor_node_id='A', position='after',
+        ),
+    ])
+
+    revised, result = apply_patch_to_ir(document, patch)
+    assert [block.node_id for block in revised.blocks] == ['A', 'C', 'B', 'D']
+    assert result.applied_hunks == ['move-B', 'move-C']
+
+
+def test_patch_generation_chains_repeated_after_move_anchors():
+    hunks = [
+        PatchHunk(
+            target_node_id='B', modify_type='move',
+            anchor_node_id='A', position='after',
+        ),
+        PatchHunk(
+            target_node_id='C', modify_type='move',
+            anchor_node_id='A', position='after',
+        ),
+        PatchHunk(
+            target_node_id='D', modify_type='move',
+            anchor_node_id='A', position='after',
+        ),
+    ]
+
+    WriterRevisionTools._chain_repeated_after_moves(hunks)
+    assert [hunk.anchor_node_id for hunk in hunks] == ['A', 'B', 'C']

--- a/tests/basic_tests/Tools/test_writer_revision_tools.py
+++ b/tests/basic_tests/Tools/test_writer_revision_tools.py
@@ -1,23 +1,21 @@
-import tempfile
-
 import pytest
 
-from lazyllm.tools.writer.data_models import WriterBlock, WriterDocument, WritingContext
-from lazyllm.tools.writer.data_models.revision import (
-    PatchBlock,
+from lazyllm.tools.writer.data_models import (
     PatchHunk,
     PatchSet,
+    WriterBlock,
+    WriterDocument,
+    WriterSpan,
 )
-from lazyllm.tools.writer.adapter.feishu import FeishuWriterAdapter
 from lazyllm.tools.writer.tools.revision_tools import WriterRevisionTools, apply_patch_to_ir
-from lazyllm.tools.writer.utils import load_artifact_json
 
 
-def _block(node_id, content, *, children=None):
+def _block(node_id, content, *, children=None, style=None):
     return WriterBlock(
         node_id=node_id,
         type='paragraph',
         content=content,
+        spans=[WriterSpan(text=content, style=style or {})],
         children=children or [],
         stage='final',
     )
@@ -28,198 +26,118 @@ def _document():
         document_id='doc-1',
         stage='final',
         blocks=[
-            _block('replace', 'old replacement'),
-            _block('insert-anchor', 'insert anchor'),
+            _block('update', 'old'),
             _block('delete', 'delete me'),
             _block('move', 'move me'),
-            _block('move-anchor', 'move anchor'),
+            _block('anchor', 'anchor'),
         ],
     )
 
 
-def _context():
-    return WritingContext(context_id='context-1', doc_id='doc-1', query='revise')
-
-
-def _move_hunk(source, anchor):
-    return PatchHunk(
-        hunk_id=f'move-{source}', target_node_id=source, modify_type='move',
-        anchor_node_id=anchor, position='after',
-    )
-
-
-def _revised_document(result):
-    path = result['metadata']['artifact_paths']['revised_document']
-    return load_artifact_json(path, WriterDocument)
-
-
-def test_apply_patch_supports_all_block_operations_atomically():
-    patch_set = PatchSet(
+def test_apply_patch_supports_all_block_operations():
+    document = _document()
+    updated = document.block_by_id('update').model_copy(deep=True)
+    updated.type = 'heading'
+    updated.numbering = {'level': 4}
+    updated.spans[0].style = {
+        'bold': True,
+        'text_color': '#ff0000',
+        'background_color': '#ffff00',
+        'font_size': 16,
+    }
+    created = _block('created', 'new block')
+    patch = PatchSet(
         patch_id='patch-1',
-        target_doc_id='doc-1',
+        target_doc_id=document.document_id,
         hunks=[
             PatchHunk(
-                hunk_id='replace-hunk',
-                target_node_id='replace',
-                modify_type='replace',
-                old_text='old replacement',
-                new_text='new replacement',
-            ),
-            PatchHunk(
-                hunk_id='insert-hunk',
-                target_node_id='insert-anchor',
-                modify_type='insert',
-                position='before',
-                new_blocks=[
-                    PatchBlock(type='paragraph', content='inserted one'),
-                    PatchBlock(type='paragraph', content='inserted two'),
-                ],
+                hunk_id='update-hunk',
+                target_node_id=updated.node_id,
+                modify_type='update',
+                block=updated,
             ),
             PatchHunk(
                 hunk_id='delete-hunk',
                 target_node_id='delete',
                 modify_type='delete',
-                old_text='delete me',
             ),
             PatchHunk(
                 hunk_id='move-hunk',
                 target_node_id='move',
                 modify_type='move',
-                old_text='move me',
-                anchor_node_id='move-anchor',
-                position='after',
+                parent_node_id=None,
+                index=2,
+            ),
+            PatchHunk(
+                hunk_id='create-hunk',
+                target_node_id=created.node_id,
+                modify_type='create',
+                block=created,
+                parent_node_id=None,
+                index=1,
             ),
         ],
     )
 
-    with tempfile.TemporaryDirectory() as directory:
-        result = WriterRevisionTools(artifact_store=directory).apply_patch(
-            _document(), patch_set, _context(),
-        )
-        revised = _revised_document(result)
+    revised, result = apply_patch_to_ir(document, patch)
 
     assert [block.node_id for block in revised.blocks] == [
-        'replace',
-        'insert-hunk::block-1',
-        'insert-hunk::block-2',
-        'insert-anchor',
-        'move-anchor',
-        'move',
+        'update', 'created', 'anchor', 'move',
     ]
-    assert revised.block_by_id('replace').content == 'new replacement'
-    assert revised.block_by_id('delete') is None
-    assert result['metadata']['counts'] == {'applied': 4, 'failed': 0}
+    assert revised.blocks[0].type == 'heading'
+    assert revised.blocks[0].numbering == {'level': 4}
+    assert revised.blocks[0].spans[0].style['background_color'] == '#ffff00'
+    assert result.applied_hunks == [
+        'update-hunk', 'delete-hunk', 'move-hunk', 'create-hunk',
+    ]
 
 
-def test_revision_patch_contract_with_feishu_adapter():
-    adapter = FeishuWriterAdapter()
-    source = adapter.blocks_to_ir(
-        [{
-            'block_id': 'feishu-block-1',
-            'block_type': 2,
-            'parent_id': 'feishu-doc-1',
-            'text': {
-                'elements': [{
-                    'text_run': {
-                        'content': 'Original text',
-                        'text_element_style': {'bold': True},
-                    },
-                }],
-            },
-            'plain_text': 'Original text',
-        }],
-        external_document_id='feishu-doc-1',
-        stage='final',
-    )
-    target = source.blocks[0]
-    patch_set = PatchSet(
-        patch_id='patch-feishu-contract',
-        target_doc_id=source.document_id,
-        hunks=[PatchHunk(
-            hunk_id='replace-feishu-block',
-            target_node_id=target.node_id,
-            modify_type='replace',
-            old_text='Original text',
-            new_text='Revised text',
-        )],
-    )
+def test_document_diff_round_trips_arbitrary_visible_edits():
+    source = _document()
+    revised = source.model_copy(deep=True)
+    revised.title = 'new title'
+    revised.blocks[0].type = 'heading'
+    revised.blocks[0].numbering = {'level': 4}
+    revised.blocks[0].spans[0].style = {'bold': True, 'text_color': 'red'}
+    revised.blocks.insert(1, _block('created', 'created by enter'))
+    revised.blocks = [revised.blocks[2], revised.blocks[0], revised.blocks[1]]
+    revised.blocks = [block for block in revised.blocks if block.node_id != 'anchor']
 
-    with tempfile.TemporaryDirectory() as directory:
-        result = WriterRevisionTools(artifact_store=directory).apply_patch(
-            source, patch_set, WritingContext(
-                context_id='context-feishu-contract',
-                doc_id=source.document_id,
-                query='revise',
-            ),
-        )
-        revised = _revised_document(result)
+    patch = WriterRevisionTools()._diff_documents(source, revised)
+    applied, _ = apply_patch_to_ir(source, patch)
 
-    operation = adapter.patch_to_operation(patch_set.hunks[0], source)
-    request = operation.params['requests'][0]
-    assert revised.block_by_id(target.node_id).content == 'Revised text'
-    assert operation.operation == 'update'
-    assert request['block_id'] == 'feishu-block-1'
-    assert request['update_text_elements']['elements'][0]['text_run']['content'] == 'Revised text'
-    assert request['update_text_elements']['elements'][0]['text_run']['text_element_style'] == {
-        'bold': True,
+    assert {hunk.modify_type for hunk in patch.hunks} == {
+        'create', 'update', 'delete', 'move',
     }
+    WriterRevisionTools._assert_revision_applied(applied, revised)
 
 
-def test_apply_patch_inserts_next_to_nested_anchor():
-    document = WriterDocument(
+def test_document_diff_creates_nested_subtree():
+    source = WriterDocument(
         document_id='doc-1',
         stage='final',
-        blocks=[_block('parent', 'parent', children=[_block('child', 'child')])],
+        blocks=[_block('existing', 'existing')],
     )
-    patch_set = PatchSet(
-        target_doc_id='doc-1',
-        hunks=[PatchHunk(
-            hunk_id='nested-insert',
-            target_node_id='child',
-            modify_type='insert',
-            position='after',
-            new_blocks=[PatchBlock(type='paragraph', content='new child')],
-        )],
-    )
+    revised = source.model_copy(deep=True)
+    revised.blocks.append(_block(
+        'new-parent',
+        'new parent',
+        children=[_block('new-child', 'new child')],
+    ))
 
-    with tempfile.TemporaryDirectory() as directory:
-        result = WriterRevisionTools(artifact_store=directory).apply_patch(
-            document, patch_set, _context(),
-        )
-        revised = _revised_document(result)
-
-    assert [block.content for block in revised.blocks[0].children] == ['child', 'new child']
+    patch = WriterRevisionTools()._diff_documents(source, revised)
+    assert len(patch.hunks) == 1
+    assert patch.hunks[0].modify_type == 'create'
+    assert patch.hunks[0].block.children[0].node_id == 'new-child'
 
 
-def test_apply_patch_rejects_conflict_before_any_mutation():
-    document = _document()
-    patch_set = PatchSet(
-        target_doc_id='doc-1',
-        hunks=[
-            PatchHunk(
-                hunk_id='valid-first',
-                target_node_id='replace',
-                modify_type='replace',
-                old_text='old replacement',
-                new_text='would be applied by a partial implementation',
-            ),
-            PatchHunk(
-                hunk_id='conflict-second',
-                target_node_id='delete',
-                modify_type='delete',
-                old_text='stale text',
-            ),
-        ],
-    )
+def test_document_diff_rejects_provider_field_changes():
+    source = _document()
+    revised = source.model_copy(deep=True)
+    revised.blocks[0].provider_binding = {'provider': 'feishu', 'block_id': 'other'}
 
-    with tempfile.TemporaryDirectory() as directory:
-        with pytest.raises(ValueError, match='old_text conflict'):
-            WriterRevisionTools(artifact_store=directory).apply_patch(
-                document, patch_set, _context(),
-            )
-
-    assert document.block_by_id('replace').content == 'old replacement'
-    assert document.block_by_id('delete') is not None
+    with pytest.raises(ValueError, match='provider-managed fields'):
+        WriterRevisionTools()._diff_documents(source, revised)
 
 
 def test_apply_patch_rejects_move_into_descendant():
@@ -229,41 +147,15 @@ def test_apply_patch_rejects_move_into_descendant():
         stage='final',
         blocks=[_block('parent', 'parent', children=[child])],
     )
-    patch_set = PatchSet(
+    patch = PatchSet(
         target_doc_id='doc-1',
         hunks=[PatchHunk(
             target_node_id='parent',
             modify_type='move',
-            old_text='parent',
-            anchor_node_id='child',
-            position='after',
+            parent_node_id='child',
+            index=0,
         )],
     )
 
-    with tempfile.TemporaryDirectory() as directory:
-        with pytest.raises(ValueError, match='descendants'):
-            WriterRevisionTools(artifact_store=directory).apply_patch(
-                document, patch_set, _context(),
-            )
-
-
-def test_patchset_hunks_execute_in_declared_order():
-    document = WriterDocument(
-        document_id='doc-1', stage='final',
-        blocks=[_block(node_id, node_id) for node_id in 'ABCD'],
-    )
-    patch = PatchSet(
-        target_doc_id='doc-1',
-        hunks=[_move_hunk('B', 'A'), _move_hunk('C', 'A')],
-    )
-
-    revised, result = apply_patch_to_ir(document, patch)
-    assert [block.node_id for block in revised.blocks] == ['A', 'C', 'B', 'D']
-    assert result.applied_hunks == ['move-B', 'move-C']
-
-
-def test_patch_generation_chains_repeated_after_move_anchors():
-    hunks = [_move_hunk(source, 'A') for source in 'BCD']
-
-    WriterRevisionTools._chain_repeated_after_moves(hunks)
-    assert [hunk.anchor_node_id for hunk in hunks] == ['A', 'B', 'C']
+    with pytest.raises(ValueError, match='own subtree'):
+        apply_patch_to_ir(document, patch)

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -763,7 +763,6 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
         fs.get_doc_blocks.return_value = [second, {**first, 'block_id': 'moved-b1'}]
         fs.move_block.return_value = {
             'block_id_relations': {'b1': 'moved-b1'},
-            'normalized_fields': ['b1.text.elements.file'],
         }
 
         with patch(
@@ -776,12 +775,8 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
         assert fs.move_block.call_args.kwargs['source_block_id'] == 'b1'
         persisted = load_artifact_json(
             result['metadata']['artifact_paths']['persisted_document'], WriterDocument)
-        patch_result = load_artifact_json(result['artifact_path'], PatchResult)
         assert persisted.blocks[1].node_id == moved_node_id
         assert persisted.blocks[1].provider_binding['block_id'] == 'moved-b1'
-        assert patch_result.meta['normalized_fields'] == {
-            'move-b1': ['b1.text.elements.file'],
-        }
 
 
 @pytest.mark.parametrize(

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -761,6 +761,10 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
         )])
         first, second = fs.get_doc_blocks.return_value
         fs.get_doc_blocks.return_value = [second, {**first, 'block_id': 'moved-b1'}]
+        fs.move_block.return_value = {
+            'block_id_relations': {'b1': 'moved-b1'},
+            'normalized_fields': ['b1.text.elements.file'],
+        }
 
         with patch(
             'lazyllm.tools.fs.client.FS._parse',
@@ -772,8 +776,12 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
         assert fs.move_block.call_args.kwargs['source_block_id'] == 'b1'
         persisted = load_artifact_json(
             result['metadata']['artifact_paths']['persisted_document'], WriterDocument)
+        patch_result = load_artifact_json(result['artifact_path'], PatchResult)
         assert persisted.blocks[1].node_id == moved_node_id
         assert persisted.blocks[1].provider_binding['block_id'] == 'moved-b1'
+        assert patch_result.meta['normalized_fields'] == {
+            'move-b1': ['b1.text.elements.file'],
+        }
 
 
 @pytest.mark.parametrize(

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -744,6 +744,58 @@ def test_apply_patch_to_document_dispatches_update_and_rereads():
         assert persisted.blocks[1].content == '修改后正文'
 
 
+def test_apply_patch_to_document_moves_and_restores_writer_identity():
+    pytest.importorskip('fsspec')
+    fs = _make_doc_adapter()
+    fs.get_doc_blocks.return_value = [
+        {
+            'block_id': 'b1', 'block_type': 2, 'parent_id': 'doc-1',
+            'text': {'elements': [{'text_run': {'content': '第一段'}}]},
+        },
+        {
+            'block_id': 'b2', 'block_type': 2, 'parent_id': 'doc-1',
+            'text': {'elements': [{'text_run': {'content': '第二段'}}]},
+        },
+    ]
+
+    with tempfile.TemporaryDirectory() as directory:
+        source = load_artifact_json(
+            _call_document_to_docir(fs, directory)['artifact_path'], WriterDocument)
+        moved_node_id = source.blocks[0].node_id
+        patch_set = PatchSet(target_doc_id=source.document_id, hunks=[PatchHunk(
+            hunk_id='move-b1',
+            target_node_id=moved_node_id,
+            modify_type='move',
+            anchor_node_id=source.blocks[1].node_id,
+            position='after',
+        )])
+        fs.get_doc_blocks.return_value = [
+            {
+                'block_id': 'b2', 'block_type': 2, 'parent_id': 'doc-1',
+                'text': {'elements': [{'text_run': {'content': '第二段'}}]},
+            },
+            {
+                'block_id': 'moved-b1', 'block_type': 2, 'parent_id': 'doc-1',
+                'text': {'elements': [{'text_run': {'content': '第一段'}}]},
+            },
+        ]
+
+        with patch(
+            'lazyllm.tools.fs.client.FS._parse',
+            return_value=('feishu', None, '~docx/doc-1'),
+        ), patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=fs):
+            result = WriterResourceTools(
+                artifact_store=directory).apply_patch_to_document(patch_set, source)
+
+        move_kwargs = fs.move_block.call_args.kwargs
+        assert move_kwargs['source_block_id'] == 'b1'
+        assert move_kwargs['document_revision_id'] == -1
+        persisted = load_artifact_json(
+            result['metadata']['artifact_paths']['persisted_document'], WriterDocument)
+        assert persisted.blocks[1].node_id == moved_node_id
+        assert persisted.blocks[1].provider_binding['block_id'] == 'moved-b1'
+
+
 @pytest.mark.parametrize(
     ('resource', 'expected'),
     [

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -12,6 +12,7 @@ from lazyllm.tools.writer.data_models import (
     WriterBlock,
     WriterConstraints,
     WriterDocument,
+    WriterSpan,
     WritingContext,
     WritingTask,
 )
@@ -96,6 +97,16 @@ def _make_final_writer_document(content='# Local output', title=''):
                 stage='final',
             ),
         ],
+    )
+
+
+def _patch_block(node_id, content):
+    return WriterBlock(
+        node_id=node_id,
+        type='paragraph',
+        content=content,
+        spans=[WriterSpan(text=content)],
+        stage='final',
     )
 
 
@@ -700,15 +711,17 @@ def test_apply_patch_to_document_dispatches_update_and_rereads():
         load_result = _call_document_to_docir(fs, d)
         source = load_artifact_json(load_result['artifact_path'], WriterDocument)
         target = source.blocks[1]
+        revised_target = target.model_copy(deep=True)
+        revised_target.content = '修改后正文'
+        revised_target.spans = [WriterSpan(text='修改后正文')]
         patch_set = PatchSet(
             patch_id='patch-1',
             target_doc_id=source.document_id,
             hunks=[PatchHunk(
-                hunk_id='replace-b2',
+                hunk_id='update-b2',
                 target_node_id=target.node_id,
-                modify_type='replace',
-                old_text='正文',
-                new_text='修改后正文',
+                modify_type='update',
+                block=revised_target,
             )],
         )
         fs.get_doc_blocks.return_value = [
@@ -740,7 +753,7 @@ def test_apply_patch_to_document_dispatches_update_and_rereads():
         patch_result = load_artifact_json(result['artifact_path'], PatchResult)
         persisted_path = result['metadata']['artifact_paths']['persisted_document']
         persisted = load_artifact_json(persisted_path, WriterDocument)
-        assert patch_result.applied_hunks == ['replace-b2']
+        assert patch_result.applied_hunks == ['update-b2']
         assert persisted.blocks[1].content == '修改后正文'
 
 
@@ -756,8 +769,8 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
             hunk_id='move-b1',
             target_node_id=moved_node_id,
             modify_type='move',
-            anchor_node_id=source.blocks[1].node_id,
-            position='after',
+            parent_node_id=None,
+            index=1,
         )])
         first, second = fs.get_doc_blocks.return_value
         fs.get_doc_blocks.return_value = [second, {**first, 'block_id': 'moved-b1'}]
@@ -939,8 +952,8 @@ def test_validate_patch_set_single_hunk():
             result = tool.validate_patch_set(
                 patch_set=_make_patch_set(hunks=[
                     PatchHunk(hunk_id='h1', target_node_id='blk-pro-01',
-                              old_text='万古之前...', new_text='太古之初...',
-                              modify_type='replace'),
+                              block=_patch_block('blk-pro-01', '太古之初...'),
+                              modify_type='update'),
                 ]),
                 context=_make_context(),
                 task=_make_task(),
@@ -964,11 +977,11 @@ def test_validate_patch_set_multi_hunk():
             result = tool.validate_patch_set(
                 patch_set=_make_patch_set(hunks=[
                     PatchHunk(hunk_id='h1', target_node_id='blk-pro-01',
-                              old_text='万古之前...', new_text='太古之初...',
-                              modify_type='replace'),
+                              block=_patch_block('blk-pro-01', '太古之初...'),
+                              modify_type='update'),
                     PatchHunk(hunk_id='h2', target_node_id='blk-pro-02',
-                              old_text='second...', new_text='rewrite...',
-                              modify_type='replace'),
+                              block=_patch_block('blk-pro-02', 'rewrite...'),
+                              modify_type='update'),
                 ]),
                 context=_make_context(),
                 task=_make_task(),
@@ -989,8 +1002,9 @@ def test_validate_patch_set_failing():
             result = tool.validate_patch_set(
                 patch_set=_make_patch_set(hunks=[
                     PatchHunk(hunk_id='h1', target_node_id='blk-pro-01',
-                              old_text='万古之前...', new_text='星辰大帝是九州最强者。',
-                              modify_type='replace'),
+                              block=_patch_block(
+                                  'blk-pro-01', '星辰大帝是九州最强者。'),
+                              modify_type='update'),
                 ]),
                 context=_make_context(),
                 task=_make_task(),

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -747,16 +747,6 @@ def test_apply_patch_to_document_dispatches_update_and_rereads():
 def test_apply_patch_to_document_moves_and_restores_writer_identity():
     pytest.importorskip('fsspec')
     fs = _make_doc_adapter()
-    fs.get_doc_blocks.return_value = [
-        {
-            'block_id': 'b1', 'block_type': 2, 'parent_id': 'doc-1',
-            'text': {'elements': [{'text_run': {'content': '第一段'}}]},
-        },
-        {
-            'block_id': 'b2', 'block_type': 2, 'parent_id': 'doc-1',
-            'text': {'elements': [{'text_run': {'content': '第二段'}}]},
-        },
-    ]
 
     with tempfile.TemporaryDirectory() as directory:
         source = load_artifact_json(
@@ -769,16 +759,8 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
             anchor_node_id=source.blocks[1].node_id,
             position='after',
         )])
-        fs.get_doc_blocks.return_value = [
-            {
-                'block_id': 'b2', 'block_type': 2, 'parent_id': 'doc-1',
-                'text': {'elements': [{'text_run': {'content': '第二段'}}]},
-            },
-            {
-                'block_id': 'moved-b1', 'block_type': 2, 'parent_id': 'doc-1',
-                'text': {'elements': [{'text_run': {'content': '第一段'}}]},
-            },
-        ]
+        first, second = fs.get_doc_blocks.return_value
+        fs.get_doc_blocks.return_value = [second, {**first, 'block_id': 'moved-b1'}]
 
         with patch(
             'lazyllm.tools.fs.client.FS._parse',
@@ -787,9 +769,7 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
             result = WriterResourceTools(
                 artifact_store=directory).apply_patch_to_document(patch_set, source)
 
-        move_kwargs = fs.move_block.call_args.kwargs
-        assert move_kwargs['source_block_id'] == 'b1'
-        assert move_kwargs['document_revision_id'] == -1
+        assert fs.move_block.call_args.kwargs['source_block_id'] == 'b1'
         persisted = load_artifact_json(
             result['metadata']['artifact_paths']['persisted_document'], WriterDocument)
         assert persisted.blocks[1].node_id == moved_node_id

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -1,5 +1,6 @@
 import os
 import tempfile
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,6 +68,15 @@ def _make_doc_adapter():
     return adapter
 
 
+@contextmanager
+def _route_doc_fs(fs, real_path='~docx/doc-1'):
+    with patch(
+        'lazyllm.tools.fs.client.FS._parse',
+        return_value=('feishu', None, real_path),
+    ), patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=fs):
+        yield
+
+
 def _call_document_to_docir(adapter, artifact_store):
     target_document = {
         'uri': 'feishu://~docx/doc-1',
@@ -75,13 +85,9 @@ def _call_document_to_docir(adapter, artifact_store):
         'doc_id': 'doc-1',
     }
 
-    with patch(
-        'lazyllm.tools.fs.client.FS._parse',
-        return_value=('feishu', None, '~docx/doc-1'),
-    ):
-        with patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=adapter):
-            tool = WriterResourceTools(artifact_store=artifact_store)
-            return tool.document_to_docir(target_document=target_document)
+    with _route_doc_fs(adapter):
+        tool = WriterResourceTools(artifact_store=artifact_store)
+        return tool.document_to_docir(target_document=target_document)
 
 
 def _make_final_writer_document(content='# Local output', title=''):
@@ -682,23 +688,27 @@ def test_document_to_docir():
         assert [block.content for block in document.blocks] == ['标题', '正文']
 
 
-def test_write_to_document():
+@pytest.mark.parametrize(
+    ('public_method', 'provider_method'),
+    [
+        ('write_to_document', 'write_doc_blocks'),
+        ('replace_document', 'replace_doc_blocks'),
+    ],
+)
+def test_document_write_modes(public_method, provider_method):
     pytest.importorskip('fsspec')
-    adapter = _make_doc_adapter()
+    fs = _make_doc_adapter()
 
     with tempfile.TemporaryDirectory() as d:
-        with patch(
-            'lazyllm.tools.fs.client.FS._parse',
-            return_value=('feishu', None, '/write-test.md'),
-        ):
-            with patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=adapter):
-                WriterResourceTools(artifact_store=d).write_to_document(
-                    content=_make_final_writer_document(content='world', title='Hello'),
-                    target_document={'uri': 'feishu:///write-test.md', 'adapter': 'feishu'},
-                )
+        with _route_doc_fs(fs, '/write-test.md'):
+            getattr(WriterResourceTools(artifact_store=d), public_method)(
+                content=_make_final_writer_document(content='world', title='Hello'),
+                target_document={'uri': 'feishu:///write-test.md', 'adapter': 'feishu'},
+            )
 
-        adapter.write_doc_blocks.assert_called_once()
-        document_id, blocks = adapter.write_doc_blocks.call_args[0]
+        write_blocks = getattr(fs, provider_method)
+        write_blocks.assert_called_once()
+        document_id, blocks = write_blocks.call_args[0]
         assert document_id == 'doc-1'
         assert blocks[0]['text']['elements'][0]['text_run']['content'] == 'world'
 
@@ -710,51 +720,44 @@ def test_apply_patch_to_document_dispatches_update_and_rereads():
     with tempfile.TemporaryDirectory() as d:
         load_result = _call_document_to_docir(fs, d)
         source = load_artifact_json(load_result['artifact_path'], WriterDocument)
+        source.revision = '12'
         target = source.blocks[1]
-        revised_target = target.model_copy(deep=True)
-        revised_target.content = '修改后正文'
-        revised_target.spans = [WriterSpan(text='修改后正文')]
+        revisions = []
+        for content in ('第一次修改', '第二次修改'):
+            block = target.model_copy(deep=True)
+            block.content, block.spans = content, [WriterSpan(text=content)]
+            revisions.append(block)
         patch_set = PatchSet(
             patch_id='patch-1',
             target_doc_id=source.document_id,
-            hunks=[PatchHunk(
-                hunk_id='update-b2',
-                target_node_id=target.node_id,
-                modify_type='update',
-                block=revised_target,
-            )],
+            hunks=[
+                PatchHunk(hunk_id=f'update-{index}', target_node_id=target.node_id,
+                          modify_type='update', block=block)
+                for index, block in enumerate(revisions, 1)
+            ],
         )
-        fs.get_doc_blocks.return_value = [
-            fs.get_doc_blocks.return_value[0],
-            {
-                'block_id': 'b2',
-                'block_type': 2,
-                'parent_id': 'doc-1',
-                'text': {'elements': [{'text_run': {'content': '修改后正文'}}]},
-                'plain_text': '修改后正文',
-            },
+        first, second = fs.get_doc_blocks.return_value
+        fs.get_doc_blocks.side_effect = [
+            [first, {**second, 'text': {'elements': [{'text_run': {'content': content}}]}}]
+            for content in ('第一次修改', '第二次修改')
+        ]
+        fs.update_block.side_effect = [
+            {'document_revision_id': 13}, {'document_revision_id': 14},
         ]
 
-        with patch(
-            'lazyllm.tools.fs.client.FS._parse',
-            return_value=('feishu', None, '~docx/doc-1'),
-        ):
-            with patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=fs):
-                result = WriterResourceTools(artifact_store=d).apply_patch_to_document(
-                    patch_set=patch_set,
-                    source_document=source,
-                )
-
-        fs.update_block.assert_called_once()
-        update_kwargs = fs.update_block.call_args.kwargs
-        assert update_kwargs['document_id'] == 'doc-1'
-        assert update_kwargs['requests'][0]['block_id'] == 'b2'
+        with _route_doc_fs(fs):
+            result = WriterResourceTools(artifact_store=d).apply_patch_to_document(
+                patch_set=patch_set,
+                source_document=source,
+            )
 
         patch_result = load_artifact_json(result['artifact_path'], PatchResult)
         persisted_path = result['metadata']['artifact_paths']['persisted_document']
         persisted = load_artifact_json(persisted_path, WriterDocument)
-        assert patch_result.applied_hunks == ['update-b2']
-        assert persisted.blocks[1].content == '修改后正文'
+        assert patch_result.applied_hunks == ['update-1', 'update-2']
+        assert [call.kwargs['document_revision_id']
+                for call in fs.update_block.call_args_list] == [12, 13]
+        assert (persisted.blocks[1].content, persisted.revision) == ('第二次修改', '14')
 
 
 def test_apply_patch_to_document_moves_and_restores_writer_identity():
@@ -778,10 +781,7 @@ def test_apply_patch_to_document_moves_and_restores_writer_identity():
             'block_id_relations': {'b1': 'moved-b1'},
         }
 
-        with patch(
-            'lazyllm.tools.fs.client.FS._parse',
-            return_value=('feishu', None, '~docx/doc-1'),
-        ), patch('lazyllm.tools.fs.client.FS._get_or_create_fs', return_value=fs):
+        with _route_doc_fs(fs):
             result = WriterResourceTools(
                 artifact_store=directory).apply_patch_to_document(patch_set, source)
 

--- a/tests/charge_tests/Tools/test_writer_pipeline.py
+++ b/tests/charge_tests/Tools/test_writer_pipeline.py
@@ -311,7 +311,7 @@ def test_revise_workflow_e2e():
     plan = _load_stage(stages, 'modify_plan', ModifyPlan)
     assert {i.target_node_id for i in plan.instructions} == set(locate.target_node_ids)
     for instr in plan.instructions:
-        assert instr.modify_type in {'insert', 'replace', 'delete'}
+        assert instr.modify_type in {'create', 'update', 'delete', 'move'}
         assert instr.instruction.strip()
 
     # --- patch_set ---
@@ -321,13 +321,13 @@ def test_revise_workflow_e2e():
     for block in document.iter_blocks():
         original_text_by_id[block.node_id] = block.content
     for hunk in patch.hunks:
-        assert hunk.anchor is not None and hunk.anchor.node_id == hunk.target_node_id
-        assert hunk.old_text == original_text_by_id[hunk.target_node_id]
-        assert hunk.new_text and hunk.new_text != hunk.old_text, f'new_text is a no-op for {hunk.target_node_id}.'
+        assert hunk.modify_type == 'update'
+        assert hunk.block is not None
+        assert hunk.block.content != original_text_by_id[hunk.target_node_id]
     assert {h.target_node_id for h in patch.hunks} <= {'blk-lang-list', 'blk-deploy'}
-    assert any('rust' in (h.new_text or '').lower() for h in patch.hunks
+    assert any('rust' in (h.block.content if h.block else '').lower() for h in patch.hunks
                if h.target_node_id == 'blk-lang-list'), 'Rust must appear in blk-lang-list patch.'
-    assert any('financial' in (h.new_text or '').lower() for h in patch.hunks
+    assert any('financial' in (h.block.content if h.block else '').lower() for h in patch.hunks
                if h.target_node_id == 'blk-deploy'), 'financial must appear in blk-deploy patch.'
 
     # --- patch_review ---


### PR DESCRIPTION
## 改动内容

### 写作能力

- 将 Writer 修改操作统一为 `create`、`update`、`delete` 和 `move`，`PatchHunk` 直接携带完整 `WriterBlock`、父节点和索引，支持对 Block 类型、内容、Span、编号、引用和子树结构进行一致修改。
- 重构 `WriterRevisionTools`，由模型生成修改后的完整 `WriterDocument`，再根据修改前后的文档确定性生成 PatchSet，并校验 document id、stage、revision、provider binding 以及不可编辑 Block 等约束。
- 扩展标题修改链路，`LocateResult`、`ModifyPlan` 和 `PatchSet` 支持标题定位、标题修改指令和 `new_title`，平台写回时同步更新文档标题。
- 统一 Writer IR 的可见内容表达，移除重复字段和兼容分支，并同步调整 drafting、planning、quality 和 revision prompts。
- 抽取通用 `render_document_markdown`，由 Writer drafting 和其他调用方共享文档 Markdown 渲染逻辑，避免重复实现。

### 飞书文档能力

- 完整实现 Feishu Adapter 对 `create`、`update`、`delete` 和 `move` 的转换；当 Block 类型发生变化时使用安全 replace，并在平台写回后合并新旧 Block ID、authoring 和 references。
- 扩展 FeishuFS 的 Block 操作，支持带 revision 的创建、文本更新、整块替换、删除和跨层级移动，并在移动/替换时复制完整子树、校验内容和层级关系、失败时回滚目标副本。
- 新增飞书 Docx 子树序列化与克隆工具，统一 Block 类型映射、descendant payload 生成和不可写字段规范化，并在写回结果中返回被规范化的字段。
- 新增空文档创建和发布能力，支持在飞书云盘目录或知识库节点下创建文档，并返回内部 URI、浏览器链接、space id、node token 等标准化 TargetDocument 信息。
- 扩展 `WriterResourceTools`，新增 `create_document`、`append_to_document` 和 `replace_document`；保留 `write_to_document` 作为追加写入的兼容入口。
- 调整飞书根路径路由，显式使用运行时 `feishu_wiki_space_id` 判断默认写入云盘还是知识库，并补齐对应测试。

### 稳定性与兼容性

- 平台 Patch 按 hunk 逐步写回并重新读取文档，保留 Writer 元数据，同时根据平台返回的 Block ID relations 恢复稳定的 Writer node id。
- 为 create、replace、delete、move 统一传递 `document_revision_id`，降低并发修改时使用过期文档状态的风险。
- 补充并精简 WriterRevisionTools、Feishu Adapter、FeishuFS URL 路由和 WriterResourceTools 测试，覆盖完整 Block 修改、文档创建、追加/替换写入以及异常回滚路径。

## 验证

- `python -m pytest tests/basic_tests/Tools/test_writer_data_model.py tests/basic_tests/Tools/test_writer_revision_tools.py tests/basic_tests/Tools/test_writer_adapter.py tests/basic_tests/Tools/test_writer_tools.py tests/basic_tests/Tools/test_feishu_fs_url.py -q`
- 结果：132 passed。

## 后续补充

- 使用真实飞书云盘和知识库文档，对创建文档、追加/替换整文以及四种 Block 操作进行端到端验证。
- 继续补充复杂表格、Grid、Callout、Mention、附件等飞书 Block 在跨层级移动和类型替换时的兼容性验证。
- 基于 provider revision 完善并发写入冲突检测，并补充部分成功、回滚失败和结果不确定场景的可观测信息。
