### PR TITLE
refactor(writer): simplify Writer IR and omit default fields

### DIFF
--- a/lazyllm/docs/tools/tool_writer.py
+++ b/lazyllm/docs/tools/tool_writer.py
@@ -154,14 +154,6 @@ add_writer_models_english_doc('PatchHunk.validate_operation', '''
 Validate the fields required by each patch operation.
 ''')
 
-add_writer_models_chinese_doc('WriterConstraints.validate_word_range', '''
-校验最小和最大字数限制。
-''')
-
-add_writer_models_english_doc('WriterConstraints.validate_word_range', '''
-Validate the minimum and maximum word count constraints.
-''')
-
 add_writer_adapter_chinese_doc('FeishuWriterAdapter.merge_refreshed_document', '''
 将刷新的飞书绑定信息合并到修订后的文档。
 ''')

--- a/lazyllm/tools/writer/adapter/feishu.py
+++ b/lazyllm/tools/writer/adapter/feishu.py
@@ -274,7 +274,6 @@ class FeishuWriterAdapter(WriterAdapterBase):
             previous = previous_blocks.get(block.node_id)
             if previous is None:
                 continue
-            block.authoring = deepcopy(previous.authoring)
             block.references = deepcopy(previous.references)
         return WriterDocument.model_validate(refreshed_document.model_dump())
 

--- a/lazyllm/tools/writer/data_models/__init__.py
+++ b/lazyllm/tools/writer/data_models/__init__.py
@@ -12,7 +12,7 @@ from .planning import SectionInstruction, SectionInstructionList
 from .revision import LocateResult, ModifyInstruction, ModifyPlan, PatchHunk, PatchResult, PatchSet
 from .multimodal import MediaAsset, MediaAssetLibrary, VisualInstruction
 from .quality import AuditIssue, AuditResult, ReviewReport
-from .writer_ir import WriterAuthoring, WriterBlock, WriterConstraints, WriterDocument, WriterSpan, WriterStage
+from .writer_ir import WriterBlock, WriterDocument, WriterSpan, WriterStage
 
 __all__ = [
     'InputResource',
@@ -41,9 +41,7 @@ __all__ = [
     'AuditIssue',
     'AuditResult',
     'ReviewReport',
-    'WriterAuthoring',
     'WriterBlock',
-    'WriterConstraints',
     'WriterDocument',
     'WriterSpan',
     'WriterStage',

--- a/lazyllm/tools/writer/data_models/writer_ir.py
+++ b/lazyllm/tools/writer/data_models/writer_ir.py
@@ -2,56 +2,13 @@ from __future__ import annotations
 
 from typing import Any, Dict, Iterable, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 
 WriterStage = Literal['outline', 'draft', 'final']
 
-WRITER_BLOCK_MUTABLE_FIELDS = ('type', 'content', 'spans', 'stage', 'authoring', 'numbering', 'references')
+WRITER_BLOCK_MUTABLE_FIELDS = ('type', 'content', 'spans', 'stage', 'numbering', 'references')
 WRITER_BLOCK_PROVIDER_MANAGED_FIELDS = ('provider_binding', 'provider_payload', 'editable')
-
-
-class WriterConstraints(BaseModel):
-    '''Authoring requirements attached to a document block across all stages.'''
-
-    model_config = ConfigDict(extra='forbid')
-
-    section_goal: Optional[str] = None
-    required_points: List[str] = Field(default_factory=list)
-    fact_constraints: List[str] = Field(default_factory=list)
-    style_constraints: List[str] = Field(default_factory=list)
-    relation_constraints: List[str] = Field(default_factory=list)
-    min_words: Optional[int] = None
-    max_words: Optional[int] = None
-    pov: Optional[str] = None
-    tone: Optional[str] = None
-    must_include: List[str] = Field(default_factory=list)
-    must_avoid: List[str] = Field(default_factory=list)
-
-    @model_validator(mode='after')
-    def validate_word_range(self) -> 'WriterConstraints':
-        if self.min_words is not None and self.min_words < 0:
-            raise ValueError('min_words must be non-negative')
-        if self.max_words is not None and self.max_words < 0:
-            raise ValueError('max_words must be non-negative')
-        if (
-            self.min_words is not None and self.max_words is not None
-            and self.min_words > self.max_words
-        ):
-            raise ValueError('min_words cannot exceed max_words')
-        return self
-
-
-class WriterAuthoring(BaseModel):
-    '''Planning and execution metadata that does not belong to visible content.'''
-
-    # Provider/plugin extensions may add namespaced fields while the common contract
-    # above remains validated.
-    model_config = ConfigDict(extra='allow')
-    instruction_id: Optional[str] = None
-    origin_node_id: Optional[str] = None
-    constraints: WriterConstraints = Field(default_factory=WriterConstraints)
-    meta: Dict[str, Any] = Field(default_factory=dict)
 
 
 class WriterSpan(BaseModel):
@@ -70,7 +27,6 @@ class WriterBlock(BaseModel):
     spans: List[WriterSpan] = Field(default_factory=list)
     children: List['WriterBlock'] = Field(default_factory=list)
     stage: WriterStage
-    authoring: Optional[WriterAuthoring] = None
     numbering: Dict[str, Any] = Field(default_factory=dict)
     references: List[Dict[str, Any]] = Field(default_factory=list)
     # Provider-neutral binding contract. Common keys are provider, uri, document_id,
@@ -141,6 +97,5 @@ WriterDocument.model_rebuild()
 
 __all__ = [
     'WriterDocument', 'WriterBlock', 'WriterSpan', 'WriterStage',
-    'WriterConstraints', 'WriterAuthoring',
     'WRITER_BLOCK_MUTABLE_FIELDS', 'WRITER_BLOCK_PROVIDER_MANAGED_FIELDS',
 ]

--- a/lazyllm/tools/writer/prompts/drafting.py
+++ b/lazyllm/tools/writer/prompts/drafting.py
@@ -20,7 +20,7 @@ Requirements:
 - Do not invent facts that conflict with the writing context.
 - If previous_blocks are provided, keep continuity and avoid repeating their content.
 - Fill node_id for the section root and for each child (e.g. draft-<node>-1). The system will normalize ids if needed.
-- Leave spans, authoring, references, provider_binding and provider_payload empty.
+- Omit spans, references, provider_binding and provider_payload; the system manages them.
 
 Writing task:
 {task_json}

--- a/lazyllm/tools/writer/prompts/planning.py
+++ b/lazyllm/tools/writer/prompts/planning.py
@@ -9,26 +9,15 @@ Requirements:
 - All user-visible outline text MUST use the same document tree contract as draft and final content:
   put section titles in heading block.content, and put section descriptions and key points in
   paragraph or list_item blocks under block.children.
-- block.authoring is only for non-visible planning and execution metadata.
 - Fill node_id for every block. Use stable ids such as section-1, section-2, section-1-1.
 - Use block.numbering.level for the heading level: 1 for top-level sections, incrementing for children.
   Put child sections under block.children as heading blocks alongside any visible description blocks.
-- Constraints live in block.authoring.constraints and may only use the fields defined by WriterConstraints:
-  section_goal, required_points, fact_constraints, style_constraints, relation_constraints,
-  min_words, max_words, pov, tone, must_include, must_avoid.
-- Do not invent other constraints fields. Fill only the fields useful for the section.
 - block.references holds identifiers for facts or resources the section depends on.
 - Each element of block.references is an object with at least an "id" field. The id must match a
-  DocumentFact.fact_id or ResourceProfile.resource_id present in the input. Additional fields are allowed.
-- references is a WriterBlock field only. Never put references inside block.authoring or
-  block.authoring.constraints.
-- fact_constraints contains the literal factual statements that the section must preserve. Do not put
-  fact IDs or resource IDs in fact_constraints; identifiers belong only in references.
-- Every fact_constraints statement must be grounded in the writing context. If no factual statement
-  applies to a section, leave fact_constraints empty.
+  DocumentFact.fact_id or ResourceProfile.resource_id present in the input.
 - Prefer the target document title or task intent as document.title.
 - Use the writing context and resource profiles as constraints, not as content to copy blindly.
-- Leave spans, provider_binding and provider_payload empty; the system manages them.
+- Omit spans, provider_binding and provider_payload; the system manages them.
 
 Writing task:
 {task_json}
@@ -59,7 +48,7 @@ Requirements:
 - fact_constraints should preserve the literal text of locked facts and important context facts
   relevant to this section. It must not contain fact IDs or resource IDs.
 - fact_constraints MUST only contain factual statements actually present in the writing context.
-- references are owned by the authoritative outline. Leave references empty; the system copies them from
+- references are owned by the authoritative outline. Omit references; the system copies them from
   the matching outline block.
 - style_constraints should include tone, pov, audience, and style requirements when applicable.
 - relation_constraints should describe dependencies on previous or later sections when useful.

--- a/lazyllm/tools/writer/prompts/structured_output.py
+++ b/lazyllm/tools/writer/prompts/structured_output.py
@@ -10,4 +10,5 @@ Schema:
 {schema_json}
 
 If the input is incomplete, infer reasonable values from the available context. Do not omit required fields.
+Omit fields whose values equal their schema defaults.
 '''

--- a/lazyllm/tools/writer/tools/base.py
+++ b/lazyllm/tools/writer/tools/base.py
@@ -70,7 +70,7 @@ class WriterToolBase(ModuleBase):
         if isinstance(value, str):
             return self._load_artifact(value, validate_schema=False)
         if isinstance(value, BaseModel):
-            return value.model_dump()
+            return value.model_dump(exclude_defaults=True)
         return value
 
     def _write_single_artifact(

--- a/lazyllm/tools/writer/tools/drafting_tools.py
+++ b/lazyllm/tools/writer/tools/drafting_tools.py
@@ -5,11 +5,7 @@ from typing import Any, List, Optional
 from .base import WriterToolBase
 from ..data_models.context import WritingContext
 from ..data_models.task import WritingTask
-from ..data_models.writer_ir import (
-    WriterAuthoring,
-    WriterBlock,
-    WriterDocument,
-)
+from ..data_models.writer_ir import WriterBlock, WriterDocument
 from ..data_models.planning import SectionInstruction, SectionInstructionList
 from ..prompts import GENERATE_DRAFT_SECTION_PROMPT
 from ..utils import render_document_markdown, to_prompt_json
@@ -232,22 +228,11 @@ class WriterDraftingTools(WriterToolBase):
             if not child.type.strip():
                 child.type = 'paragraph'
 
-        authoring_meta = {}
-        for key in ('outline_id', 'outline_title'):
-            value = instruction.meta.get(key)
-            if value is not None:
-                authoring_meta[key] = value
-        draft_block.authoring = WriterAuthoring(
-            instruction_id=instruction.instruction_id,
-            origin_node_id=instruction.outline_node_id,
-            meta=authoring_meta,
-        )
-
         draft_block.references = [dict(reference) for reference in instruction.references]
         return draft_block
 
     def _default_section_node_id(self, instruction: SectionInstruction) -> str:
-        return f'draft-{instruction.outline_node_id}'
+        return instruction.outline_node_id
 
     def _unified_draft_blocks(self, value: Any) -> List[WriterBlock]:
         if value is None:
@@ -353,8 +338,6 @@ class WriterDraftingTools(WriterToolBase):
             context.meta.get('title') if context.meta else None,
             context.meta.get('document_title') if context.meta else None,
             context.meta.get('outline_title') if context.meta else None,
-            self._first_block_authoring_meta(blocks, 'document_title'),
-            self._first_block_authoring_meta(blocks, 'outline_title'),
         )
         if title:
             return str(title)
@@ -370,17 +353,6 @@ class WriterDraftingTools(WriterToolBase):
             total += len(block.children)
             total += self._count_draft_blocks(block.children)
         return total
-
-    def _first_block_authoring_meta(self, blocks: List[WriterBlock], key: str) -> Any:
-        for block in blocks:
-            if block.authoring and block.authoring.meta:
-                value = block.authoring.meta.get(key)
-                if value:
-                    return value
-            child_value = self._first_block_authoring_meta(block.children, key)
-            if child_value:
-                return child_value
-        return None
 
     def _first_non_empty(self, *values: Any) -> Any:
         for value in values:

--- a/lazyllm/tools/writer/tools/planning_tools.py
+++ b/lazyllm/tools/writer/tools/planning_tools.py
@@ -5,12 +5,7 @@ from .base import WriterToolBase
 from ..data_models.context import WritingContext
 from ..data_models.resource import ResourceProfile
 from ..data_models.task import WritingTask
-from ..data_models.writer_ir import (
-    WriterAuthoring,
-    WriterBlock,
-    WriterConstraints,
-    WriterDocument,
-)
+from ..data_models.writer_ir import WriterBlock, WriterDocument
 from ..data_models.planning import SectionInstruction, SectionInstructionList
 from ..prompts import GENERATE_OUTLINE_PROMPT, GENERATE_SECTION_INSTRUCTIONS_PROMPT
 from ..utils import to_prompt_json
@@ -125,14 +120,12 @@ class WriterPlanningTools(WriterToolBase):
         outline.title = outline.title or self._default_outline_title(task)
         outline.ui_editable = False
         valid_reference_ids = self._valid_reference_ids(context, profiles)
-        has_available_facts = self._has_available_facts(context, profiles)
         for index, block in enumerate(outline.blocks, start=1):
             self._normalize_outline_block(
                 block,
                 level=1,
                 fallback_id=f'section-{index}',
                 valid_reference_ids=valid_reference_ids,
-                has_available_facts=has_available_facts,
             )
 
         outline.metadata.setdefault('source', 'llm')
@@ -145,19 +138,13 @@ class WriterPlanningTools(WriterToolBase):
         level: int,
         fallback_id: str,
         valid_reference_ids: set[str],
-        has_available_facts: bool,
     ) -> None:
         block.stage = 'outline'
         if not block.type.strip():
             block.type = 'heading'
         block.node_id = block.node_id or fallback_id
         block.numbering['level'] = level
-        if block.authoring is None:
-            block.authoring = WriterAuthoring()
-
         block.references = self._filter_references(block.references, valid_reference_ids)
-        if not has_available_facts:
-            block.authoring.constraints.fact_constraints = []
 
         for index, child in enumerate(block.children, start=1):
             self._normalize_outline_block(
@@ -165,7 +152,6 @@ class WriterPlanningTools(WriterToolBase):
                 level=level + 1,
                 fallback_id=f'{block.node_id}-{index}',
                 valid_reference_ids=valid_reference_ids,
-                has_available_facts=has_available_facts,
             )
 
     def _default_outline_id(self, task: WritingTask, context: WritingContext) -> str:
@@ -245,8 +231,6 @@ class WriterPlanningTools(WriterToolBase):
         outline: WriterDocument,
         has_available_facts: bool,
     ) -> SectionInstruction:
-        block_constraints = block.authoring.constraints if block.authoring else WriterConstraints()
-
         if not instruction.instruction_id.strip():
             raise ValueError(f'Section instruction for {block.node_id!r} has an empty instruction_id.')
         if not instruction.section_goal.strip():
@@ -255,21 +239,13 @@ class WriterPlanningTools(WriterToolBase):
         instruction.section_title = block.content
         instruction.references = [dict(reference) for reference in block.references]
         if not instruction.required_points:
-            instruction.required_points = list(block_constraints.required_points)
-        if not instruction.fact_constraints:
-            instruction.fact_constraints = list(block_constraints.fact_constraints)
+            instruction.required_points = [
+                child.content for child in block.children if child.content
+            ]
         if not has_available_facts:
             instruction.fact_constraints = []
-        if not instruction.style_constraints:
-            instruction.style_constraints = list(block_constraints.style_constraints)
-            if block_constraints.pov:
-                instruction.style_constraints.append(f'POV: {block_constraints.pov}')
-            if block_constraints.tone:
-                instruction.style_constraints.append(f'Tone: {block_constraints.tone}')
-        if not instruction.relation_constraints:
-            instruction.relation_constraints = list(block_constraints.relation_constraints)
         if not instruction.expected_blocks:
-            instruction.expected_blocks = self._default_expected_blocks(block, block_constraints)
+            instruction.expected_blocks = self._default_expected_blocks(block)
 
         instruction.meta.update(
             {
@@ -283,11 +259,11 @@ class WriterPlanningTools(WriterToolBase):
     def _default_expected_blocks(
         self,
         block: WriterBlock,
-        constraints: WriterConstraints,
     ) -> List[str]:
         blocks = [block.content] if block.content else []
-        if constraints.required_points:
-            blocks.extend(constraints.required_points[:3])
+        blocks.extend(
+            child.content for child in block.children[:3] if child.content
+        )
         return blocks
 
     def _valid_reference_ids(

--- a/lazyllm/tools/writer/tools/quality_tools.py
+++ b/lazyllm/tools/writer/tools/quality_tools.py
@@ -189,21 +189,13 @@ class WriterQualityTools(WriterToolBase):
         draft_block: WriterBlock,
         instruction_list: SectionInstructionList,
     ) -> Optional[SectionInstruction]:
-        draft_authoring = draft_block.authoring
-        instruction_id = draft_authoring.instruction_id if draft_authoring else None
-        origin_node_id = draft_authoring.origin_node_id if draft_authoring else None
-
-        if instruction_id:
-            for instruction in instruction_list.instructions:
-                if instruction.instruction_id == instruction_id:
-                    return instruction
-
-        if origin_node_id:
-            for instruction in instruction_list.instructions:
-                if instruction.outline_node_id == origin_node_id:
-                    return instruction
-
-        return None
+        return next(
+            (
+                instruction for instruction in instruction_list.instructions
+                if instruction.outline_node_id == draft_block.node_id
+            ),
+            None,
+        )
 
     def _issue_counts(self, audit_result: AuditResult) -> dict:
         return {

--- a/lazyllm/tools/writer/utils/artifact.py
+++ b/lazyllm/tools/writer/utils/artifact.py
@@ -44,7 +44,7 @@ def _infer_schema_name(obj: Any) -> str:
 
 def _to_json_data(obj: Any) -> Any:
     if isinstance(obj, BaseModel):
-        return obj.model_dump()
+        return obj.model_dump(exclude_defaults=True)
     return obj
 
 

--- a/lazyllm/tools/writer/utils/serialization.py
+++ b/lazyllm/tools/writer/utils/serialization.py
@@ -8,7 +8,7 @@ from ..data_models.writer_ir import WriterBlock, WriterDocument
 def to_prompt_json(value: Any) -> str:
     def default(obj: Any) -> Any:
         if hasattr(obj, 'model_dump'):
-            return obj.model_dump()
+            return obj.model_dump(exclude_defaults=True)
         return str(obj)
 
     return json.dumps(value, ensure_ascii=False, indent=2, default=default)

--- a/tests/basic_tests/Tools/test_writer_data_model.py
+++ b/tests/basic_tests/Tools/test_writer_data_model.py
@@ -4,9 +4,7 @@ import tempfile
 
 from lazyllm.tools.writer.data_models import (
     ResourceProfile,
-    WriterAuthoring,
     WriterBlock,
-    WriterConstraints,
     WriterDocument,
     WriterSpan,
     WritingContext,
@@ -35,10 +33,6 @@ def _make_writer_document():
         content='第一章',
         stage='draft',
         numbering={'level': 1},
-        authoring=WriterAuthoring(
-            instruction_id='instruction-1',
-            constraints=WriterConstraints(section_goal='介绍背景'),
-        ),
         children=[paragraph],
     )
     return WriterDocument(

--- a/tests/basic_tests/Tools/test_writer_tools.py
+++ b/tests/basic_tests/Tools/test_writer_tools.py
@@ -9,9 +9,7 @@ from lazyllm.tools.writer.data_models import (
     DocumentSummary,
     MaterialStyle,
     ResourceProfile,
-    WriterAuthoring,
     WriterBlock,
-    WriterConstraints,
     WriterDocument,
     WriterSpan,
     WritingContext,
@@ -147,14 +145,10 @@ def _make_section_instruction_list():
 
 def _make_quality_draft_block():
     return WriterBlock(
-        node_id='sec-prologue',
+        node_id='prologue',
         type='heading',
         content='楔子 · 星辰陨落',
         stage='draft',
-        authoring=WriterAuthoring(
-            instruction_id='si-prologue',
-            origin_node_id='prologue',
-        ),
         children=[
             WriterBlock(
                 node_id='blk-pro-01',
@@ -595,11 +589,6 @@ def test_generate_section_instructions_preserves_outline_references():
                 content='第一节',
                 stage='outline',
                 references=references,
-                authoring=WriterAuthoring(
-                    constraints=WriterConstraints(
-                        fact_constraints=['未在上下文中出现的事实'],
-                    ),
-                ),
             )
         ],
     )
@@ -871,7 +860,7 @@ def test_validate_section_happy_path():
         report = load_artifact_json(result['artifact_path'], ReviewReport)
         assert result['metadata']['step_name'] == 'validate_section'
         assert report.result.is_passed is True
-        assert report.target == 'sec-prologue'
+        assert report.target == 'prologue'
         assert report.meta['instruction_id'] == 'si-prologue'
         assert report.meta['outline_node_id'] == 'prologue'
 


### PR DESCRIPTION
## 改动内容

### 统一 Writer IR

- 删除 `WriterAuthoring` 和 `WriterConstraints`，移除对应导出、文档、Prompt、Adapter 合并逻辑及测试依赖，避免 Outline 引入正文和飞书文档不存在的特殊字段。
- Outline、Draft 和 Final 继续统一使用 `WriterDocument` / `WriterBlock`；章节说明和关键点改为普通子 Block 表达，不再存入隐藏 authoring 元数据。
- Draft 章节根节点沿用对应 Outline 的 `node_id`，Quality Tools 直接通过 `draft_block.node_id == instruction.outline_node_id` 匹配章节指令，不再依赖 `instruction_id` 和 `origin_node_id`。
- SectionInstruction 的默认要点和预期 Block 从 Outline 的可见子 Block 提取，保留规划与成稿间的章节约束传递。

### 模型输出与序列化

- Writer 模型输入、Artifact 保存和工具间 BaseModel 转换统一使用 `model_dump(exclude_defaults=True)`，省略空列表、空对象、`None` 和其他默认值。
- Structured Output Prompt 明确要求模型省略等于 Schema 默认值的字段，降低 WriterDocument JSON 长度和模型生成开销。
- Outline、SectionInstruction 和 Draft Prompt 改为省略系统管理字段，不再要求模型显式生成空 `spans`、`references`、`provider_binding` 和 `provider_payload`。

### 兼容性调整

- Feishu Adapter 刷新文档时不再读写已删除的 authoring，仅继续保留 Writer references。
- 同步调整 Writer 数据模型、Planning、Drafting、Quality 及相关测试，保持现有 Outline、Draft、Final 和飞书写回链路使用同一套 IR。

## 验证

- `git diff --check`
- `python3 -m pytest -q tests/basic_tests/Tools/test_writer_data_model.py tests/basic_tests/Tools/test_writer_tools.py`
- 结果：48 passed。