### PR TITLE
Persist ReAct round budgets in tool results

### DIFF
--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -156,7 +156,10 @@ class FunctionCall(ModuleBase):
                 f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
             )
             budget_message = {'role': 'system', 'content': f'Internal ReAct rounds left: {remaining_rounds}.'}
-            chat_history = [budget_message, *chat_history]
+            if isinstance(input, dict) and isinstance(input.get('input'), list):
+                input = {**input, 'input': [*input['input'], budget_message]}
+            else:
+                chat_history = [*chat_history, budget_message]
         locals['chat_history'][self._llm._module_id] = chat_history
         return input
 

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -115,6 +115,21 @@ class FunctionCall(ModuleBase):
     def _build_history(self, input: Union[str, dict, list]):
         workspace = locals['_lazyllm_agent']['workspace']
         history_idx = len(workspace.setdefault('history', []))
+        budget_notice = None
+        if self._round_limit is not None:
+            current_round = int(workspace.get('_react_round_number', 0)) + 1
+            workspace['_react_round_number'] = current_round
+            round_limit = int(workspace.get('_react_round_limit', self._round_limit))
+            remaining_rounds = max(0, round_limit - current_round)
+            LOG.info(
+                f'[ReactAgent] [ROUND_BUDGET] sid={lazyllm_globals._sid} current_round={current_round} '
+                f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
+            )
+            budget_notice = (
+                f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}. '
+                'Finish the task or provide a concise final summary before the limit.'
+            )
+
         if isinstance(input, str):
             workspace['history'].append({'role': 'user', 'content': input})
         elif isinstance(input, dict) and 'input' in input:
@@ -134,6 +149,11 @@ class FunctionCall(ModuleBase):
                     'name': tool_call['function']['name'],
                 } for tool_call in workspace['tool_call_trace']
             ]
+            if budget_notice and tool_call_results:
+                tool_call_results[-1] = {
+                    **tool_call_results[-1],
+                    'content': f'{tool_call_results[-1]["content"]}\n\n{budget_notice}',
+                }
             workspace['history'].append({
                 'role': 'assistant',
                 'content': input.get('content', ''),
@@ -146,20 +166,6 @@ class FunctionCall(ModuleBase):
         chat_history = workspace['history'][:history_idx]
         if self._keep_full_turns > 0:
             chat_history = _compact_chat_history(chat_history, self._keep_full_turns)
-        if self._round_limit is not None:
-            current_round = int(workspace.get('_react_round_number', 0)) + 1
-            workspace['_react_round_number'] = current_round
-            round_limit = int(workspace.get('_react_round_limit', self._round_limit))
-            remaining_rounds = max(0, round_limit - current_round)
-            LOG.info(
-                f'[ReactAgent] [ROUND_BUDGET] sid={lazyllm_globals._sid} current_round={current_round} '
-                f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
-            )
-            budget_message = {'role': 'system', 'content': f'Internal ReAct rounds left: {remaining_rounds}.'}
-            if isinstance(input, dict) and isinstance(input.get('input'), list):
-                input = {**input, 'input': [*input['input'], budget_message]}
-            else:
-                chat_history = [*chat_history, budget_message]
         locals['chat_history'][self._llm._module_id] = chat_history
         return input
 

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -125,10 +125,7 @@ class FunctionCall(ModuleBase):
                 f'[ReactAgent] [ROUND_BUDGET] sid={lazyllm_globals._sid} current_round={current_round} '
                 f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
             )
-            budget_notice = (
-                f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}. '
-                'Finish the task or provide a concise final summary before the limit.'
-            )
+            budget_notice = f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
 
         if isinstance(input, str):
             workspace['history'].append({'role': 'user', 'content': input})

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -388,11 +388,9 @@ class TestReactAgentEvents(object):
             for input_value in llm.inputs[1:]
         ] == [
             '2\n\n'
-            '[Internal runtime notice] Internal ReAct rounds left: 2. '
-            'Finish the task or provide a concise final summary before the limit.',
+            '[Internal runtime notice] Internal ReAct rounds left: 2.',
             '3\n\n'
-            '[Internal runtime notice] Internal ReAct rounds left: 1. '
-            'Finish the task or provide a concise final summary before the limit.',
+            '[Internal runtime notice] Internal ReAct rounds left: 1.',
         ]
         persisted_history = lazyllm.locals['_lazyllm_agent']['history']
         persisted_budget_queries = [
@@ -434,8 +432,7 @@ class TestReactAgentEvents(object):
         assert tool_message['role'] == 'tool'
         assert tool_message['content'] == (
             f'{str({"status": "ok", "content": "Error handling reference"})}\n\n'
-            '[Internal runtime notice] Internal ReAct rounds left: 2. '
-            'Finish the task or provide a concise final summary before the limit.'
+            '[Internal runtime notice] Internal ReAct rounds left: 2.'
         )
 
     def test_react_agent_stream_emits_text_reasoning_and_tool_events(self):

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -182,13 +182,16 @@ class TestReactAgentEvents(object):
         )
         assert continuation_agent('continue') == 'Finished after the follow-up continuation.'
         continuation_history = continuation_llm.budget_histories[0]
-        assert any(message.get('content') == 'complete all steps' for message in continuation_history)
-        continuation_budget = next(
-            message['content']
+        assert any(
+            message.get('content', '').startswith('complete all steps')
             for message in continuation_history
-            if message.get('content', '').startswith('Internal ReAct rounds left:')
         )
-        assert continuation_budget == 'Internal ReAct rounds left: 1.'
+        assert continuation_llm.inputs[0] == 'continue'
+        assert any(
+            'Internal ReAct rounds left: 0.' in str(message.get('content', ''))
+            for message in continuation_history
+        )
+        assert not any(message.get('role') == 'system' for message in continuation_history)
 
     def test_react_agent_summarizes_when_round_limit_callback_declines_expansion(self):
         llm = _SharedCursorLLM([
@@ -264,7 +267,7 @@ class TestReactAgentEvents(object):
         assert agent('complete all steps') == 'Finished after explicit continuation.'
         assert limit_calls == [(2, 2)]
 
-    def test_react_agent_injects_ephemeral_dynamic_round_budget(self):
+    def test_react_agent_persists_dynamic_round_budget_in_tool_result(self):
         llm = _BudgetRecordingLLM([
             {
                 'role': 'assistant',
@@ -298,25 +301,109 @@ class TestReactAgentEvents(object):
         result = agent('complete all steps')
 
         assert result == 'Finished within the expanded budget.'
-        budget_messages = [
-            next(
-                message['content']
-                for message in history
-                if message.get('role') == 'system'
-                and message.get('content', '').startswith('Internal ReAct rounds left:')
-            )
+        input_snapshots = [json.dumps(value) for value in llm.inputs]
+        assert 'Internal ReAct rounds left:' not in input_snapshots[0]
+        assert 'Internal ReAct rounds left: 0.' in input_snapshots[1]
+        assert 'Internal ReAct rounds left: 1.' in input_snapshots[2]
+        assert all(
+            '"role": "system"' not in json.dumps(history)
             for history in llm.budget_histories
-        ]
-        assert budget_messages == [
-            'Internal ReAct rounds left: 1.',
-            'Internal ReAct rounds left: 0.',
-            'Internal ReAct rounds left: 1.',
-        ]
+        )
         persisted_history = lazyllm.locals['_lazyllm_agent']['history']
-        assert 'Internal ReAct rounds left:' not in json.dumps(persisted_history)
+        persisted_snapshot = json.dumps(persisted_history)
+        assert [
+            f'Internal ReAct rounds left: {remaining}.' in persisted_snapshot
+            for remaining in [0, 1]
+        ] == [True, True]
+        assert sum(
+            'Internal ReAct rounds left:' in str(message.get('content', ''))
+            for message in persisted_history
+        ) == 2
+        assert all(
+            notice in persisted_snapshot
+            for notice in [
+                '[Internal runtime notice] Internal ReAct rounds left: 1.',
+                '[Internal runtime notice] Internal ReAct rounds left: 0.',
+            ]
+        )
         assert 'Internal ReAct rounds left:' not in result
         events = _read_agent_events()
         assert 'Internal ReAct rounds left:' not in json.dumps([vars(event) for event in events])
+
+        for input_value in llm.inputs:
+            if isinstance(input_value, dict):
+                invocation_messages = input_value.get('input', [])
+                assert invocation_messages
+                assert all(message['role'] == 'tool' for message in invocation_messages)
+        assert [
+            message['content']
+            for message in persisted_history
+            if 'Internal ReAct rounds left:' in str(message.get('content', ''))
+        ] == [
+            llm.inputs[1]['input'][-1]['content'],
+            llm.inputs[2]['input'][-1]['content'],
+        ]
+
+    def test_react_agent_appends_round_budget_to_last_tool_result(self):
+        llm = _BudgetRecordingLLM([
+            {
+                'role': 'assistant',
+                'content': 'First step.',
+                'tool_calls': [{
+                    'id': 'call-1',
+                    'type': 'function',
+                    'function': {'name': 'add_one', 'arguments': '{"value": 1}'},
+                }],
+            },
+            {
+                'role': 'assistant',
+                'content': 'Second step.',
+                'tool_calls': [{
+                    'id': 'call-2',
+                    'type': 'function',
+                    'function': {'name': 'add_one', 'arguments': '{"value": 2}'},
+                }],
+            },
+            {'role': 'assistant', 'content': 'Finished before the limit.'},
+        ])
+        agent = ReactAgent(
+            llm=llm,
+            tools=[add_one],
+            max_retries=3,
+            stream=False,
+            enable_builtin_tools=False,
+        )
+
+        assert agent('complete all steps') == 'Finished before the limit.'
+        assert len(llm.budget_histories) == 3
+        invocation_snapshots = [
+            json.dumps({'history': history, 'input': input_value})
+            for history, input_value in zip(llm.budget_histories, llm.inputs)
+        ]
+        assert 'Internal ReAct rounds left:' not in invocation_snapshots[0]
+        assert 'Internal ReAct rounds left: 2.' in invocation_snapshots[1]
+        assert 'Internal ReAct rounds left: 1.' in invocation_snapshots[2]
+        assert [
+            input_value['input'][-1]['content']
+            for input_value in llm.inputs[1:]
+        ] == [
+            '2\n\n'
+            '[Internal runtime notice] Internal ReAct rounds left: 2. '
+            'Finish the task or provide a concise final summary before the limit.',
+            '3\n\n'
+            '[Internal runtime notice] Internal ReAct rounds left: 1. '
+            'Finish the task or provide a concise final summary before the limit.',
+        ]
+        persisted_history = lazyllm.locals['_lazyllm_agent']['history']
+        persisted_budget_queries = [
+            message['content']
+            for message in persisted_history
+            if 'Internal ReAct rounds left:' in str(message.get('content', ''))
+        ]
+        assert persisted_budget_queries == [
+            llm.inputs[1]['input'][-1]['content'],
+            llm.inputs[2]['input'][-1]['content'],
+        ]
 
     def test_react_agent_stream_preserves_structured_tool_results(self):
         llm = _FakeLLM([
@@ -331,7 +418,7 @@ class TestReactAgentEvents(object):
             },
             {'role': 'assistant', 'content': 'Done.'},
         ])
-        agent = ReactAgent(llm=llm, tools=[get_status], max_retries=1, stream=True,
+        agent = ReactAgent(llm=llm, tools=[get_status], max_retries=3, stream=True,
                            enable_builtin_tools=False)
 
         assert agent('read status') == 'Done.'
@@ -345,10 +432,11 @@ class TestReactAgentEvents(object):
         tool_message = llm.inputs[1]['input'][0]
 
         assert tool_message['role'] == 'tool'
-        assert tool_message['content'] == str({
-            'status': 'ok',
-            'content': 'Error handling reference',
-        })
+        assert tool_message['content'] == (
+            f'{str({"status": "ok", "content": "Error handling reference"})}\n\n'
+            '[Internal runtime notice] Internal ReAct rounds left: 2. '
+            'Finish the task or provide a concise final summary before the limit.'
+        )
 
     def test_react_agent_stream_emits_text_reasoning_and_tool_events(self):
         llm = _FakeLLM([


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

Append the remaining round budget to the latest tool result instead of injecting a system message.
Preserve an append-only prompt history for better prefix-cache reuse.
Add tests for budget persistence, expansion, and tool-result handling.

---

# ✅ 变更类型 / Type of Change

* [X] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [X] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [X] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：