### PR TITLE
fix(agent): execute skill scripts through the configured sandbox

### DIFF
--- a/lazyllm/docs/tools/tool_sandbox.py
+++ b/lazyllm/docs/tools/tool_sandbox.py
@@ -90,6 +90,70 @@ add_sandbox_example('DummySandbox', """\
 2
 """)
 
+add_sandbox_chinese_doc('DummySandbox.execute_script', '''\
+在临时执行目录中运行一个已物化的 Skill 脚本。
+
+该方法会将 `source_dir` 的完整目录树复制到临时目录，校验脚本路径和工作目录均未逃逸出临时目录，
+再根据扩展名选择解释器执行。`.py` 文件使用当前 Python 解释器，`.sh` 和 `.bash` 文件使用 Bash，
+其他扩展名使用 `sh`。执行结束后会清理临时目录。
+
+Args:
+    source_dir (str): 已物化的 Skill 包根目录。
+    rel_path (str): 相对于 `source_dir` 的脚本路径。
+    args (list[str] | None): 传递给脚本的参数。
+    cwd (str): 相对于 `source_dir` 的工作目录，默认为 `.`。
+    allow_unsafe (bool): 预留的审批参数；DummySandbox 当前不提供审批边界，因此会忽略该参数。
+
+**Returns:**\n
+    dict：包含 `status`、`stdout`、`stderr`、`exit_code` 和 `cwd`。脚本不存在时返回
+    `status='missing'`；非零退出码返回 `status='failed'`。
+
+Notes:
+    DummySandbox 只提供临时目录和子进程执行边界，并非强安全隔离。它不会限制脚本读取宿主机文件、
+    访问网络或继承当前进程环境。不要用它执行未经信任的代码。
+''')
+
+add_sandbox_english_doc('DummySandbox.execute_script', '''\
+Execute a materialized Skill script in a temporary working directory.
+
+The method copies the complete `source_dir` tree into a temporary directory, verifies that the script path and working
+directory remain inside it, and selects an interpreter by file extension. `.py` files use the current Python interpreter,
+`.sh` and `.bash` files use Bash, and other extensions use `sh`. The temporary directory is removed after execution.
+
+Args:
+    source_dir (str): root directory of the materialized Skill package.
+    rel_path (str): script path relative to `source_dir`.
+    args (list[str] | None): arguments passed to the script.
+    cwd (str): working directory relative to `source_dir`, default `.`.
+    allow_unsafe (bool): reserved approval parameter; DummySandbox currently has no approval boundary and ignores it.
+
+**Returns:**\n
+    dict: contains `status`, `stdout`, `stderr`, `exit_code`, and `cwd`. A missing script returns `status='missing'`;
+    a non-zero exit code returns `status='failed'`.
+
+Notes:
+    DummySandbox provides only a temporary-directory and subprocess boundary, not strong security isolation. It does not
+    prevent scripts from reading host files, accessing the network, or inheriting the current process environment. Do not
+    use it to execute untrusted code.
+''')
+
+add_sandbox_example('DummySandbox.execute_script', """\
+>>> import tempfile
+>>> from pathlib import Path
+>>> from lazyllm.tools.sandbox import DummySandbox
+>>> with tempfile.TemporaryDirectory() as root:
+...     script = Path(root) / "scripts" / "check.py"
+...     script.parent.mkdir()
+...     _ = script.write_text("print('ok')\\n", encoding="utf-8")
+...     result = DummySandbox(timeout=10).execute_script(
+...         source_dir=root,
+...         rel_path="scripts/check.py",
+...         args=[],
+...     )
+...     print(result['stdout'].strip())
+ok
+""")
+
 add_sandbox_chinese_doc('SandboxFusion', '''\
 远程沙箱实现，通过 HTTP API 执行代码并获取结果。
 
@@ -131,4 +195,3 @@ add_sandbox_example('SandboxFusion', """\
 >>> print(result['stdout'].strip())
 ok
 """)
-

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -74,9 +74,14 @@ class LazyLLMAgentBase(ModuleBase):
         if self._enable_builtin_tools:
             self._ensure_builtin_tools()
         if use_skills:
-            self._skill_manager = SkillManager(dir=skills_dir, skills=self._skills, fs=fs)
+            self._skill_manager = SkillManager(
+                dir=skills_dir, skills=self._skills, fs=fs, sandbox=self._sandbox,
+            )
             self._ensure_default_skill_tools()
         self._tools_manager = ToolManager(self._tools, return_trace=return_trace, sandbox=self._sandbox)
+        for tool in self._tools_manager.all_tools:
+            if tool.name in self._skill_tool_names:
+                tool.execute_in_sandbox = False
 
     @staticmethod
     def _normalize_skills_config(skills: Optional[Union[bool, str, Iterable[str]]]):

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -1,7 +1,6 @@
 import os
 import posixpath
 import re
-import shlex
 import subprocess
 import tempfile
 import threading
@@ -11,7 +10,6 @@ import yaml
 
 from lazyllm import config, LOG, ModuleBase
 from lazyllm.thirdparty import fsspec
-from .shell_tool import shell_tool as _shell_tool
 
 DEFAULT_SKILLS_DIR = os.path.join(config['home'], 'skills')
 os.makedirs(DEFAULT_SKILLS_DIR, exist_ok=True)
@@ -103,9 +101,13 @@ _META_REQUIRED_FIELDS = {
 
 class SkillManager(ModuleBase):
     def __init__(self, dir: Optional[str] = None, skills: Optional[Iterable[str]] = None,
-                 max_skill_md_bytes: Optional[int] = None, fs=None):
+                 max_skill_md_bytes: Optional[int] = None, fs=None, sandbox=None):
         super().__init__(return_trace=False)
         self._fs = fs or fsspec.implementations.local.LocalFileSystem()
+        if sandbox is None:
+            from lazyllm.tools.sandbox.sandbox_base import create_sandbox
+            sandbox = create_sandbox()
+        self._sandbox = sandbox
         self._skills_dir = self._parse_dirs(dir or config['skills_dir'], fs=fs)
         self._validate_fs_dir_consistency(fs, self._skills_dir)
         self._skills_expected = self._parse_skills(skills)
@@ -580,15 +582,6 @@ class SkillManager(ModuleBase):
             raise RuntimeError(f'Failed to materialize remote skill directory {base!r}: {exc}') from exc
         return str(materialized.get('local_dir') or temp_dir.name), temp_dir
 
-    @staticmethod
-    def _build_script_command(script_path: str, args: Optional[List[str]]) -> List[str]:
-        ext = os.path.splitext(script_path)[1].lower()
-        runner = 'python' if ext == '.py' else 'bash' if ext in ('.sh', '.bash') else 'sh'
-        cmd = [runner, script_path]
-        if args:
-            cmd.extend(args)
-        return cmd
-
     def _run_script_exception(self, name: str, rel_path: str, cwd: Optional[str],
                               run_cwd: Optional[str], exc: Exception) -> Dict[str, str]:
         error_cwd = run_cwd or cwd
@@ -642,8 +635,21 @@ class SkillManager(ModuleBase):
             script_exists = os.path.exists(script_path) if temp_dir is not None else self._fs.exists(script_path)
             if not script_exists:
                 return {'status': 'missing', 'name': name, 'path': script_path, 'rel_path': normalized_rel_path}
-            cmd = self._build_script_command(script_path, args)
-            result = _shell_tool(' '.join(shlex.quote(p) for p in cmd), cwd=run_cwd, allow_unsafe=allow_unsafe)
+            if self._sandbox is None or not hasattr(self._sandbox, 'execute_script'):
+                return {
+                    'status': 'error',
+                    'name': name,
+                    'rel_path': normalized_rel_path,
+                    'error_type': 'SandboxUnavailable',
+                    'error': 'The configured sandbox does not support skill script execution.',
+                }
+            result = self._sandbox.execute_script(
+                source_dir=base,
+                rel_path=normalized_rel_path,
+                args=args,
+                cwd=os.path.relpath(run_cwd, os.path.realpath(os.path.abspath(base))),
+                allow_unsafe=allow_unsafe,
+            )
             if result.get('status') == 'ok' and result.get('exit_code', 0) != 0:
                 result['status'] = 'failed'
             return result

--- a/lazyllm/tools/sandbox/dummy_sandbox.py
+++ b/lazyllm/tools/sandbox/dummy_sandbox.py
@@ -49,6 +49,52 @@ class DummySandbox(LazyLLMSandboxBase):
             raise
         return {'returncode': proc.returncode, 'stdout': stdout, 'stderr': stderr}
 
+    def execute_script(self, source_dir: str, rel_path: str, args: Optional[List[str]] = None,
+                       cwd: str = '.', allow_unsafe: bool = False) -> Dict[str, Any]:
+        del allow_unsafe  # DummySandbox currently has no approval boundary.
+        context = self._create_context()
+        try:
+            sandbox_root = context['temp_dir']
+            shutil.copytree(source_dir, sandbox_root, dirs_exist_ok=True)
+            script_path = self._resolve_child(sandbox_root, rel_path, 'rel_path')
+            run_cwd = self._resolve_child(sandbox_root, cwd or '.', 'cwd')
+            if not os.path.isfile(script_path):
+                return {
+                    'status': 'missing',
+                    'path': script_path,
+                    'rel_path': rel_path,
+                    'cwd': run_cwd,
+                }
+            if not os.path.isdir(run_cwd):
+                raise FileNotFoundError(f'cwd not found: {run_cwd}')
+            ext = os.path.splitext(script_path)[1].lower()
+            runner = sys.executable if ext == '.py' else 'bash' if ext in ('.sh', '.bash') else 'sh'
+            completed = subprocess.run(
+                [runner, script_path, *(args or [])],
+                cwd=run_cwd,
+                env=os.environ.copy(),
+                text=True,
+                capture_output=True,
+                timeout=self._timeout,
+            )
+            return {
+                'status': 'ok' if completed.returncode == 0 else 'failed',
+                'stdout': completed.stdout,
+                'stderr': completed.stderr,
+                'exit_code': completed.returncode,
+                'cwd': run_cwd,
+            }
+        finally:
+            self._cleanup_context(context)
+
+    @staticmethod
+    def _resolve_child(root: str, rel_path: str, label: str) -> str:
+        root_real = os.path.realpath(os.path.abspath(root))
+        target = os.path.realpath(os.path.abspath(os.path.join(root_real, rel_path)))
+        if os.path.commonpath([root_real, target]) != root_real:
+            raise ValueError(f'{label} must stay inside the sandbox directory.')
+        return target
+
     def _create_context(self) -> dict:
         return {'temp_dir': tempfile.mkdtemp(prefix='lazyllm_sandbox_')}
 

--- a/tests/basic_tests/Tools/test_agent_base.py
+++ b/tests/basic_tests/Tools/test_agent_base.py
@@ -1,3 +1,5 @@
+import json
+
 import lazyllm.tools.agent.base as agent_base_module
 from lazyllm.tools.agent.base import LazyLLMAgentBase
 from lazyllm.tools.agent.skill_manager import SkillManager
@@ -41,6 +43,11 @@ class TestLazyLLMAgentBase(object):
         assert agent._builtin_tool_names == set()
         assert agent._skill_tool_names == {'get_skill', 'read_reference', 'run_script'}
         assert all(not (isinstance(tool, str) and tool.startswith('builtin_tools.')) for tool in agent._tools)
+        assert all(
+            tool.execute_in_sandbox is False
+            for tool in agent._tools_manager.all_tools
+            if tool.name in agent._skill_tool_names
+        )
 
     def test_agent_sandbox_auto_creates_sandbox(self, monkeypatch):
         sentinel = object()
@@ -48,6 +55,37 @@ class TestLazyLLMAgentBase(object):
         agent = _DummyAgent(skills=False, enable_builtin_tools=False)
         assert agent.sandbox is sentinel
         assert agent._tools_manager.sandbox is sentinel
+
+    def test_run_script_dispatches_through_tool_manager_and_executes_in_sandbox(self, tmp_path):
+        skill_dir = tmp_path / 'demo-skill'
+        scripts_dir = skill_dir / 'scripts'
+        scripts_dir.mkdir(parents=True)
+        (skill_dir / 'SKILL.md').write_text(
+            '---\nname: demo-skill\ndescription: Demo skill.\n---\n'
+            'Run `scripts/check.py`.\n',
+            encoding='utf-8',
+        )
+        (scripts_dir / 'check.py').write_text('print("sandboxed skill")\n', encoding='utf-8')
+        agent = _DummyAgent(
+            skills=['demo-skill'],
+            skills_dir=str(tmp_path),
+            enable_builtin_tools=False,
+        )
+
+        result = agent._tools_manager({
+            'function': {
+                'name': 'run_script',
+                'arguments': json.dumps({
+                    'name': 'demo-skill',
+                    'rel_path': 'scripts/check.py',
+                }),
+            },
+        })
+        result = result[0]
+
+        assert result['ok'] is True
+        assert result['value']['status'] == 'ok'
+        assert result['value']['stdout'] == 'sandboxed skill\n'
 
     def test_agent_sandbox_none_skips_creation(self, monkeypatch):
         def _unexpected_create():


### PR DESCRIPTION
<!-- 
在提交 PR 前，请确保 / Before submitting a PR, please ensure:
1. 每行不超过 120 字符 / Max 120 characters per line
2. 单引号优先（修改文件需统一）/ Prefer single quotes (be consistent within modified files)
3. 禁止 print / No print statements
4. 注释需解释"为什么"和"怎么做"，而不是"是什么" / Comments should explain "why" and "how", not "what"
5. 执行 / Run:
   pip install flake8-quotes
   pip install flake8-bugbear
   make lint-only-diff
6. 删除本模板的全部注释 / Delete all template comments before submitting
-->

# 📌 PR 内容 / PR Description

- Keep skill management tools in the main process so `SkillManager` and its lock are not serialized.
- Dispatch skill script execution through the configured sandbox.
- Add `DummySandbox.execute_script()` to copy the skill package into a temporary sandbox directory before execution.
- Support Python and shell skill scripts while preserving arguments, working directories, output, and exit codes.
- Add an end-to-end regression test covering `Agent -> ToolManager -> run_script -> DummySandbox`.

---

# 🎯 问题背景 / Problem Context

- Skill tools were registered as sandboxed ToolManager callables.
- The generated `run_script` closure captures `SkillManager`, which contains a `threading.Lock`.
- ToolManager attempted to serialize the closure before execution and failed with
  `cannot pickle '_thread.lock' object`.
- As a result, installed skill scripts could not reach the materialization or execution stage.
- Skill lookup and RemoteFS access belong in the main process, while only the script payload should run in the sandbox.

# 🔍 相关 Issue / Related Issue

* N/A

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. Ran the focused SkillManager and Agent tests:
   `pytest -q tests/basic_tests/Tools/test_agent_base.py tests/advanced_tests/Tools/test_skills.py`
2. Verified the real ToolManager path executes a skill script and returns the expected stdout.
3. Verified remote materialization, non-zero exit codes, missing working directories, and path validation.

---

# 📷 Demo (Optional)

* N/A

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
agent = ReactAgent(
    llm=llm,
    skills=['demo-skill'],
    skills_dir='/path/to/skills',
)

# The agent's run_script tool now performs skill lookup in the main process
# and executes scripts/check.py through the configured sandbox.
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
cmd = self._build_script_command(script_path, args)
result = _shell_tool(command, cwd=run_cwd, allow_unsafe=allow_unsafe)
```

Skill tools themselves were also sent through ToolManager sandbox serialization, causing the captured
`SkillManager` lock to fail before `run_script` could execute.

## After

```python
result = self._sandbox.execute_script(
    source_dir=base,
    rel_path=normalized_rel_path,
    args=args,
    cwd=relative_cwd,
    allow_unsafe=allow_unsafe,
)
```

Skill tools stay in the main process for lookup, RemoteFS materialization, and validation. The selected script package is
copied into the sandbox's temporary directory and executed there.

# ⚠️ 注意事项 / Additional Notes

* `DummySandbox` provides a temporary execution directory and subprocess boundary, but it is not a strong security sandbox.
* The new `execute_script()` boundary is intended to support a future SandboxFusion implementation without changing
  `SkillManager.run_script()` again.
* Sandboxes that do not implement `execute_script()` return a structured `SandboxUnavailable` error instead of falling
  back to host shell execution.

---

# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
Investigate why scripts from downloaded skills are often not executed and determine whether the temporary
materialization and tool registration mechanism still works.
```

## 一开始制定了什么方案

Trace the complete skill installation, loading, ToolManager registration, RemoteFS materialization, and script execution
path. Reproduce the failure through the real ToolManager path rather than calling `SkillManager.run_script()` directly.

## 方案实施后存在什么问题

The initial direct SkillManager tests passed because they bypassed ToolManager. The real Agent/ToolManager execution path
failed while serializing the skill tool closure because `SkillManager` contains an unpicklable `threading.Lock`.

## 我（用户）发现了哪些问题

The user observed that skills loaded correctly but their bundled scripts were not executed, and the model frequently
fell back to simulating the behavior with system tools. The user also identified a stale unused `cmd` variable after the
execution path was refactored.

## 对这些问题优化后相比于之前有哪些优势

Skill management and script execution now have an explicit boundary. RemoteFS access and validation stay in the main
process, while script files execute through the configured sandbox. The regression test covers the real runtime path and
prevents the serialization failure from returning unnoticed.

## 哪些可以沉淀为自己后续的编码规范

- Test agent tools through the same ToolManager path used in production.
- Do not serialize stateful managers, locks, HTTP clients, or filesystem clients into execution sandboxes.
- Separate trusted orchestration from untrusted payload execution.
- Return structured errors instead of silently falling back to a less safe execution path.
- Remove obsolete command-building code when execution responsibility moves to another component.