### PR TITLE
refactor: extract model preparation logic to FastapiApp._prepare_openapi

### DIFF
--- a/lazyllm/components/deploy/relay/base.py
+++ b/lazyllm/components/deploy/relay/base.py
@@ -154,3 +154,17 @@ class FastapiApp(object):
                 cls.__relay_services__ = dict()
             cls.__relay_services__[method, path] = ([f.__name__, kw])
         FastapiApp.__relay_services__.clear()
+
+    @staticmethod
+    def _prepare_openapi(fastapi_app):
+        '''Prepare dynamically registered routes before OpenAPI generation.'''
+        for route in fastapi_app.routes:
+            body_field = getattr(route, 'body_field', None)
+            annotation = getattr(getattr(body_field, 'field_info', None), 'annotation', None)
+            if not hasattr(annotation, 'model_rebuild'):
+                continue
+            endpoint = getattr(route, 'endpoint', None)
+            globalns = getattr(endpoint, '__globals__', None)
+            if globalns is None:
+                globalns = getattr(getattr(endpoint, '__func__', None), '__globals__', {})
+            annotation.model_rebuild(force=True, _types_namespace=globalns)

--- a/lazyllm/components/deploy/relay/server.py
+++ b/lazyllm/components/deploy/relay/server.py
@@ -113,7 +113,7 @@ async def lazyllm_call(request: fastapi.Request):
 
 @app.post('/generate')
 @security_check
-async def generate(request: fastapi.Request): # noqa C901
+async def generate(request: fastapi.Request):  # noqa C901
     try:
         input, kw = (await request.json()), {}
         try:
@@ -185,6 +185,7 @@ def find_services(cls):
         find_services(base)
 
 find_services(func.__class__)
+FastapiApp._prepare_openapi(app)
 
 class _Dummy: pass
 

--- a/lazyllm/tools/rag/doc_service/doc_server.py
+++ b/lazyllm/tools/rag/doc_service/doc_server.py
@@ -1103,11 +1103,7 @@ class DocServer(ModuleBase):
             parser_url='http://127.0.0.1:9966',
         )
         cls._register_openapi_routes(openapi_app, impl)
-        for route in openapi_app.routes:
-            body_field = getattr(route, 'body_field', None)
-            annotation = getattr(getattr(body_field, 'field_info', None), 'annotation', None)
-            if hasattr(annotation, 'model_rebuild'):
-                annotation.model_rebuild(force=True, _types_namespace=route.endpoint.__globals__)
+        app._prepare_openapi(openapi_app)
         return openapi_app
 
     @classmethod

--- a/tests/basic_tests/Modules/test_server.py
+++ b/tests/basic_tests/Modules/test_server.py
@@ -12,15 +12,15 @@ from lazyllm import FastapiApp as app
 
 
 class BaseResponse(BaseModel):
-    code: int = pydantic.Field(200, description="API status code")
-    msg: str = pydantic.Field("success", description="API status message")
-    data: Any = pydantic.Field(None, description="API data")
+    code: int = pydantic.Field(200, description='API status code')
+    msg: str = pydantic.Field('success', description='API status message')
+    data: Any = pydantic.Field(None, description='API data')
 
     class Config:
         json_schema_extra = {
-            "example": {
-                "code": 200,
-                "msg": "success",
+            'example': {
+                'code': 200,
+                'msg': 'success',
             }
         }
 
@@ -64,31 +64,39 @@ class TestServerModule(object):
         m = lazyllm.ServerModule(Manager(), pythonpath=current_dir)
         m.start()
 
-        response = requests.get(m._url.replace("generate", "docs"))
+        response = requests.get(m._url.replace('generate', 'docs'))
         assert response.status_code == 200
 
-        response = requests.post(m._url.replace("generate", "getres"), data=json.dumps('ww'))
-        assert response.json() == "test"
+        response = requests.get(m._url.replace('generate', 'openapi.json'))
+        assert response.status_code == 200
+        assert '/' in response.json()['paths']
 
-        response = requests.post(m._url.replace("generate", "getres2"), data=json.dumps('ww'))
-        assert response.json() == "test_overwrite"
+        response = requests.post(m._url.replace('generate', 'getres'), data=json.dumps('ww'))
+        assert response.json() == 'test'
+
+        response = requests.post(m._url.replace('generate', 'getres2'), data=json.dumps('ww'))
+        assert response.json() == 'test_overwrite'
 
     def test_derived_module(self):
         current_dir = os.path.dirname(os.path.abspath(__file__))
         m = lazyllm.ServerModule(Derived(), pythonpath=current_dir)
         m.start()
 
-        response = requests.get(m._url.replace("generate", "docs"))
+        response = requests.get(m._url.replace('generate', 'docs'))
         assert response.status_code == 200
 
-        response = requests.post(m._url.replace("generate", "getres"), data=json.dumps('ww'))
-        assert response.json() == "test"
+        response = requests.get(m._url.replace('generate', 'openapi.json'))
+        assert response.status_code == 200
+        assert '/subclass_api' in response.json()['paths']
 
-        response = requests.post(m._url.replace("generate", "manager2"), data=json.dumps('ww'))
-        assert response.json() == "manager2"
+        response = requests.post(m._url.replace('generate', 'getres'), data=json.dumps('ww'))
+        assert response.json() == 'test'
 
-        response = requests.post(m._url.replace("generate", "getres2"), data=json.dumps('ww'))
+        response = requests.post(m._url.replace('generate', 'manager2'), data=json.dumps('ww'))
+        assert response.json() == 'manager2'
+
+        response = requests.post(m._url.replace('generate', 'getres2'), data=json.dumps('ww'))
         assert response.status_code == 404
 
-        response = requests.post(m._url.replace("generate", "subclass_api"), data=json.dumps('ww'))
-        assert response.json() == "subclass_api"
+        response = requests.post(m._url.replace('generate', 'subclass_api'), data=json.dumps('ww'))
+        assert response.json() == 'subclass_api'

--- a/tests/basic_tests/RAG/test_doc_service_doc_server.py
+++ b/tests/basic_tests/RAG/test_doc_service_doc_server.py
@@ -196,6 +196,14 @@ def test_task_cancel_request_requires_task_id():
         TaskCancelRequest.model_validate({})
 
 
+def test_doc_server_openapi_schema_contains_doc_service_routes():
+    schema = DocServer.build_openapi_schema()
+
+    assert '/v1/health' in schema['paths']
+    assert '/v1/docs/add' in schema['paths']
+    assert '/v1/docs/upload' in schema['paths']
+
+
 def test_cancel_task_http_maps_conflict(server_impl):
     server_impl._manager.cancel_response = BaseResponse(
         code=409,


### PR DESCRIPTION
## 标题

fix(relay): fix OpenAPI schema generation for dynamic routes

## Problem

DocServer 通过 Relay 动态注册 FastAPI 路由时，部分 Pydantic 请求模型的 forward reference 未被正确解析，导致 `/openapi.json` 返回 500，进而使 `/docs` 页面显示 `Failed to load API definition`。

## Solution

抽取统一的 OpenAPI 模型准备逻辑，在 Relay 运行时路由注册和 DocServer 离线 schema 导出两个路径中执行 `model_rebuild()`，确保动态路由能够正常生成 OpenAPI schema。

## Changes

- 新增 `FastapiApp._prepare_openapi()`。
- Relay 服务注册动态路由后准备 OpenAPI 请求模型。
- DocServer schema 导出复用统一逻辑。
- 增加 `/openapi.json` 和 DocServer schema 回归测试。

## Testing

在 Python 3.10、3.11、3.12 环境执行：

```text
30 passed