### PR TITLE
feat(rag): support custom Excel column joiners

### DIFF
--- a/lazyllm/docs/tools/tool_rag.py
+++ b/lazyllm/docs/tools/tool_rag.py
@@ -1681,6 +1681,7 @@ Args:
     pandas_config (Optional[Dict]): pandas.read_excel 的可选配置项。
     fill_method (Optional[str]): 缺失值填充策略，可选 'fillna'(default) / 'ffill' / 'bfill'。
     return_trace (bool): 是否返回处理过程的 trace。
+    col_joiner (str): 列之间的连接符，默认为空格。
 ''')
 
 add_english_doc('rag.readers.PandasExcelReader', '''\
@@ -1692,6 +1693,7 @@ Args:
     pandas_config (Optional[Dict]): Optional config for pandas.read_excel.
     fill_method (Optional[str]): Missing value fill strategy: 'fillna'(default) / 'ffill' / 'bfill'.
     return_trace (bool): Whether to return the processing trace.
+    col_joiner (str): String used to join column values. Default is a single space.
 ''')
 
 add_chinese_doc('rag.readers.PDFReader', '''\

--- a/lazyllm/tools/rag/readers/pandasReader.py
+++ b/lazyllm/tools/rag/readers/pandasReader.py
@@ -77,12 +77,13 @@ class PandasCSVReader(LazyLLMReaderBase):
 class PandasExcelReader(LazyLLMReaderBase):
     def __init__(self, concat_rows: bool = True, sheet_name: Optional[str] = None,
                  pandas_config: Optional[Dict] = None, fill_method: Optional[str] = 'fillna',
-                 return_trace: bool = True) -> None:
+                 return_trace: bool = True, col_joiner: str = ' ') -> None:
         super().__init__(return_trace=return_trace)
         self._concat_rows = concat_rows
         self._sheet_name = sheet_name
         self._pandas_config = pandas_config or {}
         self._fill_method = fill_method
+        self._col_joiner = col_joiner
 
     def _load_data(self, file: Path, fs: Optional['fsspec.AbstractFileSystem'] = None) -> List[DocNode]:
         openpyxl_spec = importlib.util.find_spec('openpyxl')
@@ -99,7 +100,7 @@ class PandasExcelReader(LazyLLMReaderBase):
 
         def process_df(df: pd.DataFrame) -> List[DocNode]:
             df = _apply_fill(df, self._fill_method)
-            text_list = (df.astype(str).apply(lambda row: ' '.join(row.values), axis=1).tolist())
+            text_list = df.astype(str).apply(lambda row: self._col_joiner.join(row.values), axis=1).tolist()
 
             if self._concat_rows:
                 return [DocNode(text='\n'.join(text_list))]

--- a/tests/basic_tests/RAG/test_reader.py
+++ b/tests/basic_tests/RAG/test_reader.py
@@ -1,9 +1,10 @@
 import os
 import lazyllm
 import tiktoken
+from lazyllm.thirdparty import pandas as pd
 from lazyllm.tools.rag.transform import SentenceSplitter
 from unittest.mock import patch
-from lazyllm.tools.rag.readers import ReaderBase
+from lazyllm.tools.rag.readers import PandasExcelReader, ReaderBase
 from lazyllm.tools.rag.readers.readerBase import TxtReader, _callable_cache_signature
 from lazyllm.tools.rag.readers.docxReader import DocxReader
 from lazyllm.tools.rag import SimpleDirectoryReader, DocNode, Document
@@ -82,6 +83,16 @@ class TestRagReader(object):
         docs = reader()
 
         assert sorted(doc.text for doc in docs) == ['first document', 'second document']
+
+    def test_pandas_excel_reader_col_joiner(self, tmp_path):
+        excel_file = tmp_path / 'data.xlsx'
+        pd.DataFrame({'name': ['Alice'], 'score': [10]}).to_excel(excel_file, index=False)
+
+        default_docs = PandasExcelReader()(excel_file)
+        custom_docs = PandasExcelReader(col_joiner=' | ')(excel_file)
+
+        assert [doc.text for doc in default_docs] == ['Alice 10']
+        assert [doc.text for doc in custom_docs] == ['Alice | 10']
 
     def test_register_local_reader(self):
         self.doc1.add_reader('**/*.yml', processYml)


### PR DESCRIPTION
# 🚀 Feature

## Feature Description
Allow `PandasExcelReader` callers to choose the delimiter used between column values.

## Feature Details
- [x] Add the `col_joiner` argument
- [x] Preserve the current single-space default
- [x] Cover default and custom delimiters

## Use Cases
Use an unambiguous delimiter when Excel cells contain spaces.

## Technical Implementation
- Store `col_joiner` on `PandasExcelReader`
- Use it when each row is converted to text

## Test Coverage
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Documentation Updates
- [x] API documentation
- [ ] User guide
- [ ] Example code

## Backward Compatibility
- [x] Fully compatible
- [ ] Migration required
- [ ] Breaking changes

## Performance Impact
No expected impact.

## Related Issues
Closes #838

---

## Change Type
- [x] Feature addition
- [ ] Bug fix
- [ ] Performance optimization
- [ ] Code refactoring
- [x] Documentation update
- [x] Testing related
- [ ] Security fix

## Impact Scope
- [ ] User interface
- [x] API interface
- [ ] Database
- [ ] Configuration files
- [ ] Dependencies

## Priority
- [ ] High - Release immediately
- [x] Medium - Next version
- [ ] Low - Future version

## Release Notes Points
- `PandasExcelReader` accepts a `col_joiner` argument.
- Existing callers keep the single-space delimiter.
- No migration is required.
