### PR TITLE
refactor(search): return structured content results

### DIFF
--- a/lazyllm/docs/tools/search.py
+++ b/lazyllm/docs/tools/search.py
@@ -105,47 +105,47 @@ Calls search(query, **kwargs) and returns the result. Arguments are passed throu
 ''')
 
 add_chinese_doc('SearchBase.get_content', '''
-根据单条搜索结果（search/forward 返回的 item）获取正文文本。
+根据单条搜索结果（search/forward 返回的 item）获取正文，并保留来源身份。
 
-默认行为：请求 item 的 url，将响应 HTML 转为纯文本返回。子类可重写以使用 API 获取正文（如 Wikipedia 词条全文、arXiv 摘要、Stack Overflow 问答正文等）。
+默认行为：请求 item 的 url，将响应 HTML 转为纯文本并写入 content。子类可重写以使用 API 获取正文（如 Wikipedia 词条全文、arXiv 摘要、Stack Overflow 问答正文等）。
 
 Args:
     item (Dict[str, Any]): 至少包含 url 的搜索结果项（_make_result 格式）。
 
 Returns:
-    str: 正文文本；失败或无 url 时返回空字符串。
+    Dict[str, Any]: 包含 title、url、snippet、source、extra 和 content；正文获取失败时 content 为空字符串。
 ''')
 
 add_english_doc('SearchBase.get_content', '''
-Fetch full body text for a single search result item (as returned by search/forward).
+Fetch full body text for a single search result item while preserving its source identity.
 
-Default: GET the item url and convert response HTML to plain text. Subclasses may override to use APIs (e.g. Wikipedia full page, arXiv abstract, Stack Overflow Q&A body).
+Default: GET the item URL, convert response HTML to plain text, and store it in content. Subclasses may override to use APIs (e.g. Wikipedia full page, arXiv abstract, Stack Overflow Q&A body).
 
 Args:
     item (Dict[str, Any]): Search result item with at least url (_make_result format).
 
 Returns:
-    str: Body text; empty string on failure or when url is missing.
+    Dict[str, Any]: title, url, snippet, source, extra, and content. content is empty on fetch failure.
 ''')
 
 add_chinese_doc('SearchBase.get_contents', '''
-根据多条搜索结果批量获取正文文本。
+根据多条搜索结果批量获取正文并保留每条来源身份。
 
 Args:
     items (List[Dict[str, Any]]): 搜索结果列表（_make_result 格式）。
 
 Returns:
-    List[str]: 与 items 一一对应的正文文本列表。
+    List[Dict[str, Any]]: 与 items 一一对应的结构化正文结果列表。
 ''')
 
 add_english_doc('SearchBase.get_contents', '''
-Fetch full body text for multiple search result items.
+Fetch full body text for multiple search result items while preserving source identity.
 
 Args:
     items (List[Dict[str, Any]]): List of search result items (_make_result format).
 
 Returns:
-    List[str]: List of body texts, one per item.
+    List[Dict[str, Any]]: Structured content results in input order.
 ''')
 
 add_example('SearchBase.get_content', '''
@@ -153,14 +153,16 @@ from lazyllm.tools.tools import ArxivSearch
 engine = ArxivSearch()
 results = engine('transformer')
 if results:
-    text = engine.get_content(results[0])
+    result = engine.get_content(results[0])
+    text = result['content']
 ''')
 
 add_example('SearchBase.get_contents', '''
 from lazyllm.tools.tools import WikipediaSearch
 wiki = WikipediaSearch()
 items = wiki('machine learning')
-texts = wiki.get_contents(items[:3])
+contents = wiki.get_contents(items[:3])
+texts = [item['content'] for item in contents]
 ''')
 
 add_chinese_doc('GoogleSearch', '''

--- a/lazyllm/tools/tools/search/arxiv_search.py
+++ b/lazyllm/tools/tools/search/arxiv_search.py
@@ -16,7 +16,7 @@ class ArxivSearch(SearchBase):
         self._timeout = timeout
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch an arXiv abstract and return it with the result identity."""
+        '''Fetch an arXiv abstract and return it with the result identity.'''
         url = item.get('url') or ''
         m = re.search(r'/abs/([\d.]+(?:v\d+)?)', url) if url else None
         if not m:

--- a/lazyllm/tools/tools/search/arxiv_search.py
+++ b/lazyllm/tools/tools/search/arxiv_search.py
@@ -16,7 +16,6 @@ class ArxivSearch(SearchBase):
         self._timeout = timeout
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        '''Fetch an arXiv abstract and return it with the result identity.'''
         url = item.get('url') or ''
         m = re.search(r'/abs/([\d.]+(?:v\d+)?)', url) if url else None
         if not m:

--- a/lazyllm/tools/tools/search/arxiv_search.py
+++ b/lazyllm/tools/tools/search/arxiv_search.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 
 from lazyllm.thirdparty import httpx, xml
 
-from .base import SearchBase, _make_result
+from .base import SearchBase, _make_content_result, _make_result
 
 
 class ArxivSearch(SearchBase):
@@ -15,7 +15,8 @@ class ArxivSearch(SearchBase):
         self._url = base_url
         self._timeout = timeout
 
-    def get_content(self, item: Dict[str, Any]) -> str:
+    def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch an arXiv abstract and return it with the result identity."""
         url = item.get('url') or ''
         m = re.search(r'/abs/([\d.]+(?:v\d+)?)', url) if url else None
         if not m:
@@ -39,7 +40,7 @@ class ArxivSearch(SearchBase):
         for entry in root.findall('atom:entry', ns):
             summary_el = entry.find('atom:summary', ns)
             if summary_el is not None and summary_el.text:
-                return summary_el.text.strip().replace('\n', ' ')
+                return _make_content_result(item, summary_el.text.strip().replace('\n', ' '))
         return super().get_content(item)
 
     def search(self, query: str, max_results: int = 10,

--- a/lazyllm/tools/tools/search/base.py
+++ b/lazyllm/tools/tools/search/base.py
@@ -39,7 +39,7 @@ def _make_result(title: str, url: str, snippet: str = '', source: str = '', **ex
 
 
 def _make_content_result(item: Dict[str, Any], content: str) -> Dict[str, Any]:
-    """Return fetched content with the stable SearchBase source identity."""
+    '''Return fetched content with the stable SearchBase source identity.'''
     extra = item.get(_EXTRA_KEY)
     return {
         _TITLE_KEY: str(item.get(_TITLE_KEY) or ''),
@@ -92,7 +92,7 @@ class SearchBase(ModuleBase, CredentialMixin):
         return self._source_name
 
     def search(self, query: str, **kwargs: Any) -> List[Dict[str, Any]]:
-        """Search the provider and return ranked structured result items."""
+        '''Search the provider and return ranked structured result items.'''
         raise NotImplementedError('Subclass must implement search')
 
     def _handle_error(self, err: Exception, *, raise_on_error: bool) -> List[Dict[str, Any]]:
@@ -127,9 +127,9 @@ class SearchBase(ModuleBase, CredentialMixin):
             return ''
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch one result and return its source identity together with content."""
+        '''Fetch one result and return its source identity together with content.'''
         return _make_content_result(item, self._fetch_content_text(item))
 
     def get_contents(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        """Fetch result items in input order and preserve each source identity."""
+        '''Fetch result items in input order and preserve each source identity.'''
         return [self.get_content(it) for it in items]

--- a/lazyllm/tools/tools/search/base.py
+++ b/lazyllm/tools/tools/search/base.py
@@ -38,6 +38,19 @@ def _make_result(title: str, url: str, snippet: str = '', source: str = '', **ex
     return item
 
 
+def _make_content_result(item: Dict[str, Any], content: str) -> Dict[str, Any]:
+    """Return fetched content with the stable SearchBase source identity."""
+    extra = item.get(_EXTRA_KEY)
+    return {
+        _TITLE_KEY: str(item.get(_TITLE_KEY) or ''),
+        _URL_KEY: str(item.get(_URL_KEY) or item.get('link') or ''),
+        _SNIPPET_KEY: str(item.get(_SNIPPET_KEY) or ''),
+        _SOURCE_KEY: str(item.get(_SOURCE_KEY) or ''),
+        _EXTRA_KEY: dict(extra) if isinstance(extra, dict) else {},
+        'content': str(content or ''),
+    }
+
+
 # TODO: add tests after key is ready
 class SearchBase(ModuleBase, CredentialMixin):
     __public_apis__ = ['search', 'get_content', 'get_contents']
@@ -79,6 +92,7 @@ class SearchBase(ModuleBase, CredentialMixin):
         return self._source_name
 
     def search(self, query: str, **kwargs: Any) -> List[Dict[str, Any]]:
+        """Search the provider and return ranked structured result items."""
         raise NotImplementedError('Subclass must implement search')
 
     def _handle_error(self, err: Exception, *, raise_on_error: bool) -> List[Dict[str, Any]]:
@@ -100,7 +114,7 @@ class SearchBase(ModuleBase, CredentialMixin):
     def forward(self, query: str, **kwargs) -> List[Dict[str, Any]]:
         return self.search(query, **kwargs)
 
-    def get_content(self, item: Dict[str, Any]) -> str:
+    def _fetch_content_text(self, item: Dict[str, Any]) -> str:
         url = item.get('url') or item.get('link') or ''
         if not url:
             return ''
@@ -112,5 +126,10 @@ class SearchBase(ModuleBase, CredentialMixin):
         except Exception:
             return ''
 
-    def get_contents(self, items: List[Dict[str, Any]]) -> List[str]:
+    def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch one result and return its source identity together with content."""
+        return _make_content_result(item, self._fetch_content_text(item))
+
+    def get_contents(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Fetch result items in input order and preserve each source identity."""
         return [self.get_content(it) for it in items]

--- a/lazyllm/tools/tools/search/base.py
+++ b/lazyllm/tools/tools/search/base.py
@@ -39,7 +39,6 @@ def _make_result(title: str, url: str, snippet: str = '', source: str = '', **ex
 
 
 def _make_content_result(item: Dict[str, Any], content: str) -> Dict[str, Any]:
-    '''Return fetched content with the stable SearchBase source identity.'''
     extra = item.get(_EXTRA_KEY)
     return {
         _TITLE_KEY: str(item.get(_TITLE_KEY) or ''),
@@ -92,7 +91,6 @@ class SearchBase(ModuleBase, CredentialMixin):
         return self._source_name
 
     def search(self, query: str, **kwargs: Any) -> List[Dict[str, Any]]:
-        '''Search the provider and return ranked structured result items.'''
         raise NotImplementedError('Subclass must implement search')
 
     def _handle_error(self, err: Exception, *, raise_on_error: bool) -> List[Dict[str, Any]]:
@@ -127,9 +125,7 @@ class SearchBase(ModuleBase, CredentialMixin):
             return ''
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        '''Fetch one result and return its source identity together with content.'''
         return _make_content_result(item, self._fetch_content_text(item))
 
     def get_contents(self, items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        '''Fetch result items in input order and preserve each source identity.'''
         return [self.get_content(it) for it in items]

--- a/lazyllm/tools/tools/search/sciverse_search.py
+++ b/lazyllm/tools/tools/search/sciverse_search.py
@@ -57,7 +57,7 @@ class SciverseSearch(SearchBase):
         offset: Optional[int] = None,
         limit: int = 700,
     ) -> Dict[str, Any]:
-        """Fetch Sciverse content and return it with the result identity."""
+        '''Fetch Sciverse content and return it with the result identity.'''
         extra = item.get('extra') or {}
         doc_id = item.get('doc_id') or extra.get('doc_id')
         if doc_id:
@@ -122,7 +122,7 @@ class SciverseSearch(SearchBase):
         year_from: Optional[int] = None,
         year_to: Optional[int] = None,
     ) -> Dict[str, Any]:
-        """Search the Sciverse metadata index and return a paginated result envelope."""
+        '''Search the Sciverse metadata index and return a paginated result envelope.'''
         if query and sort:
             raise ValueError('meta_search sort cannot be used together with query')
         if cursor and page > 1:
@@ -188,7 +188,7 @@ class SciverseSearch(SearchBase):
         }
 
     def meta_catalog(self, include_sample_values: bool = False) -> Dict[str, Any]:
-        """Return the searchable Sciverse metadata field catalog."""
+        '''Return the searchable Sciverse metadata field catalog.'''
         resp = httpx.get(
             f'{self._base_url}/meta-catalog',
             headers=self.inject_auth_header(),

--- a/lazyllm/tools/tools/search/sciverse_search.py
+++ b/lazyllm/tools/tools/search/sciverse_search.py
@@ -57,7 +57,6 @@ class SciverseSearch(SearchBase):
         offset: Optional[int] = None,
         limit: int = 700,
     ) -> Dict[str, Any]:
-        '''Fetch Sciverse content and return it with the result identity.'''
         extra = item.get('extra') or {}
         doc_id = item.get('doc_id') or extra.get('doc_id')
         if doc_id:
@@ -122,7 +121,6 @@ class SciverseSearch(SearchBase):
         year_from: Optional[int] = None,
         year_to: Optional[int] = None,
     ) -> Dict[str, Any]:
-        '''Search the Sciverse metadata index and return a paginated result envelope.'''
         if query and sort:
             raise ValueError('meta_search sort cannot be used together with query')
         if cursor and page > 1:
@@ -188,7 +186,6 @@ class SciverseSearch(SearchBase):
         }
 
     def meta_catalog(self, include_sample_values: bool = False) -> Dict[str, Any]:
-        '''Return the searchable Sciverse metadata field catalog.'''
         resp = httpx.get(
             f'{self._base_url}/meta-catalog',
             headers=self.inject_auth_header(),

--- a/lazyllm/tools/tools/search/sciverse_search.py
+++ b/lazyllm/tools/tools/search/sciverse_search.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 from lazyllm.thirdparty import httpx
 
-from .base import SearchBase, _make_result
+from .base import SearchBase, _make_content_result, _make_result
 
 
 _DEFAULT_META_FIELDS = [
@@ -51,7 +51,13 @@ class SciverseSearch(SearchBase):
         self._base_url = base_url.rstrip('/')
         self._timeout = timeout
 
-    def get_content(self, item: Dict[str, Any], offset: Optional[int] = None, limit: int = 700) -> str:
+    def get_content(
+        self,
+        item: Dict[str, Any],
+        offset: Optional[int] = None,
+        limit: int = 700,
+    ) -> Dict[str, Any]:
+        """Fetch Sciverse content and return it with the result identity."""
         extra = item.get('extra') or {}
         doc_id = item.get('doc_id') or extra.get('doc_id')
         if doc_id:
@@ -68,10 +74,11 @@ class SciverseSearch(SearchBase):
                 resp.raise_for_status()
                 data = resp.json()
                 if isinstance(data, dict) and data.get('text'):
-                    return data['text']
+                    return _make_content_result(item, data['text'])
             except Exception:
                 pass
-        return extra.get('content') or item.get('snippet') or super().get_content(item)
+        fallback = extra.get('content') or item.get('snippet')
+        return _make_content_result(item, fallback) if fallback else super().get_content(item)
 
     def search(self, query: str, topk: int = 5, include_content: bool = True,
                search_type: Literal['agentic', 'meta'] = 'agentic',
@@ -115,6 +122,7 @@ class SciverseSearch(SearchBase):
         year_from: Optional[int] = None,
         year_to: Optional[int] = None,
     ) -> Dict[str, Any]:
+        """Search the Sciverse metadata index and return a paginated result envelope."""
         if query and sort:
             raise ValueError('meta_search sort cannot be used together with query')
         if cursor and page > 1:
@@ -180,6 +188,7 @@ class SciverseSearch(SearchBase):
         }
 
     def meta_catalog(self, include_sample_values: bool = False) -> Dict[str, Any]:
+        """Return the searchable Sciverse metadata field catalog."""
         resp = httpx.get(
             f'{self._base_url}/meta-catalog',
             headers=self.inject_auth_header(),

--- a/lazyllm/tools/tools/search/semantic_scholar_search.py
+++ b/lazyllm/tools/tools/search/semantic_scholar_search.py
@@ -17,7 +17,6 @@ class SemanticScholarSearch(SearchBase):
         self._base = 'https://api.semanticscholar.org/graph/v1'
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        '''Fetch a paper abstract and return it with the result identity.'''
         extra = item.get('extra') or {}
         paper_id = extra.get('paperId')
         if not paper_id:

--- a/lazyllm/tools/tools/search/semantic_scholar_search.py
+++ b/lazyllm/tools/tools/search/semantic_scholar_search.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional
 
 from lazyllm.common import ApiKeyHeaderStrategy
 
-from .base import SearchBase, _make_result
+from .base import SearchBase, _make_content_result, _make_result
 
 
 class SemanticScholarSearch(SearchBase):
@@ -16,21 +16,24 @@ class SemanticScholarSearch(SearchBase):
         self._timeout = timeout
         self._base = 'https://api.semanticscholar.org/graph/v1'
 
-    def get_content(self, item: Dict[str, Any]) -> str:
+    def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch a paper abstract and return it with the result identity."""
         extra = item.get('extra') or {}
         paper_id = extra.get('paperId')
         if not paper_id:
             snippet = item.get('snippet', '')
             if snippet:
-                return snippet
+                return _make_content_result(item, snippet)
             return super().get_content(item)
         url = f'{self._base}/paper/{paper_id}'
         try:
             resp = self._request('GET', url, params={'fields': 'abstract'}, timeout=self._timeout)
             data = resp.json()
         except Exception:
-            return (item.get('snippet') or '') or super().get_content(item)
-        return (data.get('abstract') or '').strip() or (item.get('snippet') or '')
+            snippet = item.get('snippet') or ''
+            return _make_content_result(item, snippet) if snippet else super().get_content(item)
+        content = (data.get('abstract') or '').strip() or (item.get('snippet') or '')
+        return _make_content_result(item, content)
 
     def search(self, query: str, limit: int = 10,
                fields: Optional[str] = None) -> List[dict]:

--- a/lazyllm/tools/tools/search/semantic_scholar_search.py
+++ b/lazyllm/tools/tools/search/semantic_scholar_search.py
@@ -17,7 +17,7 @@ class SemanticScholarSearch(SearchBase):
         self._base = 'https://api.semanticscholar.org/graph/v1'
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch a paper abstract and return it with the result identity."""
+        '''Fetch a paper abstract and return it with the result identity.'''
         extra = item.get('extra') or {}
         paper_id = extra.get('paperId')
         if not paper_id:

--- a/lazyllm/tools/tools/search/stackoverflow_search.py
+++ b/lazyllm/tools/tools/search/stackoverflow_search.py
@@ -19,7 +19,7 @@ class StackOverflowSearch(SearchBase):
         self._timeout = timeout
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch a question and accepted answer with the result identity."""
+        '''Fetch a question and accepted answer with the result identity.'''
         url = item.get('url') or ''
         m = re.search(r'/questions/(\d+)', url) if url else None
         if not m:

--- a/lazyllm/tools/tools/search/stackoverflow_search.py
+++ b/lazyllm/tools/tools/search/stackoverflow_search.py
@@ -19,7 +19,6 @@ class StackOverflowSearch(SearchBase):
         self._timeout = timeout
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        '''Fetch a question and accepted answer with the result identity.'''
         url = item.get('url') or ''
         m = re.search(r'/questions/(\d+)', url) if url else None
         if not m:

--- a/lazyllm/tools/tools/search/stackoverflow_search.py
+++ b/lazyllm/tools/tools/search/stackoverflow_search.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 from lazyllm.common import QueryParamStrategy
 from lazyllm.thirdparty import httpx
 
-from .base import SearchBase, _html_to_text, _make_result
+from .base import SearchBase, _html_to_text, _make_content_result, _make_result
 
 
 class StackOverflowSearch(SearchBase):
@@ -18,7 +18,8 @@ class StackOverflowSearch(SearchBase):
         self._site = site
         self._timeout = timeout
 
-    def get_content(self, item: Dict[str, Any]) -> str:
+    def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch a question and accepted answer with the result identity."""
         url = item.get('url') or ''
         m = re.search(r'/questions/(\d+)', url) if url else None
         if not m:
@@ -42,7 +43,7 @@ class StackOverflowSearch(SearchBase):
         body = _html_to_text(raw)
         accepted_id = q.get('accepted_answer_id')
         if not accepted_id:
-            return body
+            return _make_content_result(item, body)
         ans_url = f'https://api.stackexchange.com/2.3/answers/{accepted_id}'
         try:
             ar = httpx.get(ans_url, params=params, timeout=self._timeout)
@@ -52,7 +53,7 @@ class StackOverflowSearch(SearchBase):
                 body = body + '\n\n--- Accepted Answer ---\n\n' + _html_to_text(ans_items[0]['body'])
         except Exception:
             pass
-        return body
+        return _make_content_result(item, body)
 
     def search(self, query: str, count: int = 10,
                sort: str = 'relevance') -> List[dict]:

--- a/lazyllm/tools/tools/search/wikipedia_search.py
+++ b/lazyllm/tools/tools/search/wikipedia_search.py
@@ -22,7 +22,7 @@ class WikipediaSearch(SearchBase):
         self._headers = {'User-Agent': self._UA}
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        """Fetch a Wikipedia extract and return it with the result identity."""
+        '''Fetch a Wikipedia extract and return it with the result identity.'''
         extra = item.get('extra') or {}
         pageid = extra.get('pageid')
         if pageid is None:

--- a/lazyllm/tools/tools/search/wikipedia_search.py
+++ b/lazyllm/tools/tools/search/wikipedia_search.py
@@ -5,7 +5,7 @@ from urllib.parse import quote
 import lazyllm
 from lazyllm.thirdparty import httpx
 
-from .base import SearchBase, _make_result
+from .base import SearchBase, _make_content_result, _make_result
 
 
 class WikipediaSearch(SearchBase):
@@ -21,7 +21,8 @@ class WikipediaSearch(SearchBase):
         self._timeout = timeout
         self._headers = {'User-Agent': self._UA}
 
-    def get_content(self, item: Dict[str, Any]) -> str:
+    def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Fetch a Wikipedia extract and return it with the result identity."""
         extra = item.get('extra') or {}
         pageid = extra.get('pageid')
         if pageid is None:
@@ -42,7 +43,8 @@ class WikipediaSearch(SearchBase):
             return super().get_content(item)
         pages = data.get('query', {}).get('pages') or {}
         page = pages.get(str(pageid)) or {}
-        return (page.get('extract') or '').strip() or super().get_content(item)
+        content = (page.get('extract') or '').strip()
+        return _make_content_result(item, content) if content else super().get_content(item)
 
     def search(self, query: str, limit: int = 10) -> List[dict]:
         params = {

--- a/lazyllm/tools/tools/search/wikipedia_search.py
+++ b/lazyllm/tools/tools/search/wikipedia_search.py
@@ -22,7 +22,6 @@ class WikipediaSearch(SearchBase):
         self._headers = {'User-Agent': self._UA}
 
     def get_content(self, item: Dict[str, Any]) -> Dict[str, Any]:
-        '''Fetch a Wikipedia extract and return it with the result identity.'''
         extra = item.get('extra') or {}
         pageid = extra.get('pageid')
         if pageid is None:

--- a/tests/basic_tests/Tools/test_search_content_contract.py
+++ b/tests/basic_tests/Tools/test_search_content_contract.py
@@ -1,0 +1,70 @@
+from lazyllm.tools.tools.search import (
+    ArxivSearch,
+    SciverseSearch,
+    SearchBase,
+    SemanticScholarSearch,
+    StackOverflowSearch,
+    WikipediaSearch,
+)
+
+
+class FakeSearch(SearchBase):
+
+    def __init__(self):
+        super().__init__(source_name='fake', skip_auth=True)
+
+    def search(self, query: str):
+        return []
+
+    def _fetch_content_text(self, item):
+        return f"Fetched {item['title']}"
+
+
+def test_search_content_preserves_identity_without_framework_citation_fields():
+    provider = FakeSearch()
+    item = {
+        'title': 'Result',
+        'url': 'https://example.test/result',
+        'snippet': 'Snippet',
+        'source': 'fake',
+        'extra': {'doc_id': 'doc-1'},
+        'citation_index': '9.1',
+        'ref': '[[9.1]]',
+    }
+
+    result = provider.get_content(item)
+    batch = provider.get_contents([item])
+
+    assert result == {
+        'title': 'Result',
+        'url': 'https://example.test/result',
+        'snippet': 'Snippet',
+        'source': 'fake',
+        'extra': {'doc_id': 'doc-1'},
+        'content': 'Fetched Result',
+    }
+    assert batch == [result]
+    assert item['ref'] == '[[9.1]]'
+    assert result['extra'] is not item['extra']
+
+
+def test_search_provider_overrides_follow_structured_content_contract():
+    providers = [
+        ArxivSearch(skip_auth=True),
+        SciverseSearch(api_key='test'),
+        SemanticScholarSearch(api_key='test'),
+        StackOverflowSearch(key='test'),
+        WikipediaSearch(skip_auth=True),
+    ]
+    item = {
+        'title': 'Fallback',
+        'url': '',
+        'snippet': 'Snippet',
+        'source': 'test',
+        'extra': {},
+    }
+
+    for provider in providers:
+        result = provider.get_content(item)
+        assert isinstance(result, dict)
+        assert set(result) == {'title', 'url', 'snippet', 'source', 'extra', 'content'}


### PR DESCRIPTION

# 📌 PR Description

- Return structured source metadata from `get_content` and `get_contents`.
- Align content-fetching contracts across search providers.
- Add regression tests for source identity, result ordering, and provider-specific behavior.

---

# 🎯 Problem Context

Search providers previously returned only fetched text from their content methods:

- `get_content(item) -> str`
- `get_contents(items) -> list[str]`

This discarded the source identity associated with the fetched content.

Downstream consumers therefore had to reconstruct the relationship between input search results and returned content.
That required reparsing tool arguments and matching input items with output strings by position.

The reconstruction was fragile across tool boundaries and made it difficult to preserve source metadata consistently.

This PR moves that responsibility into LazyLLM by returning the original source identity together with fetched content.

# 🔍 Related Issue

- Related to the LazyMind citation middleware refactor.
- No standalone issue.

---

# ✅ Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Breaking change
- [ ] Documentation
- [ ] Performance optimization

---

# 🧪 How Has This Been Tested?

1. Tested `SearchBase.get_content` with complete and partial source metadata.
2. Tested `get_contents` result ordering and duplicate preservation.
3. Tested provider overrides to ensure they follow the structured return contract.
4. Verified that returned results do not mutate the original search result objects.
5. Ran the focused search content contract regression tests.

Suggested command:

```bash
python -m pytest \
  tests/basic_tests/Tools/test_search_content_contract.py \
  -v --tb=short
```

Before submitting, also run:

```bash
pip install flake8-quotes
pip install flake8-bugbear
make lint-only-diff
```

---

# 📷 Demo

Not applicable. This PR changes the Python search provider contract and does not introduce UI behavior.

---

# ⚡ Usage After Update

```python
provider = TavilySearch()

items = provider.search('LazyLLM')
content = provider.get_content(items[0])

assert content['title'] == items[0]['title']
assert content['url'] == items[0]['url']
assert content['source'] == items[0]['source']
assert 'content' in content
```

Batch content fetching preserves input order:

```python
contents = provider.get_contents(items)

assert len(contents) == len(items)
assert contents[0]['url'] == items[0]['url']
assert contents[1]['url'] == items[1]['url']
```

---

# 🔄 Refactor Comparison

## Before

```python
item = {
    'title': 'LazyLLM',
    'url': 'https://example.com/lazyllm',
    'source': 'tavily',
}

content = provider.get_content(item)

assert isinstance(content, str)
```

The caller had to retain the input item and associate it with the returned text separately:

```python
result = {
    **item,
    'content': content,
}
```

For batch calls, the caller had to match results by position:

```python
contents = provider.get_contents(items)
results = [
    {**item, 'content': content}
    for item, content in zip(items, contents)
]
```

## After

```python
item = {
    'title': 'LazyLLM',
    'url': 'https://example.com/lazyllm',
    'source': 'tavily',
}

result = provider.get_content(item)

assert result == {
    'title': 'LazyLLM',
    'url': 'https://example.com/lazyllm',
    'snippet': '',
    'source': 'tavily',
    'extra': {},
    'content': result['content'],
}
```

Batch calls return structured results directly:

```python
results = provider.get_contents(items)

assert [result['url'] for result in results] == [
    item['url'] for item in items
]
```

---

# ⚠️ Additional Notes

- This is an intentional breaking change to the search content-fetching contract.
- `get_content` now returns a structured dictionary instead of a string.
- `get_contents` now returns a list of structured dictionaries instead of a list of strings.
- Ranked order and duplicate entries are preserved.
- The returned object contains source identity but no application-specific citation fields.
- LazyMind remains responsible for assigning request-scoped references and citation indices.
- Tool-call JSON normalization and malformed argument repair are excluded from this PR.
- Those bug fixes will be submitted separately.

---

# 🧠 AI Involvement

- [ ] No AI used
- [ ] AI-assisted (partial code)
- [x] AI-led (majority of code)

**Tools Used:**

- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] Other

# 🤖 AI Generation Process

## Initial Prompt

```text
Refactor LazyLLM search content methods so source identity is not lost.

Change SearchBase.get_content to return the original source metadata together
with fetched content. Change get_contents to return the corresponding list of
structured results.

Update provider overrides and add regression tests. LazyLLM must not add
LazyMind-specific citation fields such as ref or citation_index.
```

## Initial Plan

The initial plan was to:

1. Define one structured content result shape in `SearchBase`.
2. Preserve `title`, `url`, `snippet`, `source`, and `extra`.
3. Add fetched page text under `content`.
4. Update provider-specific overrides to follow the same contract.
5. Preserve batch input order and duplicate results.
6. Add focused regression tests for the new contract.

## Problems Found After the Initial Implementation

The first implementation was evaluated together with the downstream LazyMind citation middleware.

The previous string-based contract forced the middleware to:

- Parse tool-call arguments again.
- Recover the original input search items.
- Match input items and fetched content with `zip`.
- Depend on positional association across tool boundaries.

It also made current-request citation registration harder when content was fetched in a later agent turn.

## Problems Identified by the User

The user identified that source identity should be owned by LazyLLM rather than reconstructed by LazyMind.

The user also required that:

- LazyLLM must return provider-neutral source metadata.
- LazyLLM must not contain LazyMind citation indices or references.
- Provider overrides must follow the same contract.
- Cross-turn content fetching must retain enough identity for downstream citation registration.
- Ranked order and duplicates must not be removed by the contract change.

## Advantages After Optimization

The updated design provides the following advantages:

- Source identity remains attached to fetched content.
- Downstream middleware no longer needs to parse tool arguments.
- Positional reconstruction with `zip` is no longer required.
- Provider results remain independent of LazyMind citation state.
- Search result ordering and duplicates are preserved.
- Cross-turn content fetching can register a new request-scoped citation from the returned result.
- The contract is easier to test independently at the LazyLLM boundary.

## Reusable Coding Guidelines

- Preserve source identity when transforming retrieval results.
- Keep framework-level results independent of application-specific citation state.
- Do not require downstream code to reconstruct relationships already known upstream.
- Preserve ranked order and duplicates unless deduplication is an explicit consumer responsibility.
- Avoid mutating provider-returned objects when adding derived fields.
- Define shared contracts at the base class and test every provider override against them.
- Separate contract refactors from unrelated tool-call robustness fixes.