### PR TITLE
fix(search): align Sciverse content return docs

### DIFF
--- a/lazyllm/docs/tools/search.py
+++ b/lazyllm/docs/tools/search.py
@@ -775,7 +775,7 @@ Args:
     limit (int): 单次读取字符数，默认 700；仅 offset 非空时传给接口。
 
 Returns:
-    str: 原文文本、片段文本或空字符串。
+    Dict[str, Any]: 包含 title、url、snippet、source、extra 和 content；正文获取失败时 content 为空字符串。
 ''')
 
 add_english_doc('SciverseSearch.get_content', '''
@@ -789,7 +789,7 @@ Args:
     limit (int): Number of characters to read, default 700; sent only when offset is provided.
 
 Returns:
-    str: Full text, passage text, or an empty string.
+    Dict[str, Any]: title, url, snippet, source, extra, and content. content is empty on fetch failure.
 ''')
 
 add_chinese_doc('SciverseSearch.meta_search', '''

--- a/lazyllm/tools/tools/search/google_books_search.py
+++ b/lazyllm/tools/tools/search/google_books_search.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from lazyllm.common import QueryParamStrategy
 from lazyllm.thirdparty import httpx
@@ -17,7 +17,7 @@ class GoogleBooksSearch(SearchBase):
         self._timeout = timeout
         self._url = 'https://www.googleapis.com/books/v1/volumes'
 
-    def search(self, query: str, max_results: int = 10) -> List[dict]:
+    def search(self, query: str, max_results: int = 10) -> List[Dict[str, Any]]:
         params = self.inject_auth_params({'q': query, 'maxResults': min(max_results, 40)})
         resp = httpx.get(self._url, params=params, timeout=self._timeout)
         resp.raise_for_status()

--- a/lazyllm/tools/tools/search/semantic_scholar_search.py
+++ b/lazyllm/tools/tools/search/semantic_scholar_search.py
@@ -35,7 +35,7 @@ class SemanticScholarSearch(SearchBase):
         return _make_content_result(item, content)
 
     def search(self, query: str, limit: int = 10,
-               fields: Optional[str] = None) -> List[dict]:
+               fields: Optional[str] = None) -> List[Dict[str, Any]]:
         url = f'{self._base}/paper/search'
         params = {
             'query': query,

--- a/lazyllm/tools/tools/search/stackoverflow_search.py
+++ b/lazyllm/tools/tools/search/stackoverflow_search.py
@@ -55,7 +55,7 @@ class StackOverflowSearch(SearchBase):
         return _make_content_result(item, body)
 
     def search(self, query: str, count: int = 10,
-               sort: str = 'relevance') -> List[dict]:
+               sort: str = 'relevance') -> List[Dict[str, Any]]:
         url = 'https://api.stackexchange.com/2.3/search/advanced'
         params = self.inject_auth_params({
             'order': 'desc',


### PR DESCRIPTION
# 📌 PR Description

- Align `SciverseSearch.get_content` documentation with its structured return
  contract.
- Align search return annotations for Stack Overflow, Semantic Scholar, and
  Google Books with `SearchBase`.

---

# 🎯 Problem Context

Search tool schemas are generated from both Python type annotations and
dynamically injected documentation.

ToolManager validates that the documented return type matches the function
prototype. A mismatch causes agent construction to fail before any tool call is
executed.

`SciverseSearch.get_content` returned `Dict[str, Any]`, while its Chinese and
English documentation still declared `str`. This caused the following runtime
error:

```text
TypeError: return info in docstring (<class 'str'>) is different from
function prototype (typing.Dict[str, typing.Any]) in get_content
```

The audit also found three search methods with the inverse mismatch:

- `StackOverflowSearch.search`
- `SemanticScholarSearch.search`
- `GoogleBooksSearch.search`

Their documentation and the `SearchBase` contract declared
`List[Dict[str, Any]]`, while their function annotations used `List[dict]`.

The implementation already returns structured result dictionaries, so the
annotations were made more precise instead of weakening the documentation.

No search execution logic or returned data was changed.

# 🔍 Related Issue

# ✅ Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation
- [ ] Performance optimization

---

# ⚡ Usage After Update

```python
from lazyllm.tools.agent.toolsManager import ToolManager
from lazyllm.tools.tools import SciverseSearch

provider = SciverseSearch(api_key='<your_api_key>')
manager = ToolManager([provider])
```

`SciverseSearch.get_content` is now correctly documented as returning:

```python
{
    'title': '...',
    'url': '...',
    'snippet': '...',
    'source': 'sciverse',
    'extra': {},
    'content': '...',
}
```

---

# 🔄 Refactor Comparison

## Before

```python
def get_content(...) -> Dict[str, Any]:
    ...
```

```text
Returns:
    str: Full text, passage text, or an empty string.
```

Some provider search methods also used an overly broad annotation:

```python
def search(...) -> List[dict]:
    ...
```

## After

```text
Returns:
    Dict[str, Any]: title, url, snippet, source, extra, and content.
```

Provider annotations now follow the shared SearchBase contract:

```python
def search(...) -> List[Dict[str, Any]]:
    ...
```

---

# ⚠️ Additional Notes

- This change does not alter search execution behavior.
- This change does not alter provider result ordering or result contents.
- Tencent Search was checked statically because its optional SDK is not
  installed in the local test environment.
- The unrelated tool-call JSON normalization changes are not included.
