### PR TITLE
feat(online-chat): pass through provider status

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
+++ b/lazyllm/module/llms/onlinemodule/base/onlineChatModuleBase.py
@@ -5,6 +5,7 @@ import requests
 import re
 import random
 import time
+import uuid
 from typing import Tuple, List, Dict, Union, Any, Optional
 from urllib.parse import urljoin
 from operator import itemgetter as itemget
@@ -17,22 +18,25 @@ from ....servermodule import LLMBase, StaticParams
 from .utils import LazyLLMOnlineBase, resolve_online_params
 
 
-def _is_input_inspection_failure(exc: Exception) -> bool:
-    detail = str(exc).lower()
-    return 'data_inspection_failed' in detail or 'input data may contain inappropriate content' in detail
+config.add('online_chat_transport_max_retries', int, 5, 'ONLINE_CHAT_TRANSPORT_MAX_RETRIES',
+           description='The number of extra online chat attempts allowed for transient transport failures.')
+config.add('online_chat_transport_retry_base_delay_s', float, 1.0, 'ONLINE_CHAT_TRANSPORT_RETRY_BASE_DELAY_S',
+           description='The base delay in seconds for online chat transport retries.')
+config.add('online_chat_transport_retry_max_delay_s', float, 16.0, 'ONLINE_CHAT_TRANSPORT_RETRY_MAX_DELAY_S',
+           description='The maximum delay in seconds for online chat transport retries.')
+config.add('online_chat_transport_retry_jitter_ratio', float, 0.2, 'ONLINE_CHAT_TRANSPORT_RETRY_JITTER_RATIO',
+           description='The jitter ratio applied to online chat transport retry delays.')
 
 
-def _remove_prior_tool_traces(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    '''Drop untrusted tool payloads from older turns while preserving conversational history.'''
-    last_user_index = max(
-        (index for index, message in enumerate(messages) if message.get('role') == 'user'),
-        default=len(messages),
-    )
-    return [
-        message for index, message in enumerate(messages)
-        if index >= last_user_index
-        or (message.get('role') != 'tool' and not message.get('tool_calls'))
-    ]
+class _ProviderResponseError(requests.RequestException):
+    def __init__(self, message: str, *, http_status: Optional[int], error_body: Optional[str]):  # noqa B042
+        super().__init__(message)
+        self.http_status = http_status
+        self.error_body = error_body
+
+
+class _ProviderHTTPError(_ProviderResponseError): pass
+class _ProviderProtocolError(_ProviderResponseError): pass
 
 
 class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
@@ -41,6 +45,7 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
     NO_PROXY = True
     __lazyllm_registry_key__ = LLMType.CHAT
     _message_format = 'openai'
+    _openai_compatible_response = True
 
     def __init__(self, api_key: Union[str, List[str]], base_url: str, model_name: str,
                  stream: Union[bool, Dict[str, str]], return_trace: bool = False, skip_auth: bool = False,
@@ -97,28 +102,140 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
         return data
 
     def _str_to_json(self, msg: str, stream_output: bool):
-        if isinstance(msg, bytes):
-            msg = msg.decode('utf-8')
-        content = re.sub(r'^data:\s*', '', msg.strip())
-        if not content or content == '[DONE]':
-            return ''
+        content = self._extract_sse_payload(msg)
+        if content is None or content == '[DONE]': return ''
         try:
-            message = self._convert_msg_format(json.loads(content))
-            if not stream_output: return message
-            color = stream_output.get('color') if isinstance(stream_output, dict) else None
-            for item in message.get('choices', []):
-                delta = item.get('message', item.get('delta', {}))
-                if delta.get('reasoning_content') and delta.get('content'):
-                    lazyllm.LOG.warning('stream delta contains both reasoning_content and content')
-                if (reasoning_content := delta.get('reasoning_content', '')):
-                    self._stream_output(reasoning_content, color, cls='think')
-                if (content := delta.get('content', '')) and not delta.get('tool_calls'):
-                    self._stream_output(content, color)
-            lazyllm.LOG.debug(f'message: {message}')
-            return message
-        except Exception:
-            lazyllm.LOG.warning(f'Failed to parse message: {msg}')
-            return ''
+            raw_message = json.loads(content)
+        except (TypeError, ValueError) as exc:
+            raise _ProviderProtocolError('Provider returned an invalid JSON frame.', http_status=200,
+                                         error_body=content) from exc
+        if not isinstance(raw_message, dict):
+            raise _ProviderProtocolError('Provider returned a non-object JSON frame.', http_status=200,
+                                         error_body=content)
+        if raw_message.get('error') is not None:
+            raise _ProviderProtocolError('Provider returned an error frame.', http_status=200, error_body=content)
+        try:
+            message = self._convert_msg_format(raw_message)
+        except Exception as exc:
+            raise _ProviderProtocolError('Provider response conversion failed.', http_status=200,
+                                         error_body=content) from exc
+        if not isinstance(message, dict):
+            if message in ('', None): return ''
+            raise _ProviderProtocolError('Provider response conversion returned an invalid frame.', http_status=200,
+                                         error_body=content)
+        if stream_output: self._emit_message_content(message, stream_output)
+        lazyllm.LOG.debug(f'message: {message}')
+        return message
+
+    @staticmethod
+    def _extract_sse_payload(msg: Union[str, bytes]) -> Optional[str]:
+        if isinstance(msg, bytes):
+            try:
+                msg = msg.decode('utf-8')
+            except UnicodeDecodeError as exc:
+                body = msg.decode('utf-8', errors='replace')
+                raise _ProviderProtocolError('Provider returned a non-UTF-8 frame.', http_status=200,
+                                             error_body=body) from exc
+        content = msg.strip()
+        if not content or content.startswith(':') or re.match(r'^(event|id|retry):', content): return None
+        return re.sub(r'^data:\s?', '', content)
+
+    def _emit_message_content(self, message: Dict[str, Any], stream_output: Union[bool, Dict]):
+        color = stream_output.get('color') if isinstance(stream_output, dict) else None
+        for item in message.get('choices', []):
+            if not isinstance(item, dict): continue
+            delta = item.get('message', item.get('delta', {}))
+            if not isinstance(delta, dict): continue
+            if delta.get('reasoning_content') and delta.get('content'):
+                lazyllm.LOG.warning('stream delta contains both reasoning_content and content')
+            if (reasoning_content := delta.get('reasoning_content', '')):
+                self._stream_output(reasoning_content, color, cls='think')
+            if (content := delta.get('content', '')) and not delta.get('tool_calls'):
+                self._stream_output(content, color)
+
+    @staticmethod
+    def _frame_state(message: Dict[str, Any], error_body: Optional[str] = None) -> Tuple[Optional[Any], bool]:
+        choices = message.get('choices')
+        if choices is None: return None, False
+        if not isinstance(choices, list):
+            raise _ProviderProtocolError('Provider response has an invalid choices field.', http_status=200,
+                                         error_body=error_body)
+        if not choices: return None, False
+        choice = choices[0]
+        if not isinstance(choice, dict):
+            raise _ProviderProtocolError('Provider response has an invalid first choice.', http_status=200,
+                                         error_body=error_body)
+        delta = choice.get('message') or choice.get('delta') or {}
+        if not isinstance(delta, dict):
+            raise _ProviderProtocolError('Provider response has an invalid choice payload.', http_status=200,
+                                         error_body=error_body)
+        semantic_output = bool(delta.get('content') or delta.get('reasoning_content') or delta.get('tool_calls'))
+        finish_reason = choice.get('finish_reason')
+        return finish_reason if finish_reason not in (None, '') else None, semantic_output
+
+    def _emit_structured_event(self, stream_output: Union[bool, Dict], tag: str, **fields):
+        if not stream_output: return
+        payload = {'tag': tag, **fields}
+        stream_sink = stream_output.get('_stream_sink') if isinstance(stream_output, dict) \
+            else getattr(self, '_stream_sink', None)
+        if stream_sink is not None:
+            stream_sink(payload)
+        else:
+            lazyllm.FileSystemQueue().enqueue(json.dumps(payload, ensure_ascii=False))
+
+    def _emit_provider_status(self, state: Dict[str, Any], stream_output: Union[bool, Dict],
+                              error_body: Optional[str] = None):
+        if state['provider_status_emitted']: return
+        fields = {
+            'model_call_id': state['model_call_id'],
+            'http_status': state['http_status'],
+            'finish_reason': state['finish_reason'],
+        }
+        if error_body is not None: fields['error_body'] = error_body
+        self._emit_structured_event(stream_output, 'provider_status', **fields)
+        state['provider_status_emitted'] = True
+
+    @staticmethod
+    def _exception_chain(exc: Exception):
+        seen = set()
+        while exc is not None and id(exc) not in seen:
+            seen.add(id(exc))
+            yield exc
+            exc = exc.__cause__ or exc.__context__
+
+    @classmethod
+    def _is_retryable_transport_error(cls, exc: Exception) -> bool:
+        chain = tuple(cls._exception_chain(exc))
+        if any(isinstance(item, (requests.exceptions.SSLError, requests.exceptions.ProxyError)) for item in chain):
+            return False
+        retryable_types = (
+            requests.exceptions.ConnectTimeout,
+            requests.exceptions.ReadTimeout,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.ConnectionError,
+            ConnectionResetError,
+            ConnectionAbortedError,
+            BrokenPipeError,
+        )
+        retryable_names = {'RemoteDisconnected', 'IncompleteRead', 'ProtocolError'}
+        return any(isinstance(item, retryable_types) or type(item).__name__ in retryable_names for item in chain)
+
+    @classmethod
+    def _is_transport_error(cls, exc: Exception) -> bool:
+        if isinstance(exc, _ProviderResponseError): return False
+        chain = tuple(cls._exception_chain(exc))
+        transport_types = (
+            requests.exceptions.Timeout,
+            requests.exceptions.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.SSLError,
+            requests.exceptions.ProxyError,
+            ConnectionResetError,
+            ConnectionAbortedError,
+            BrokenPipeError,
+        )
+        transport_names = {'RemoteDisconnected', 'IncompleteRead', 'ProtocolError'}
+        return any(isinstance(item, transport_types) or type(item).__name__ in transport_names for item in chain)
 
     def _extract_specified_key_fields(self, response: Dict[str, Any]):
         if not ('choices' in response and isinstance(response['choices'], list)):
@@ -161,31 +278,61 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
             return {k: self._merge_stream_result([d.get(k) for d in src], k == 'content') for k in set().union(*src)}
         return src[-1]
 
-    def _extract_partial_content(self, msg_json: list) -> str:
-        if not msg_json:
-            return ''
-        try:
-            extractor = self._extract_specified_key_fields(self._merge_stream_result(msg_json))
-            return extractor.get('content', '') or ''
-        except Exception:
-            return ''
-
-    def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
-                      proxies: Optional[Dict], request_timeout: Optional[Union[float, Tuple[float, float]]]
+    def _forward_impl(self, data: Dict[str, Any], *, runtime_url: str,  # noqa C901
+                      stream_output: Union[bool, Dict],
+                      proxies: Optional[Dict], request_timeout: Optional[Union[float, Tuple[float, float]]],
+                      state: Dict[str, Any],
                       ) -> List[Dict[str, Any]]:
-        with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
-                           proxies=proxies, timeout=request_timeout) as r:
-            if r.status_code != 200:
-                err_msg = '\n'.join([c.decode('utf-8') for c in r.iter_content(None)]) \
-                    if stream_output else r.text
-                raise requests.RequestException(f'{r.status_code}: {err_msg}')
+        msg_json = []
+        try:
+            with requests.post(runtime_url, json=data, headers=self._header, stream=stream_output,
+                               proxies=proxies, timeout=request_timeout) as r:
+                state['http_status'] = r.status_code
+                if r.status_code != 200:
+                    error_body = r.text
+                    raise _ProviderHTTPError(f'Provider returned HTTP status {r.status_code}.',
+                                             http_status=r.status_code, error_body=error_body)
 
-            with self.stream_output(stream_output):
-                msg_json = list(filter(lambda x: x, (
-                    [self._str_to_json(line, stream_output) for line in r.iter_lines() if len(line)]
-                    if stream_output
-                    else [self._str_to_json(r.text, stream_output)]
-                )))
+                with self.stream_output(stream_output):
+                    frames = r.iter_lines() if stream_output else [r.text]
+                    for raw_frame in frames:
+                        if raw_frame in (b'', ''): continue
+                        if self._openai_compatible_response:
+                            payload = self._extract_sse_payload(raw_frame)
+                            if payload is None: continue
+                            if payload == '[DONE]':
+                                if state['finish_reason'] is None:
+                                    raise _ProviderProtocolError(
+                                        'Provider stream ended without a finish_reason.',
+                                        http_status=200, error_body=payload,
+                                    )
+                                break
+                            message = self._str_to_json(payload, stream_output)
+                        else:
+                            message = self._str_to_json(raw_frame, stream_output)
+                        if not message: continue
+                        msg_json.append(message)
+                        finish_reason, semantic_output = self._frame_state(
+                            message, payload if self._openai_compatible_response else None,
+                        )
+                        if semantic_output: state['semantic_output_emitted'] = True
+                        if self._openai_compatible_response and finish_reason is not None:
+                            state['finish_reason'] = finish_reason
+                if self._openai_compatible_response and state['finish_reason'] is None:
+                    raise _ProviderProtocolError('Provider response ended without a finish_reason.',
+                                                 http_status=200, error_body='')
+        except _ProviderResponseError as exc:
+            if self._openai_compatible_response:
+                state['http_status'] = exc.http_status
+                self._emit_provider_status(state, stream_output, exc.error_body)
+            raise
+        except Exception as exc:
+            if self._openai_compatible_response and state['finish_reason'] is not None \
+                    and self._is_retryable_transport_error(exc):
+                self._emit_provider_status(state, stream_output)
+                return msg_json
+            raise
+        if self._openai_compatible_response: self._emit_provider_status(state, stream_output)
         return msg_json
 
     def _request_timeout(self, data: Dict[str, Any],
@@ -207,68 +354,52 @@ class LazyLLMOnlineChatModuleBase(LazyLLMOnlineBase, LLMBase):
             return None
 
     def _forward_with_retry(self, data: Dict[str, Any], *, runtime_url: str, stream_output: Union[bool, Dict],
-                            proxies: Optional[Dict], max_retries: int,
+                            proxies: Optional[Dict], max_retries: Optional[int],
                             request_timeout: Optional[Union[float, Tuple[float, float]]]) -> List[Dict[str, Any]]:
-        _RETRY_DELAYS = [3, 10, 30]
-        _CONTINUATION_PROMPT = (
-            'Your previous response was interrupted. '
-            'Please continue your response exactly from where it left off. '
-            'Do NOT repeat any content that was already provided. '
-            'Do NOT add any transitional phrases like "Continuing..." or "As I was saying...". '
-            'Just seamlessly continue the response. '
-            'Keep the same language as your previous response.'
-        )
-        msg_json = []
-        partial_content = ''
-        for attempt in range(max_retries):
-            if attempt > 0 and partial_content:
-                # If the stream was cut mid-tool-call, the partial assistant message contains
-                # a truncated tool_calls block with malformed JSON arguments.  Appending it
-                # back into the history causes a 400 from providers that validate
-                # function.arguments.  In that case, skip the continuation injection and
-                # retry with the original messages so the model can restart the tool call.
-                last_msg = data['messages'][-1] if data['messages'] else {}
-                stream_cut_in_tool_call = (
-                    last_msg.get('role') == 'assistant' and last_msg.get('tool_calls')
-                )
-                if not stream_cut_in_tool_call:
-                    data['messages'].append({'role': 'assistant', 'content': partial_content})
-                    data['messages'].append({'role': 'user', 'content': _CONTINUATION_PROMPT})
-                else:
-                    lazyllm.LOG.warning('Stream interrupted mid-tool-call; retrying without continuation injection.')
-                partial_content = ''
+        total_attempts = max_retries if max_retries is not None \
+            else config['online_chat_transport_max_retries'] + 1
+        if total_attempts < 1: raise ValueError('max_retries must be at least 1.')
+        retry_budget = total_attempts - 1
+        state = {
+            'model_call_id': f'call_{uuid.uuid4().hex}',
+            'http_status': None,
+            'finish_reason': None,
+            'semantic_output_emitted': False,
+            'provider_status_emitted': False,
+        }
+        for attempt in range(total_attempts):
             try:
-                msg_json = self._forward_impl(data, runtime_url=runtime_url,
-                                              stream_output=stream_output, proxies=proxies,
-                                              request_timeout=request_timeout)
-            except (requests.exceptions.ChunkedEncodingError, requests.exceptions.ConnectionError):
-                if attempt < max_retries - 1:
-                    partial_content = self._extract_partial_content(msg_json)
-                    lazyllm.LOG.warning(f'Stream interrupted (attempt {attempt + 1}), retrying...')
-                    time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
+                return self._forward_impl(data, runtime_url=runtime_url, stream_output=stream_output,
+                                          proxies=proxies, request_timeout=request_timeout, state=state)
+            except Exception as exc:
+                retryable = self._is_retryable_transport_error(exc)
+                if retryable and not state['semantic_output_emitted'] and attempt < total_attempts - 1:
+                    retry_index = attempt + 1
+                    base_delay = max(0.0, config['online_chat_transport_retry_base_delay_s'])
+                    max_delay = max(base_delay, config['online_chat_transport_retry_max_delay_s'])
+                    jitter_ratio = max(0.0, config['online_chat_transport_retry_jitter_ratio'])
+                    nominal_delay = min(base_delay * (2 ** (retry_index - 1)), max_delay)
+                    delay = random.uniform(max(0.0, nominal_delay * (1 - jitter_ratio)),
+                                           nominal_delay * (1 + jitter_ratio))
+                    self._emit_structured_event(stream_output, 'model_retry',
+                                                model_call_id=state['model_call_id'], retry_index=retry_index,
+                                                max_retries=retry_budget, delay_ms=round(delay * 1000))
+                    lazyllm.LOG.warning(f'Online chat transport retry {retry_index}/{retry_budget} '
+                                        f'for model call {state["model_call_id"]}.')
+                    time.sleep(delay)
                     continue
+                if self._is_transport_error(exc):
+                    self._emit_structured_event(
+                        stream_output, 'model_transport_error', model_call_id=state['model_call_id'],
+                        http_status=None, finish_reason=None, error_type=type(exc).__name__,
+                        error_message=str(exc),
+                    )
                 raise
-            except requests.RequestException as exc:
-                if _is_input_inspection_failure(exc) and attempt < max_retries - 1:
-                    sanitized = _remove_prior_tool_traces(data.get('messages') or [])
-                    if len(sanitized) < len(data.get('messages') or []):
-                        data['messages'] = sanitized
-                        lazyllm.LOG.warning(
-                            'Provider rejected model input during content inspection; retrying without '
-                            'tool calls/results from prior turns while preserving conversation messages.'
-                        )
-                        continue
-                if attempt < max_retries - 1:
-                    lazyllm.LOG.warning(f'Request failed (attempt {attempt + 1}), retrying...')
-                    time.sleep(_RETRY_DELAYS[min(attempt, len(_RETRY_DELAYS) - 1)])
-                    continue
-                raise
-            break
-        return msg_json
+        raise RuntimeError('Online chat retry loop exited unexpectedly.')
 
     def forward(self, __input: Union[Dict, str] = None, *, llm_chat_history: List[List[str]] = None,
                 tools: List[Dict[str, Any]] = None, stream_output: bool = None, stream: bool = None,
-                lazyllm_files=None, url: str = None, model: str = None, max_retries: int = 3, **kw):
+                lazyllm_files=None, url: str = None, model: str = None, max_retries: Optional[int] = None, **kw):
         request_timeout = self._request_timeout(kw, default_timeout=self._timeout)
         stream_output = stream_output if stream_output is not None else stream
         stream_output = stream_output if stream_output is not None else self._stream

--- a/lazyllm/module/llms/onlinemodule/supplier/claude.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/claude.py
@@ -13,6 +13,7 @@ class ClaudeChat(OnlineChatModuleBase):
     _ANTHROPIC_VERSION = '2023-06-01'
     _DEFAULT_MAX_TOKENS = 4096
     _message_format = 'anthropic'
+    _openai_compatible_response = False
 
     def __init__(self, base_url: Optional[str] = None, model: Optional[str] = None,
                  api_key: str = None, stream: bool = True, return_trace: bool = False, **kwargs):

--- a/tests/basic_tests/Models/test_online_chat_history_sanitization.py
+++ b/tests/basic_tests/Models/test_online_chat_history_sanitization.py
@@ -1,37 +1,6 @@
-import requests
-
 from lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase import (
     LazyLLMOnlineChatModuleBase,
-    _is_input_inspection_failure,
-    _remove_prior_tool_traces,
 )
-
-
-def test_input_inspection_failure_detection_is_specific():
-    assert _is_input_inspection_failure(
-        requests.RequestException('400: {"code":"data_inspection_failed"}')
-    )
-    assert not _is_input_inspection_failure(requests.RequestException('500: unavailable'))
-
-
-def test_prior_tool_traces_are_removed_without_losing_conversation_or_current_observation():
-    messages = [
-        {'role': 'system', 'content': 'system'},
-        {'role': 'user', 'content': 'original goal'},
-        {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'old'}]},
-        {'role': 'tool', 'tool_call_id': 'old', 'content': 'untrusted web payload'},
-        {'role': 'assistant', 'content': 'prior final answer'},
-        {'role': 'user', 'content': 'continue with that goal'},
-        {'role': 'assistant', 'content': '', 'tool_calls': [{'id': 'current'}]},
-        {'role': 'tool', 'tool_call_id': 'current', 'content': 'current observation'},
-    ]
-
-    sanitized = _remove_prior_tool_traces(messages)
-
-    assert [message.get('content') for message in sanitized] == [
-        'system', 'original goal', 'prior final answer', 'continue with that goal', '', 'current observation',
-    ]
-    assert sanitized[-2]['tool_calls'] == [{'id': 'current'}]
 
 
 def test_streamed_tool_calls_merge_by_index_when_chunk_lengths_differ():

--- a/tests/basic_tests/Models/test_online_chat_provider_status.py
+++ b/tests/basic_tests/Models/test_online_chat_provider_status.py
@@ -1,0 +1,297 @@
+import json
+
+import pytest
+import requests
+
+from lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase import (
+    LazyLLMOnlineChatModuleBase,
+    _ProviderHTTPError,
+    _ProviderProtocolError,
+)
+from lazyllm.module.llms.onlinemodule.supplier.claude import ClaudeChat
+
+
+class _TestChat(LazyLLMOnlineChatModuleBase):
+    def _get_system_prompt(self):
+        return 'test'
+
+
+class _Response:
+    def __init__(self, status_code=200, frames=(), text=None):
+        self.status_code = status_code
+        self._frames = frames
+        self.text = text if text is not None else ''
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def iter_lines(self):
+        for frame in self._frames:
+            if isinstance(frame, Exception): raise frame
+            yield frame
+
+
+def _module():
+    return _TestChat(api_key='', base_url='http://provider.test/v1/', model_name='test',
+                     stream=True, skip_auth=True)
+
+
+def _stream_frame(delta=None, finish_reason=None, usage=None):
+    choice = {'index': 0, 'delta': delta or {}, 'finish_reason': finish_reason}
+    payload = {'choices': [choice]}
+    if usage is not None: payload['usage'] = usage
+    return f'data: {json.dumps(payload)}'.encode()
+
+
+def _call(module, monkeypatch, responses, *, max_retries=1):
+    events = []
+    iterator = iter(responses)
+
+    def post(*args, **kwargs):
+        response = next(iterator)
+        if isinstance(response, Exception): raise response
+        return response
+
+    monkeypatch.setattr(requests, 'post', post)
+    result = module._forward_with_retry(
+        {'messages': []}, runtime_url='http://provider.test/v1/chat/completions',
+        stream_output={'_stream_sink': events.append}, proxies=None, max_retries=max_retries,
+        request_timeout=1,
+    )
+    return result, events
+
+
+@pytest.mark.parametrize('finish_reason', ['stop', 'tool_calls', 'length', 'content_filter', 'VendorLimit'])
+def test_finish_reason_is_forwarded_without_normalization(monkeypatch, finish_reason):
+    module = _module()
+    _, events = _call(module, monkeypatch, [
+        _Response(frames=[_stream_frame({'content': 'answer'}, finish_reason), b'data: [DONE]']),
+    ])
+
+    statuses = [event for event in events if event['tag'] == 'provider_status']
+    assert statuses == [{
+        'tag': 'provider_status',
+        'model_call_id': statuses[0]['model_call_id'],
+        'http_status': 200,
+        'finish_reason': finish_reason,
+    }]
+
+
+@pytest.mark.parametrize('status_code,error_body', [
+    (429, '{"error":{"message":"rate limited"}}'),
+    (503, 'temporarily unavailable'),
+])
+def test_non_200_body_is_forwarded_once_and_never_retried(monkeypatch, status_code, error_body):
+    module = _module()
+    events = []
+    calls = 0
+
+    def post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _Response(status_code=status_code, text=error_body)
+
+    monkeypatch.setattr(requests, 'post', post)
+    with pytest.raises(_ProviderHTTPError) as exc_info:
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert calls == 1
+    assert error_body not in str(exc_info.value)
+    assert [event['tag'] for event in events] == ['provider_status']
+    assert events[0]['http_status'] == status_code
+    assert events[0]['error_body'] == error_body
+
+
+def test_http_200_error_frame_preserves_payload(monkeypatch):
+    module = _module()
+    payload = '{"error":{"code":"bad_request","message":"invalid"}}'
+    events = []
+    monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: _Response(frames=[f'data: {payload}'.encode()]))
+
+    with pytest.raises(_ProviderProtocolError) as exc_info:
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert payload not in str(exc_info.value)
+    assert events[-1] == {
+        'tag': 'provider_status',
+        'model_call_id': events[-1]['model_call_id'],
+        'http_status': 200,
+        'finish_reason': None,
+        'error_body': payload,
+    }
+
+
+@pytest.mark.parametrize('frame,error_body', [
+    (b'data: not-json', 'not-json'),
+    (b'data: [DONE]', '[DONE]'),
+])
+def test_protocol_errors_are_forwarded_and_not_retried(monkeypatch, frame, error_body):
+    module = _module()
+    events = []
+    calls = 0
+
+    def post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _Response(frames=[frame])
+
+    monkeypatch.setattr(requests, 'post', post)
+    with pytest.raises(_ProviderProtocolError):
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert calls == 1
+    assert events[-1]['error_body'] == error_body
+
+
+def test_clean_eof_without_finish_reason_is_protocol_error(monkeypatch):
+    module = _module()
+    events = []
+    monkeypatch.setattr(requests, 'post', lambda *args, **kwargs: _Response(frames=[
+        _stream_frame({'role': 'assistant'}),
+    ]))
+
+    with pytest.raises(_ProviderProtocolError):
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert events[-1]['http_status'] == 200
+    assert events[-1]['finish_reason'] is None
+    assert events[-1]['error_body'] == ''
+
+
+def test_network_failures_retry_with_same_call_id_then_succeed(monkeypatch):
+    module = _module()
+    sleeps = []
+    monkeypatch.setattr('lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase.random.uniform',
+                        lambda low, high: (low + high) / 2)
+    monkeypatch.setattr('lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase.time.sleep', sleeps.append)
+    _, events = _call(module, monkeypatch, [
+        requests.exceptions.ConnectTimeout('connect timeout'),
+        requests.exceptions.ReadTimeout('read timeout'),
+        _Response(frames=[_stream_frame({'content': 'ok'}, 'stop'), b'data: [DONE]']),
+    ], max_retries=3)
+
+    retries = [event for event in events if event['tag'] == 'model_retry']
+    status = next(event for event in events if event['tag'] == 'provider_status')
+    assert [event['retry_index'] for event in retries] == [1, 2]
+    assert [event['max_retries'] for event in retries] == [2, 2]
+    assert sleeps == [1.0, 2.0]
+    assert {event['model_call_id'] for event in retries} == {status['model_call_id']}
+
+
+def test_default_retry_budget_is_five_extra_attempts(monkeypatch):
+    module = _module()
+    events = []
+    calls = 0
+    monkeypatch.setattr('lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase.random.uniform',
+                        lambda low, high: (low + high) / 2)
+    monkeypatch.setattr('lazyllm.module.llms.onlinemodule.base.onlineChatModuleBase.time.sleep', lambda delay: None)
+
+    def post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise requests.exceptions.ReadTimeout('read timeout')
+
+    monkeypatch.setattr(requests, 'post', post)
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=None, request_timeout=1,
+        )
+
+    assert calls == 6
+    assert len([event for event in events if event['tag'] == 'model_retry']) == 5
+    assert [event['tag'] for event in events][-1] == 'model_transport_error'
+
+
+@pytest.mark.parametrize('delta', [
+    {'content': 'partial'},
+    {'reasoning_content': 'thinking'},
+    {'tool_calls': [{'index': 0, 'function': {'arguments': '{'}}]},
+])
+def test_disconnect_after_semantic_output_is_not_retried(monkeypatch, delta):
+    module = _module()
+    events = []
+    calls = 0
+
+    def post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return _Response(frames=[_stream_frame(delta), requests.exceptions.ChunkedEncodingError('cut')])
+
+    monkeypatch.setattr(requests, 'post', post)
+    with pytest.raises(requests.exceptions.ChunkedEncodingError):
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert calls == 1
+    assert not [event for event in events if event['tag'] == 'model_retry']
+    assert events[-1]['tag'] == 'model_transport_error'
+
+
+@pytest.mark.parametrize('error', [
+    requests.exceptions.SSLError('certificate verify failed'),
+    requests.exceptions.ProxyError('proxy unavailable'),
+])
+def test_certificate_and_proxy_errors_are_not_retried(monkeypatch, error):
+    module = _module()
+    events = []
+    calls = 0
+
+    def post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise error
+
+    monkeypatch.setattr(requests, 'post', post)
+    with pytest.raises(type(error)):
+        module._forward_with_retry(
+            {'messages': []}, runtime_url='http://provider.test',
+            stream_output={'_stream_sink': events.append}, proxies=None, max_retries=6, request_timeout=1,
+        )
+
+    assert calls == 1
+    assert [event['tag'] for event in events] == ['model_transport_error']
+
+
+def test_finish_reason_remains_authoritative_if_connection_closes_before_done(monkeypatch):
+    module = _module()
+    _, events = _call(module, monkeypatch, [
+        _Response(frames=[
+            _stream_frame({'content': 'complete'}, 'stop'),
+            requests.exceptions.ChunkedEncodingError('missing done'),
+        ]),
+    ])
+
+    assert events[-1]['tag'] == 'provider_status'
+    assert events[-1]['finish_reason'] == 'stop'
+    assert not [event for event in events if event['tag'] == 'model_transport_error']
+
+
+def test_claude_native_protocol_does_not_emit_openai_provider_status(monkeypatch):
+    module = ClaudeChat(api_key='test', base_url='http://provider.test/', stream=True)
+    _, events = _call(module, monkeypatch, [
+        _Response(frames=[
+            b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}',
+            b'data: {"type":"message_stop"}',
+        ]),
+    ])
+
+    assert not [event for event in events if event['tag'] == 'provider_status']
+    assert any(event.get('tag') == 'text' and event.get('delta') == 'hello' for event in events)


### PR DESCRIPTION
## What changed

- pass OpenAI-compatible provider HTTP status and raw `choices[0].finish_reason` through structured stream events
- emit retry and terminal transport-error events with one stable model call ID
- retry only pre-output transient network failures, with bounded exponential backoff and jitter
- preserve non-200 and HTTP 200 error-frame payloads for immediate delivery without embedding them in exception strings
- keep native Claude responses opted out of the OpenAI-compatible status protocol

## Why

Provider implementations return different termination reasons and error envelopes. Normalizing them inside LazyLLM loses the provider's authoritative signal and can also cause unsafe retries after partial output.

## Impact

Callers can observe exact provider status without changing the existing Agent lifecycle finish reason. HTTP/protocol/provider errors are surfaced immediately; only retryable transport failures before semantic output are retried.

## Root cause

The previous streaming path mixed provider termination, content inspection, continuation, and broad request retries. It did not expose a stable provider outcome contract to downstream consumers.

## Validation

- 23 targeted LazyLLM tests passed
- flake8 passed for changed Python files
- local fake OpenAI-compatible HTTP/SSE service passed stop, HTTP 429 passthrough, and read-timeout-then-success scenarios
- no real paid provider was called
