### PR TITLE
fix: allow larger h11 request headers

### DIFF
--- a/lazyllm/components/deploy/relay/server.py
+++ b/lazyllm/components/deploy/relay/server.py
@@ -58,6 +58,8 @@ parser.add_argument('--pythonpath')
 parser.add_argument('--num_replicas', type=int, default=1, help='num of ray replicas')
 parser.add_argument('--security_key', type=str, default=None, help='security key')
 parser.add_argument('--defined_pos', type=str, default=None, help='user defined positional')
+parser.add_argument('--h11_max_incomplete_event_size', type=int, default=1024 * 1024,
+                    help='maximum buffered size for an incomplete h11 request event')
 args = parser.parse_args()
 
 func = load_obj(args.function)
@@ -208,4 +210,5 @@ if __name__ == '__main__':
                     printed = True
             time.sleep(2)
     else:
-        uvicorn.run(app, host=args.open_ip, port=args.open_port)
+        uvicorn.run(app, host=args.open_ip, port=args.open_port,
+                    h11_max_incomplete_event_size=args.h11_max_incomplete_event_size)


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

## Problem
Large retrieval contexts can exceed h11’s default request-header buffer, causing Connection reset by peer.

## Fix
Increase the relay’s h11 buffer limit to 1 MiB and make it configurable via a startup argument.

## Verification
A 170 KB header request now returns HTTP 200 without connection resets.

---


# ✅ 变更类型 / Type of Change

* [X] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

<!-- 本 PR 是否使用 AI 工具 / Whether AI tools were used in this PR -->
- [ ] 未使用 AI / No AI used
- [X] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [X] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：
