### PR TITLE
feat(agent): support dynamic skill visibility

### DIFF
--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -642,6 +642,7 @@ Args:
     stream (bool): 是否启用流式输出，默认为False。
     return_last_tool_calls (bool): 若为True，在模型结束且存在工具调用记录时返回最后一次的工具调用轨迹。
     skills (bool | str | List[str]): Skills 配置。True 启用 Skills 并自动筛选；传入 str/list 启用指定技能。
+    skill_manager (SkillManager, optional): 预构建的 SkillManager。使用时不要同时传入 skills、fs 或 skills_dir。
     desc (str): Agent 能力描述，可为空。
     workspace (str): Agent 默认工作目录，默认是 `config['home']/agent_workspace`。
 ''')
@@ -758,7 +759,8 @@ SkillManager 用于发现、加载与管理 Skills。
 
 Args:
     dir (str, optional): Skills 目录路径，支持逗号分隔的多个路径。
-    skills (Iterable[str], optional): 期望使用的技能名称列表。
+    skills (Iterable[str], optional): 初始向模型展示的技能名称列表。
+    allowed_skills (Iterable[str], optional): 当前 Agent 被允许调用的技能名称列表。省略时保持原有行为。
     max_skill_md_bytes (int, optional): 单个 SKILL.md 最大读取大小。
     llm: 预留参数，目前不强制使用。
 ''')
@@ -768,7 +770,8 @@ SkillManager discovers, loads, and manages Skills.
 
 Args:
     dir (str, optional): Skills directory paths, comma-separated is supported.
-    skills (Iterable[str], optional): Expected skill name list.
+    skills (Iterable[str], optional): Skill names initially exposed to the model.
+    allowed_skills (Iterable[str], optional): Skill names the current agent is allowed to invoke. Omit to keep the legacy behavior.
     max_skill_md_bytes (int, optional): Maximum SKILL.md size to load.
     llm: Reserved parameter, not required currently.
 ''')
@@ -785,6 +788,34 @@ List available skills under configured directories and return a Markdown string.
 
 **Returns:**\n
 - str: Skill list with name/description/path.
+''')
+
+add_chinese_doc('SkillManager.list_skill_metadata', '''\
+按可见或允许范围返回结构化 Skill 元数据，用于外部检索器，不读取完整工作流正文。
+
+Args:
+    scope (str): `visible` 或 `allowed`。
+''')
+
+add_english_doc('SkillManager.list_skill_metadata', '''\
+Return structured Skill metadata for the visible or allowed scope without loading workflow bodies.
+
+Args:
+    scope (str): `visible` or `allowed`.
+''')
+
+add_chinese_doc('SkillManager.expose_skills', '''\
+将允许范围内的 Skill 动态加入当前 Agent 会话的可见范围。
+
+Args:
+    names (Iterable[str]): Skill 名称或标识列表。
+''')
+
+add_english_doc('SkillManager.expose_skills', '''\
+Dynamically expose allowed Skills to the current agent session.
+
+Args:
+    names (Iterable[str]): Skill names or identifiers.
 ''')
 
 add_chinese_doc('SkillManager.build_prompt', '''\
@@ -998,6 +1029,7 @@ Args:
     stream (bool): Whether to enable streaming output for real-time display. Defaults to False.
     return_last_tool_calls (bool): If True, returns the last tool-call trace when the model finishes with pending tool calls.
     skills (bool | str | List[str]): Skills configuration. True enables Skills with automatic selection; a str/list enables the specified skills.
+    skill_manager (SkillManager, optional): A prebuilt SkillManager. Do not also pass skills, fs, or skills_dir.
     desc (str): Description of the agent capabilities. Can be empty.
     workspace (str): Default working directory for the agent. Defaults to `config['home']/agent_workspace`.
     force_summarize (bool): When True, if the agent has not produced a final answer after max_retries + 1 tool-call iterations, one additional LLM call is made with the full conversation history plus a force-summarize instruction, asking the model to stop tool calls and output its final answer immediately. If False (default), a ValueError is raised instead.

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -45,9 +45,18 @@ class LazyLLMAgentBase(ModuleBase):
                  desc: str = '', workspace: Optional[str] = None,
                  sandbox: Union[str, LazyLLMSandboxBase, None] = 'auto',
                  fs: Optional[Any] = None, skills_dir: Optional[str] = None,
-                 enable_builtin_tools: bool = True):
+                 enable_builtin_tools: bool = True,
+                 skill_manager: Optional[SkillManager] = None):
         super().__init__(return_trace=return_trace)
         use_skills, skills = self._normalize_skills_config(skills)
+        if skill_manager is not None:
+            if not isinstance(skill_manager, SkillManager):
+                raise TypeError('skill_manager must be a SkillManager instance.')
+            if use_skills or fs is not None or skills_dir is not None:
+                raise ValueError(
+                    'skills, fs, and skills_dir must be omitted when skill_manager is provided.'
+                )
+            use_skills = True
         if not use_skills and (fs is not None or skills_dir is not None):
             import warnings
             warnings.warn(
@@ -65,8 +74,12 @@ class LazyLLMAgentBase(ModuleBase):
         self._return_last_tool_calls = return_last_tool_calls
         self._workspace = self._init_workspace(workspace)
         self._agent = None
-        self._skill_manager = None
-        self._sandbox = create_sandbox() if sandbox == 'auto' else sandbox
+        self._skill_manager = skill_manager
+        self._sandbox = (
+            skill_manager.sandbox
+            if skill_manager is not None and sandbox == 'auto'
+            else create_sandbox() if sandbox == 'auto' else sandbox
+        )
         self._builtin_tool_names = set()
         self._skill_tool_names = set()
         self._enable_builtin_tools = enable_builtin_tools
@@ -74,9 +87,10 @@ class LazyLLMAgentBase(ModuleBase):
         if self._enable_builtin_tools:
             self._ensure_builtin_tools()
         if use_skills:
-            self._skill_manager = SkillManager(
-                dir=skills_dir, skills=self._skills, fs=fs, sandbox=self._sandbox,
-            )
+            if self._skill_manager is None:
+                self._skill_manager = SkillManager(
+                    dir=skills_dir, skills=self._skills, fs=fs, sandbox=self._sandbox,
+                )
             self._ensure_default_skill_tools()
         self._tools_manager = ToolManager(self._tools, return_trace=return_trace, sandbox=self._sandbox)
         for tool in self._tools_manager.all_tools:

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -81,11 +81,12 @@ class ReactAgent(LazyLLMAgentBase):
                  keep_full_turns: int = 0, fs: Optional[Any] = None, skills_dir: Optional[str] = None,
                  enable_builtin_tools: bool = True,
                  extra_stop_condition: Optional[Callable] = None,
-                 on_max_retries: Optional[Callable] = None):
+                 on_max_retries: Optional[Callable] = None,
+                 skill_manager: Optional[Any] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries, return_trace=return_trace,
                          stream=stream, return_last_tool_calls=return_last_tool_calls, skills=skills,
                          desc=desc, workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir,
-                         enable_builtin_tools=enable_builtin_tools)
+                         enable_builtin_tools=enable_builtin_tools, skill_manager=skill_manager)
         prompt = prompt or INSTRUCTION
         if self._return_last_tool_calls:
             prompt += '\nIf no more tool calls are needed, reply with ok and skip any summary.'

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -196,7 +196,7 @@ class ReactAgent(LazyLLMAgentBase):
         )
         return summary if summary else None
 
-    def _post_process(self, ret):
+    def _post_process(self, ret):  # noqa: C901
         if isinstance(ret, str):
             completed = self._pop_tool_calls()
             if completed is not None:

--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, List, Optional, Tuple
 
 import yaml
 
-from lazyllm import config, LOG, ModuleBase
+from lazyllm import config, LOG, ModuleBase, locals as lazyllm_locals
 from lazyllm.thirdparty import fsspec
 
 DEFAULT_SKILLS_DIR = os.path.join(config['home'], 'skills')
@@ -101,6 +101,7 @@ _META_REQUIRED_FIELDS = {
 
 class SkillManager(ModuleBase):
     def __init__(self, dir: Optional[str] = None, skills: Optional[Iterable[str]] = None,
+                 allowed_skills: Optional[Iterable[str]] = None,
                  max_skill_md_bytes: Optional[int] = None, fs=None, sandbox=None):
         super().__init__(return_trace=False)
         self._fs = fs or fsspec.implementations.local.LocalFileSystem()
@@ -111,10 +112,18 @@ class SkillManager(ModuleBase):
         self._skills_dir = self._parse_dirs(dir or config['skills_dir'], fs=fs)
         self._validate_fs_dir_consistency(fs, self._skills_dir)
         self._skills_expected = self._parse_skills(skills)
+        self._allowed_skills_expected = (
+            None if allowed_skills is None else self._parse_skills(allowed_skills)
+        )
         self._max_skill_md_bytes = max_skill_md_bytes or config['max_skill_md_bytes']
         self._skills_index: Dict[str, Dict] = {}
+        self._skills_allowed: List[str] = []
         self._skills_selected: List[str] = []
         self._skills_index_lock = threading.Lock()
+
+    @property
+    def sandbox(self):
+        return self._sandbox
 
     @staticmethod
     def _extract_protocol(path: str) -> Optional[str]:
@@ -363,58 +372,82 @@ class SkillManager(ModuleBase):
                 return
             skills_index: Dict[str, Dict] = {}
             for skill_dir, skill_md in self._iter_skill_files():
-                try:
-                    size = self._fs_getsize(skill_md)
-                    if size is not None and size > self._max_skill_md_bytes:
-                        continue
-                    content = self._fs_read(skill_md)
-                    if size is None and self._content_exceeds_limit(content):
-                        continue
-                    meta = self._extract_yaml_meta(content)
-                    validation_error = self._validate_meta(meta)
-                    if validation_error:
-                        details = ' '.join(
-                            f'{detail_key}={detail_value}'
-                            for detail_key, detail_value in validation_error.items()
-                        )
-                        LOG.warning(
-                            f'event=skill_load_skipped {details} skill_md={skill_md!r}'
-                        )
-                        continue
-                    name = meta['name']
-                    key = self._skill_key_from_dir(skill_dir)
-                    if not key or key in skills_index:
-                        continue
-                    skills_index[key] = {
-                        'key': key,
-                        'name': name,
-                        'description': meta['description'],
-                        'argument-hint': meta.get('argument-hint', ''),
-                        'disable-model-invocation': self._to_bool(meta.get('disable-model-invocation', False)),
-                        'user-invocable': self._to_bool(meta.get('user-invocable', True)),
-                        'allowed-tools': meta.get('allowed-tools'),
-                        'source': self._extract_protocol(skill_dir) or 'file',
-                        'path': skill_dir,
-                        'skill_md': skill_md,
-                        'raw_meta': meta,
-                    }
-                except Exception as exc:
-                    LOG.warning(
-                        'event=skill_load_skipped code=unexpected_skill_load_error '
-                        f'error_type={type(exc).__name__} skill_md={skill_md!r}'
-                    )
+                entry = self._load_skill_index_entry(skill_dir, skill_md)
+                if entry is None:
                     continue
+                key, info = entry
+                if key not in skills_index:
+                    skills_index[key] = info
             self._skills_index = skills_index
-            if self._skills_expected:
-                self._skills_selected = [
-                    key for key in (self._resolve_skill_ref(ref, self._skills_index.keys())[0]
-                                    for ref in self._skills_expected)
-                    if key
-                ]
+            model_invocable = [
+                key for key, info in self._skills_index.items()
+                if not info.get('disable-model-invocation')
+            ]
+            if self._allowed_skills_expected is not None:
+                self._skills_allowed = self._resolve_skill_refs(
+                    self._allowed_skills_expected, model_invocable,
+                )
+            elif self._skills_expected:
+                self._skills_allowed = self._resolve_skill_refs(
+                    self._skills_expected, self._skills_index.keys(),
+                )
             else:
-                self._skills_selected = [
-                    key for key, info in self._skills_index.items() if not info.get('disable-model-invocation')
-                ]
+                self._skills_allowed = model_invocable
+
+            if self._skills_expected:
+                self._skills_selected = self._resolve_skill_refs(
+                    self._skills_expected, self._skills_allowed,
+                )
+            elif self._allowed_skills_expected is None:
+                self._skills_selected = list(self._skills_allowed)
+
+    def _load_skill_index_entry(self, skill_dir: str, skill_md: str) -> Optional[Tuple[str, Dict]]:
+        try:
+            size = self._fs_getsize(skill_md)
+            if size is not None and size > self._max_skill_md_bytes:
+                return None
+            content = self._fs_read(skill_md)
+            if size is None and self._content_exceeds_limit(content):
+                return None
+            meta = self._extract_yaml_meta(content)
+            validation_error = self._validate_meta(meta)
+            if validation_error:
+                details = ' '.join(
+                    f'{detail_key}={detail_value}'
+                    for detail_key, detail_value in validation_error.items()
+                )
+                LOG.warning(f'event=skill_load_skipped {details} skill_md={skill_md!r}')
+                return None
+            key = self._skill_key_from_dir(skill_dir)
+            if not key:
+                return None
+            return key, {
+                'key': key,
+                'name': meta['name'],
+                'description': meta['description'],
+                'argument-hint': meta.get('argument-hint', ''),
+                'disable-model-invocation': self._to_bool(meta.get('disable-model-invocation', False)),
+                'user-invocable': self._to_bool(meta.get('user-invocable', True)),
+                'allowed-tools': meta.get('allowed-tools'),
+                'source': self._extract_protocol(skill_dir) or 'file',
+                'path': skill_dir,
+                'skill_md': skill_md,
+                'raw_meta': meta,
+            }
+        except Exception as exc:
+            LOG.warning(
+                'event=skill_load_skipped code=unexpected_skill_load_error '
+                f'error_type={type(exc).__name__} skill_md={skill_md!r}'
+            )
+            return None
+
+    def _resolve_skill_refs(self, refs: Iterable[str], keys: Iterable[str]) -> List[str]:
+        resolved = []
+        for ref in refs:
+            key, _ = self._resolve_skill_ref(ref, keys)
+            if key and key not in resolved:
+                resolved.append(key)
+        return resolved
 
     def _resolve_skill_ref(self, ref: str, keys: Iterable[str]) -> Tuple[Optional[str], Optional[Dict]]:
         name = str(ref or '').strip()
@@ -442,15 +475,29 @@ class SkillManager(ModuleBase):
             }
         return matches[0], None
 
-    def _visible_skill_keys(self) -> List[str]:
+    def _allowed_skill_keys(self) -> List[str]:
         self._load_skills_index()
-        if self._skills_selected:
-            return [key for key in self._skills_selected if key in self._skills_index]
-        if self._skills_expected:
+        return [key for key in self._skills_allowed if key in self._skills_index]
+
+    def _runtime_exposed_skill_keys(self) -> List[str]:
+        try:
+            workspace = lazyllm_locals['_lazyllm_agent'].setdefault('workspace', {})
+        except Exception:
             return []
+        exposed_by_manager = workspace.get('_exposed_skills', {})
+        if not isinstance(exposed_by_manager, dict):
+            return []
+        exposed = exposed_by_manager.get(self._module_id, [])
+        return list(exposed) if isinstance(exposed, list) else []
+
+    def _visible_skill_keys(self) -> List[str]:
+        allowed = set(self._allowed_skill_keys())
         return [
-            key for key, info in self._skills_index.items()
-            if not info.get('disable-model-invocation')
+            key for key in dict.fromkeys([
+                *self._skills_selected,
+                *self._runtime_exposed_skill_keys(),
+            ])
+            if key in allowed
         ]
 
     def _visible_skills_index(self) -> Dict[str, Dict]:
@@ -466,6 +513,66 @@ class SkillManager(ModuleBase):
         if error:
             return None, error
         return self._skills_index.get(key), None
+
+    @staticmethod
+    def _metadata_list(value) -> List[str]:
+        if isinstance(value, str):
+            values = [item.strip() for item in value.split(',')]
+        elif isinstance(value, (list, tuple, set)):
+            values = [str(item).strip() for item in value]
+        else:
+            values = []
+        return list(dict.fromkeys(item for item in values if item))
+
+    def _skill_metadata(self, key: str) -> Dict:
+        info = self._skills_index[key]
+        raw_meta = info.get('raw_meta') or {}
+        return {
+            'id': key,
+            'name': str(info.get('name') or key),
+            'description': str(info.get('description') or ''),
+            'aliases': self._metadata_list(raw_meta.get('aliases')),
+            'tags': self._metadata_list(raw_meta.get('tags')),
+            'source': str(info.get('source') or 'file'),
+            'revision': str(raw_meta.get('revision') or ''),
+        }
+
+    def list_skill_metadata(self, scope: str = 'visible') -> List[Dict]:
+        if scope == 'visible':
+            keys = self._visible_skill_keys()
+        elif scope == 'allowed':
+            keys = self._allowed_skill_keys()
+        else:
+            raise ValueError("scope must be 'visible' or 'allowed'.")
+        return [self._skill_metadata(key) for key in keys]
+
+    def expose_skills(self, names: Iterable[str]) -> Dict:
+        allowed_keys = self._allowed_skill_keys()
+        resolved, errors = [], []
+        for name in self._parse_skills(names):
+            key, error = self._resolve_skill_ref(name, allowed_keys)
+            if error:
+                errors.append(error)
+            elif key and key not in resolved:
+                resolved.append(key)
+        try:
+            workspace = lazyllm_locals['_lazyllm_agent'].setdefault('workspace', {})
+            exposed_by_manager = workspace.setdefault('_exposed_skills', {})
+            exposed = exposed_by_manager.setdefault(self._module_id, [])
+        except Exception as exc:
+            return {
+                'status': 'error',
+                'skills': [],
+                'errors': [{'status': 'error', 'error': str(exc)}],
+            }
+        for key in resolved:
+            if key not in exposed:
+                exposed.append(key)
+        return {
+            'status': 'ok' if not errors else 'partial',
+            'skills': [self._skill_metadata(key) for key in resolved],
+            'errors': errors,
+        }
 
     def list_skill(self) -> str:
         visible_skills = self._visible_skills_index()

--- a/tests/advanced_tests/Tools/test_skills.py
+++ b/tests/advanced_tests/Tools/test_skills.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 
 import lazyllm
+from lazyllm.common import new_session
 from lazyllm.tools import ReactAgent
 from lazyllm.cli.skills import skills as skills_cli
 from lazyllm.tools.agent.skill_manager import SkillManager
@@ -101,6 +102,73 @@ class TestSkills(object):
         listing = manager.list_skill()
         assert self._alpha_name in listing
         assert self._beta_name in listing
+
+    def test_skill_manager_separates_allowed_and_visible_skills(self):
+        manager = SkillManager(
+            dir=self._src_root,
+            skills=[self._alpha_name],
+            allowed_skills=[self._alpha_name, self._beta_name],
+        )
+
+        assert [item['id'] for item in manager.list_skill_metadata('visible')] == [
+            self._alpha_name,
+        ]
+        assert [item['id'] for item in manager.list_skill_metadata('allowed')] == [
+            self._alpha_name,
+            self._beta_name,
+        ]
+        assert manager.get_skill(self._beta_name)['status'] == 'missing'
+
+        with new_session('skill-exposure-one'):
+            result = manager.expose_skills([self._beta_name, 'not-allowed'])
+            assert result['status'] == 'partial'
+            assert [item['id'] for item in result['skills']] == [self._beta_name]
+            assert manager.get_skill(self._beta_name)['status'] == 'ok'
+
+        with new_session('skill-exposure-two'):
+            assert manager.get_skill(self._beta_name)['status'] == 'missing'
+
+    def test_skill_metadata_normalizes_aliases_and_tags(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = _make_skill(tmp, 'resume', 'resume')
+            with open(os.path.join(skill_dir, 'SKILL.md'), 'w', encoding='utf-8') as f:
+                f.write(
+                    '---\n'
+                    'name: resume\n'
+                    'description: Build a professional resume.\n'
+                    'aliases: [CV, 简历]\n'
+                    'tags: career, document\n'
+                    'revision: v2\n'
+                    '---\n'
+                )
+
+            metadata = SkillManager(dir=tmp).list_skill_metadata('allowed')
+
+            assert metadata == [{
+                'id': 'resume',
+                'name': 'resume',
+                'description': 'Build a professional resume.',
+                'aliases': ['CV', '简历'],
+                'tags': ['career', 'document'],
+                'source': 'file',
+                'revision': 'v2',
+            }]
+
+    def test_allowed_scope_excludes_skills_that_disable_model_invocation(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            skill_dir = _make_skill(tmp, 'manual-only', 'manual-only')
+            with open(os.path.join(skill_dir, 'SKILL.md'), 'w', encoding='utf-8') as f:
+                f.write(
+                    '---\n'
+                    'name: manual-only\n'
+                    'description: Must not be called by a model.\n'
+                    'disable-model-invocation: true\n'
+                    '---\n'
+                )
+
+            manager = SkillManager(dir=tmp, allowed_skills=['manual-only'])
+
+            assert manager.list_skill_metadata('allowed') == []
 
     def test_parse_dirs_local_expands_paths(self):
         parsed = SkillManager._parse_dirs('~/skills')

--- a/tests/basic_tests/Tools/test_agent_base.py
+++ b/tests/basic_tests/Tools/test_agent_base.py
@@ -49,6 +49,18 @@ class TestLazyLLMAgentBase(object):
             if tool.name in agent._skill_tool_names
         )
 
+    def test_agent_accepts_prebuilt_skill_manager(self, tmp_path):
+        skill_manager = SkillManager(dir=str(tmp_path), allowed_skills=[])
+
+        agent = _DummyAgent(
+            skill_manager=skill_manager,
+            enable_builtin_tools=False,
+        )
+
+        assert agent._skill_manager is skill_manager
+        assert agent._sandbox is skill_manager.sandbox
+        assert agent._skill_tool_names == {'get_skill', 'read_reference', 'run_script'}
+
     def test_agent_sandbox_auto_creates_sandbox(self, monkeypatch):
         sentinel = object()
         monkeypatch.setattr(agent_base_module, 'create_sandbox', lambda: sentinel)


### PR DESCRIPTION
## What
把 SkillManager 构造时的 Skill 列表拆成两个概念：
- `allowed_skills`：权限/启用边界，运行中不可越过
- `skills`：初始可见集合

新增：
- `expose_skills(ids)`：在当前 session 内动态把 allowed skill 加入可见
- `list_skill_metadata(scope='allowed'|'visible')`：对外暴露 descriptor catalog（不含 SKILL.md 正文）
- 动态 exposed 存 session-local workspace，session 结束自动清理，不跨会话泄漏
- `ReactAgent`/`LazyLLMAgentBase` 支持传入预构建 `skill_manager`

## Why
LazyMind 需要在 AgentLoop 前做候选筛选、Loop 内二次发现，但原 SkillManager 把「允许范围」和「当前可见范围」混为一谈，无法动态扩大可见范围。

## Tests
- `test_skills.py` + `test_agent_base.py`：allowed/visible 分离、aliases/tags 归一化、disable-model-invocation 不进 allowed、动态 expose 边界、Agent 接受预构建 manager（25 passed）
- 既有 `test_react_agent_with_skills` 需下载 Qwen2.5-32B + ModelScope，与本次无关，本地 deselect
