### PR TITLE
feat(online): add OrcaRouter chat provider

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -167,7 +167,7 @@ https://github.com/LazyAGI/LazyLLM/assets/12124621/77267adc-6e40-47b8-96a8-895df
         + 支持根据用户场景自动选择最合适的框架和模型参数(如micro-bs、tp、zero等)。
     * 在线服务：
         + 支持微调服务：GPT、SenseNova、通义千问
-        + 支持推理服务：GPT、SenseNova、Kimi、智谱、通义千问
+        + 支持推理服务：GPT、SenseNova、Kimi、智谱、通义千问、OrcaRouter
         + 支持Embedding推理服务：Openai、SenseNova、GLM、通义千问
     * 支持开发者以统一的方式使用本地服务和线上服务
 4. **支持RAG常用组件**：Document、Parser、Retriever、Reranker等。

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ For more examples, please refer to our official documentation [Usage Examples](h
         + Supports automatically selecting the most suitable framework and model parameters (such as micro-bs, tp, zero, etc.) based on user scenarios..
     * Online services:
         + Supports fine-tuning services: GPT, SenseNova, Tongyi Qianwen
-        + Supports inference services: GPT, SenseNova, Kimi, Zhipu, Tongyi Qianwen
+        + Supports inference services: GPT, SenseNova, Kimi, Zhipu, Tongyi Qianwen, OrcaRouter
         + Supports embedding inference services: OpenAI, SenseNova, GLM, Tongyi Qianwen
     * Support developers to use local services and online services uniformly.
 4. **Supports common RAG (Retrieval-Augmented Generation) components**: Document, Parser, Retriever, Reranker, etc.

--- a/docs/en/API Reference/module.md
+++ b/docs/en/API Reference/module.md
@@ -196,6 +196,10 @@
     options:
       members:
 
+::: lazyllm.module.llms.onlinemodule.supplier.orcarouter.OrcaRouterChat
+    options:
+      members:
+
 ::: lazyllm.module.llms.onlinemodule.supplier.doubao.DoubaoText2Image
     options:
       members:

--- a/docs/zh/API Reference/module.md
+++ b/docs/zh/API Reference/module.md
@@ -196,6 +196,10 @@
     options:
       members:
 
+::: lazyllm.module.llms.onlinemodule.supplier.orcarouter.OrcaRouterChat
+    options:
+      members:
+
 ::: lazyllm.module.llms.onlinemodule.supplier.doubao.DoubaoText2Image
     options:
       members:

--- a/lazyllm/cli/run.py
+++ b/lazyllm/cli/run.py
@@ -79,7 +79,7 @@ def run(commands):
     if args.command in ('chatbot', 'rag'):
         parser.add_argument('--model', type=str, default=None, help='model name')
         parser.add_argument('--source', type=str, default=None, help='Online model source, conflict with framework',
-                            choices=['openai', 'sensenova', 'glm', 'kimi', 'qwen', 'doubao'])
+                            choices=['openai', 'sensenova', 'glm', 'kimi', 'qwen', 'doubao', 'orcarouter'])
         parser.add_argument('--framework', type=str, default=None, help='Online model source, conflict with source',
                             choices=['lightllm', 'vllm', 'lmdeploy'])
         if args.command == 'rag':

--- a/lazyllm/docs/module.py
+++ b/lazyllm/docs/module.py
@@ -2683,6 +2683,47 @@ Args:
     **kwargs: Other parameters passed to base class
 """)
 
+add_chinese_doc('llms.onlinemodule.supplier.orcarouter.OrcaRouterChat', """\
+OrcaRouter 在线聊天模块，继承自 OnlineChatModuleBase。
+封装了对 [OrcaRouter](https://www.orcarouter.ai) API 的调用，用于进行多轮问答交互。
+OrcaRouter 是一个多模型统一网关，默认使用智能路由模型 `orcarouter/auto`，支持流式输出和调用链追踪。
+OrcaRouter 提供 OpenAI 兼容的 API 接口。It also runs gateway-level, zero-trust security for AI agents on the same endpoint.
+
+Args:
+    model (str): 使用的模型名称，默认为 `orcarouter/auto`。
+    base_url (str): API 基础 URL，默认为 "https://api.orcarouter.ai/v1/"。
+    api_key (Optional[str]): OrcaRouter API Key（`sk-orca-` 前缀），若未提供，则从 lazyllm.config['orcarouter_api_key'] 读取。
+    stream (bool): 是否启用流式输出，默认为 True。
+    return_trace (bool): 是否返回调用链追踪信息，默认为 False。
+    **kwargs: 其他传递给基类 OnlineChatModuleBase 的参数。
+""")
+
+add_english_doc('llms.onlinemodule.supplier.orcarouter.OrcaRouterChat', """\
+OrcaRouter online chat module, inheriting from OnlineChatModuleBase.
+Wraps the [OrcaRouter](https://www.orcarouter.ai) API for multi-turn Q&A interactions.
+OrcaRouter is a unified multi-model gateway. Defaults to the smart-routing model `orcarouter/auto`,
+supporting streaming and optional trace return. OrcaRouter provides an OpenAI-compatible API interface.
+It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every
+prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Args:
+    model (str): The model name to use. Defaults to `orcarouter/auto`.
+    base_url (str): Base URL of the API, default is "https://api.orcarouter.ai/v1/".
+    api_key (Optional[str]): OrcaRouter API key (prefixed `sk-orca-`). If not provided, it is read from `lazyllm.config['orcarouter_api_key']`.
+    stream (bool): Whether to enable streaming output. Defaults to True.
+    return_trace (bool): Whether to return trace information. Defaults to False.
+    **kwargs: Additional arguments passed to the base class OnlineChatModuleBase.
+""")
+
+add_example('llms.onlinemodule.supplier.orcarouter.OrcaRouterChat', """\
+>>> import lazyllm
+>>> # Set environment variable: export LAZYLLM_ORCAROUTER_API_KEY=your_api_key
+>>> # Or create config file ~/.lazyllm/config.json: {"orcarouter_api_key": "your_api_key"}
+>>> chat = lazyllm.OnlineChatModule(source='orcarouter', model='orcarouter/auto')
+>>> response = chat('Hello, how are you?')
+>>> print(response)
+""")
+
 add_chinese_doc('llms.onlinemodule.supplier.glm.GLMEmbed', """\
 GLM嵌入模型接口类，用于调用智谱AI的文本嵌入服务。
 

--- a/lazyllm/module/llms/onlinemodule/map_model_type.py
+++ b/lazyllm/module/llms/onlinemodule/map_model_type.py
@@ -456,6 +456,12 @@ MODEL_MAPPING = {
     'deepseek-v4-flash': 'llm',
     'deepseek-v4-pro': 'llm',
 
+    # ===== OrcaRouter (gateway) =====
+    'orcarouter/auto': 'llm',
+    'orcarouter/fusion': 'llm',
+    'orcarouter/fusion-flash': 'llm',
+    'orcarouter/fusion-mini': 'llm',
+
     # ===== SiliconFlow =====
     # free speech2text model
     'FunAudioLLM/SenseVoiceSmall': 'stt',

--- a/lazyllm/module/llms/onlinemodule/supplier/orcarouter.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/orcarouter.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from ..base import OnlineChatModuleBase
+
+
+class OrcaRouterChat(OnlineChatModuleBase):
+    PROVIDER_NAME = 'orcarouter'
+
+    def __init__(self, base_url: Optional[str] = None, model: Optional[str] = None,
+                 api_key: str = None, stream: bool = True, return_trace: bool = False,
+                 skip_auth: bool = False, **kw):
+        base_url = base_url or 'https://api.orcarouter.ai/v1/'
+        model = model or 'orcarouter/auto'
+        super().__init__(api_key=api_key or self._default_api_key(),
+                         base_url=base_url, model_name=model, stream=stream,
+                         return_trace=return_trace, skip_auth=skip_auth, **kw)
+
+    def _get_system_prompt(self):
+        return 'You are a helpful assistant.'

--- a/tests/basic_tests/Models/test_orcarouter_provider.py
+++ b/tests/basic_tests/Models/test_orcarouter_provider.py
@@ -1,0 +1,25 @@
+import lazyllm
+import pytest
+from lazyllm.module.llms.onlinemodule.supplier.orcarouter import OrcaRouterChat
+
+
+class TestOrcaRouterChat:
+
+    def test_registered_in_online_chat(self):
+        assert 'orcarouter' in lazyllm.online.chat
+        assert lazyllm.online.chat.orcarouter is OrcaRouterChat
+
+    def test_default_base_url_and_model(self):
+        chat = OrcaRouterChat(api_key='sk-orca-test')
+        assert chat._base_url == 'https://api.orcarouter.ai/v1/'
+        assert chat._model_name == 'orcarouter/auto'
+
+    def test_custom_base_url_and_model(self):
+        chat = OrcaRouterChat(api_key='sk-orca-test', base_url='https://custom.example/v1',
+                              model='orcarouter/fusion')
+        assert chat._base_url == 'https://custom.example/v1'
+        assert chat._model_name == 'orcarouter/fusion'
+
+    def test_api_key_required(self):
+        with pytest.raises(ValueError, match='api_key is required'):
+            OrcaRouterChat(api_key=None)

--- a/tests/basic_tests/Modules/test_map_model.py
+++ b/tests/basic_tests/Modules/test_map_model.py
@@ -9,7 +9,11 @@ test_models = {
         'sensechat-128k',
         'glm-4-5-airx',
         'qwen3-coder-plus-2025-09-23',
-        'deepseek-v3-1-terminus'
+        'deepseek-v3-1-terminus',
+        'orcarouter/auto',
+        'orcarouter/fusion',
+        'orcarouter/fusion-flash',
+        'orcarouter/fusion-mini'
     ],
     'vlm': [
         'moonshot-v1-128k-vision-preview',


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

Add a named **OrcaRouter** online chat provider to LazyLLM's `OnlineChatModule`.

[OrcaRouter](https://www.orcarouter.ai) is a unified multi-model gateway that exposes an OpenAI-compatible API (`https://api.orcarouter.ai/v1/`). This PR mirrors the existing DeepSeek/PPIO OpenAI-compatible gateway wiring so users can select it by name (`source='orcarouter'`) instead of manually filling in a generic OpenAI-compatible endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

---

# 🎯 问题背景 / Problem Context

- LazyLLM already ships named providers (openai, deepseek, ppio, glm, kimi, qwen, ...). OrcaRouter is another OpenAI-compatible gateway, so adding a named provider keeps the user experience consistent and lets users route through OrcaRouter's smart-routing models (`orcarouter/auto`, `orcarouter/fusion`, `orcarouter/fusion-flash`, `orcarouter/fusion-mini`).

# 🔍 相关 Issue / Related Issue

* None (small provider addition following the existing supplier pattern in `lazyllm/module/llms/onlinemodule/supplier/`).

---

# ✅ 变更类型 / Type of Change

* [x] New feature

---

# 🧪 如何测试 / How Has This Been Tested?

1. `python3 -m flake8` on all changed files — clean.
2. `pytest tests/basic_tests/Models/test_orcarouter_provider.py tests/basic_tests/Modules/test_map_model.py` — 5 passed.
3. `pytest tests/basic_tests/Models/test_online_chat_model_runtime.py` — 59 passed (regression).
4. `pytest tests/doc_check/test_doc_api_check.py -k OrcaRouterChat` — passed (docs registration).
5. Live end-to-end (real API key): `OnlineChatModule(source='orcarouter', model='orcarouter/auto')` → `https://api.orcarouter.ai/v1/chat/completions` → HTTP 200 `ORCA-LIVE-OK`. All four gateway models (`orcarouter/auto`, `fusion`, `fusion-flash`, `fusion-mini`) returned `ORCA-LIVE-OK`.

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
import lazyllm
# export LAZYLLM_ORCAROUTER_API_KEY=sk-orca-...
chat = lazyllm.OnlineChatModule(source='orcarouter', model='orcarouter/auto')
print(chat('Hello!'))
```

---

# ⚠️ 注意事项 / Additional Notes

- Default `base_url` is `https://api.orcarouter.ai/v1/` (trailing slash, matching the existing `openai.py` convention so `urljoin` produces `/v1/chat/completions`).
- OrcaRouter is a chat-only gateway — no embedding/rerank endpoints were added.

# 🧠 AI 参与情况 / AI Involvement

- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)

**使用工具 / Tools Used：**
- [x] ClaudeCode
