### PR TITLE
Support legacy Markdown skill metadata

### DIFF
--- a/lazyllm/tools/agent/skill_manager.py
+++ b/lazyllm/tools/agent/skill_manager.py
@@ -309,6 +309,32 @@ class SkillManager(ModuleBase):
         return meta if isinstance(meta, dict) else None
 
     @staticmethod
+    def _has_frontmatter_start(text: str) -> bool:
+        normalized = text.lstrip('\ufeff')
+        return normalized == '---' or normalized.startswith(('---\n', '---\r\n'))
+
+    @staticmethod
+    def _extract_legacy_meta(text: str, name: str) -> Optional[dict]:
+        if SkillManager._has_frontmatter_start(text):
+            return None
+        paragraph = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                if paragraph:
+                    break
+                continue
+            if line.startswith(('#', '|', '- ', '* ', '> ', '```')) or line == '---':
+                continue
+            paragraph.append(line)
+        if not paragraph:
+            return None
+        description = re.sub(r'[*_`]+', '', ' '.join(paragraph)).strip()
+        if not description:
+            return None
+        return {'name': name, 'description': description}
+
+    @staticmethod
     def _validate_meta(meta: Optional[dict]) -> Optional[Dict[str, str]]:
         if not isinstance(meta, dict):
             return {
@@ -370,7 +396,11 @@ class SkillManager(ModuleBase):
                     content = self._fs_read(skill_md)
                     if size is None and self._content_exceeds_limit(content):
                         continue
-                    meta = self._extract_yaml_meta(content)
+                    key = self._skill_key_from_dir(skill_dir)
+                    if self._has_frontmatter_start(content):
+                        meta = self._extract_yaml_meta(content)
+                    else:
+                        meta = self._extract_legacy_meta(content, key.rsplit('/', 1)[-1])
                     validation_error = self._validate_meta(meta)
                     if validation_error:
                         details = ' '.join(
@@ -382,7 +412,6 @@ class SkillManager(ModuleBase):
                         )
                         continue
                     name = meta['name']
-                    key = self._skill_key_from_dir(skill_dir)
                     if not key or key in skills_index:
                         continue
                     skills_index[key] = {

--- a/tests/advanced_tests/Tools/test_skills.py
+++ b/tests/advanced_tests/Tools/test_skills.py
@@ -200,6 +200,53 @@ class TestSkills(object):
         assert 'skills/bad-name' not in prompt
         assert 'skills/bad-description' not in prompt
 
+    def test_skill_manager_loads_legacy_markdown_without_frontmatter(self):
+        content = (
+            b'# Interview Simulator\n\n'
+            b'## Identity\n\n'
+            b'You are a professional interview simulator.\n\n'
+            b'---\n\n'
+            b'## Flow\n'
+        )
+        fs = _MemoryCloudFS(
+            {
+                'skills': [{'name': 'skills/interview-simulator', 'type': 'directory'}],
+                'skills/interview-simulator': [
+                    {'name': 'skills/interview-simulator/SKILL.md', 'type': 'file'},
+                ],
+            },
+            {'skills/interview-simulator/SKILL.md': content},
+        )
+        manager = SkillManager(dir='skills', fs=fs)
+
+        listing = manager.list_skill()
+        skill = manager.get_skill('interview-simulator')
+
+        assert 'professional interview simulator' in listing
+        assert skill['status'] == 'ok'
+        assert skill['content'].encode() == content
+
+    def test_skill_manager_rejects_malformed_frontmatter_as_legacy(self):
+        fs = _MemoryCloudFS(
+            {
+                'skills': [{'name': 'skills/broken', 'type': 'directory'}],
+                'skills/broken': [{'name': 'skills/broken/SKILL.md', 'type': 'file'}],
+            },
+            {
+                'skills/broken/SKILL.md': (
+                    b'---\n'
+                    b'name: broken\n'
+                    b'description: missing closing separator\n'
+                    b'# Broken\n'
+                ),
+            },
+        )
+        manager = SkillManager(dir='skills', fs=fs)
+
+        listing = manager.list_skill()
+
+        assert 'skills/broken' not in listing
+
     def test_skill_manager_enforces_size_limit_when_info_has_no_size(self):
         fs = _MemoryCloudFS(
             {


### PR DESCRIPTION
## Summary

- discover legacy `SKILL.md` packages that do not contain YAML frontmatter
- derive the trusted runtime name from the skill directory and the description from the first prose paragraph
- preserve strict rejection for malformed files that start a frontmatter block

## Why

The unchanged SkillHub package `@clawhub_wscats/interview-simulator` v1.0.0 contains a valid instruction document but no YAML frontmatter. LazyMind can install that complete package, while LazyLLM currently omits it from `SkillManager` discovery and therefore cannot call `get_skill`.

This compatibility path is only selected when the file does not begin with `---`; malformed frontmatter is not silently reinterpreted as legacy Markdown.

## Validation

- two focused `SkillManager` regressions passed in the LazyMind algorithm image
- the original interview-simulator package was discovered and returned unchanged by `get_skill`
- LazyMind Docker E2E invoked `get_skill`, conducted a multi-turn interview, scored the answer, and produced a final scorecard