### PR TITLE
feat(agent): support pluggable history compaction

### DIFF
--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -973,6 +973,22 @@ Notes:
     The base class invokes it lazily on first use.
 ''')
 
+add_chinese_doc('LazyLLMAgentBase.describe_context', '''\
+返回当前面向模型的静态上下文，不调用模型或工具。
+
+**返回值：**
+
+- Dict[str, Any]: 包含 ``system_prompt``、``tool_definitions``、``skills_prompt``、``skill_prompt_parts`` 和 ``workspace``。
+''')
+
+add_english_doc('LazyLLMAgentBase.describe_context', '''\
+Return the current model-facing static context without invoking the model or tools.
+
+**Returns:**
+
+- Dict[str, Any]: Includes ``system_prompt``, ``tool_definitions``, ``skills_prompt``, ``skill_prompt_parts``, and ``workspace``.
+''')
+
 add_chinese_doc('ReactAgent', '''\
 ReactAgent是按照 `Thought->Action->Observation->Thought...->Finish` 的流程一步一步的通过LLM和工具调用来显示解决用户问题的步骤，以及最后给用户的答案。
 
@@ -1062,6 +1078,30 @@ add_chinese_doc('ReactAgent.build_agent', '''\
 
 add_english_doc('ReactAgent.build_agent', '''\
 Build the internal reasoning and tool-calling loop for ReactAgent.
+''')
+
+add_chinese_doc('ReactAgent.describe_context', '''\
+返回当前面向模型的上下文预览，不调用模型、工具或 history_compactor。
+
+Args:
+    llm_chat_history (Optional[List[Dict[str, Any]]]): 已有对话历史。默认为空。
+    current_input (Any): 当前用户输入，用于同步工具组可见性。默认为 ``None``。
+
+**返回值：**
+
+- Dict[str, Any]: 在基类字段之上增加 ``history``（原始 history 的浅拷贝）。
+''')
+
+add_english_doc('ReactAgent.describe_context', '''\
+Return a model-facing context preview without invoking the model, tools, or history_compactor.
+
+Args:
+    llm_chat_history (Optional[List[Dict[str, Any]]]): Existing chat history. Defaults to empty.
+    current_input (Any): Current user input, used to sync visible tool groups. Defaults to ``None``.
+
+**Returns:**
+
+- Dict[str, Any]: Base context fields plus ``history`` (a shallow copy of the raw history).
 ''')
 
 add_chinese_doc('ReactAgent.set_stop_tools', '''\

--- a/lazyllm/tools/agent/__init__.py
+++ b/lazyllm/tools/agent/__init__.py
@@ -1,6 +1,14 @@
 from .functionCall import FunctionCall, FunctionCallAgent
 from .toolsManager import register, tool_concurrency, ToolManager
-from .base import LazyLLMAgentBase
+from .base import (
+    LazyLLMAgentBase,
+    TOOL_OBSERVATION_KEY,
+    TOOL_OBSERVATION_VERSION,
+    attachable_tool_observation,
+    is_tool_result_envelope,
+    normalize_tool_observation,
+    strip_tool_observations,
+)
 from .reactAgent import ReactAgent
 from .planAndSolveAgent import PlanAndSolveAgent
 from .rewooAgent import ReWOOAgent
@@ -11,6 +19,12 @@ from .skill_hub import install_skill
 from .todo_tool import todo_write
 
 __all__ = [
+    'TOOL_OBSERVATION_KEY',
+    'TOOL_OBSERVATION_VERSION',
+    'attachable_tool_observation',
+    'is_tool_result_envelope',
+    'normalize_tool_observation',
+    'strip_tool_observations',
     'ToolManager',
     'FunctionCall',
     'FunctionCallAgent',

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -37,6 +37,18 @@ def _unwrap_tool_result(result: Any) -> Any:
             return result.get('value', '')
         return str(result.get('msg', repr(result)))
     return result
+
+
+def _model_facing_prefix(system_prompt: str, tools_manager: Any, skill_manager: Any = None) -> Dict[str, Any]:
+    skills_prompt = skill_manager.build_prompt() if skill_manager else ''
+    return {
+        'system_prompt': system_prompt,
+        'tool_definitions': tools_manager.tools_description,
+        'skills_prompt': skills_prompt or '',
+        'skill_prompt_parts': skill_manager.describe_prompt() if skill_manager else [],
+    }
+
+
 class LazyLLMAgentBase(ModuleBase):
     def __init__(self, llm=None, tools: Optional[List[Union[str, Callable, Dict]]] = None,
                  max_retries: int = 5, return_trace: bool = False,
@@ -185,11 +197,8 @@ class LazyLLMAgentBase(ModuleBase):
 
     def describe_context(self) -> Dict[str, Any]:
         '''Return the model-facing static context without invoking the model or tools.'''
-        skills_prompt = self._skill_manager.build_prompt() if self._skill_manager else ''
         return {
-            'tool_definitions': self._tools_manager.tools_description,
-            'skills_prompt': skills_prompt or '',
-            'skill_prompt_parts': self._skill_manager.describe_prompt() if self._skill_manager else [],
+            **_model_facing_prefix('', self._tools_manager, self._skill_manager),
             'workspace': self._workspace,
         }
 

--- a/lazyllm/tools/agent/base.py
+++ b/lazyllm/tools/agent/base.py
@@ -21,22 +21,64 @@ from .shell_tool import shell_tool  # noqa: F401
 from .download_tool import download_file  # noqa: F401
 
 
+TOOL_OBSERVATION_KEY = '_lazyllm_tool_observation'
+TOOL_OBSERVATION_VERSION = 1
+
+
 def _write_agent_data(tag: str, **kwargs):
     payload = {'tag': tag, **kwargs}
     lazyllm.FileSystemQueue().enqueue(
         json.dumps(payload, ensure_ascii=False, default=str))
 
 
+def is_tool_result_envelope(result: Any) -> bool:
+    # ToolManager._call_tool envelopes: {'ok': True, 'value': v} or {'ok': False, 'msg': m}.
+    if not isinstance(result, dict):
+        return False
+    ok = result.get('ok')
+    if ok is True:
+        return 'value' in result
+    return ok is False
+
+
 def _unwrap_tool_result(result: Any) -> Any:
-    # Unpack structured tool results produced by ToolManager._call_tool.
-    # {'ok': True,  'value': v}  → v
-    # {'ok': False, 'msg':   m}  → m  (already a human-readable error string)
-    # anything else              → result  (sandbox output, parse errors, etc.)
-    if isinstance(result, dict) and 'ok' in result:
+    if is_tool_result_envelope(result):
         if result['ok']:
             return result.get('value', '')
         return str(result.get('msg', repr(result)))
     return result
+
+
+def normalize_tool_observation(result: Any) -> Dict[str, Any]:
+    if is_tool_result_envelope(result):
+        ok = bool(result.get('ok'))
+        return {
+            'version': TOOL_OBSERVATION_VERSION,
+            'ok': ok,
+            'value': result.get('value') if ok else None,
+            'error': '' if ok else str(result.get('msg', repr(result))),
+        }
+    return {
+        'version': TOOL_OBSERVATION_VERSION,
+        'ok': None,
+        'value': result,
+        'error': '',
+    }
+
+
+def attachable_tool_observation(result: Any) -> Optional[Dict[str, Any]]:
+    # Skip strings/scalars: compactors already read model-facing content.
+    if not isinstance(result, (dict, list)):
+        return None
+    return normalize_tool_observation(result)
+
+
+def strip_tool_observations(history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        {key: value for key, value in message.items() if key != TOOL_OBSERVATION_KEY}
+        if TOOL_OBSERVATION_KEY in message else message
+        for message in history
+    ]
 
 
 def _model_facing_prefix(system_prompt: str, tools_manager: Any, skill_manager: Any = None) -> Dict[str, Any]:
@@ -196,7 +238,7 @@ class LazyLLMAgentBase(ModuleBase):
         return self._workspace
 
     def describe_context(self) -> Dict[str, Any]:
-        '''Return the model-facing static context without invoking the model or tools.'''
+        # Model-facing static context; does not invoke the model or tools.
         return {
             **_model_facing_prefix('', self._tools_manager, self._skill_manager),
             'workspace': self._workspace,

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -3,7 +3,7 @@ from lazyllm.components import ChatPrompter, FunctionCallFormatter
 from lazyllm import LOG, globals as lazyllm_globals, pipeline, loop, locals, package, FileSystemQueue, once_wrapper
 from .toolsManager import ToolManager
 from typing import List, Any, Dict, Union, Callable, Optional
-from .base import LazyLLMAgentBase, _write_agent_data, _unwrap_tool_result
+from .base import LazyLLMAgentBase, _model_facing_prefix, _write_agent_data, _unwrap_tool_result
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.common.deprecated import deprecated
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase, create_sandbox
@@ -118,7 +118,7 @@ class FunctionCall(ModuleBase):
                  skill_manager=None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  keep_full_turns: int = 0, stop_tools: Optional[List[str]] = None,
                  round_limit: Optional[int] = None,
-                 history_compactor: Optional[Callable[[List[Dict[str, Any]], int], List[Dict[str, Any]]]] = None,
+                 history_compactor: Optional[Callable[..., List[Dict[str, Any]]]] = None,
                  runtime_observer: Optional[Callable[..., Any]] = None):
         super().__init__(return_trace=return_trace)
         if _tool_manager is None:
@@ -136,6 +136,7 @@ class FunctionCall(ModuleBase):
         self._round_limit = round_limit
         self._runtime_observer = runtime_observer
         prompt = _prompt or FC_PROMPT
+        self._system_prompt = prompt
         self._prompter = ChatPrompter(
             instruction={'system': prompt, 'user': ''},
             tools=lambda: self._tools_manager.tools_description,
@@ -188,9 +189,23 @@ class FunctionCall(ModuleBase):
         )
         return current_round, f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
 
-    def _compact_history(self, history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _compact_history(
+        self,
+        history: List[Dict[str, Any]],
+        current_input: Any = None,
+    ) -> List[Dict[str, Any]]:
         if self._history_compactor is not None:
-            return self._history_compactor(history, self._keep_full_turns)
+            prefix = _model_facing_prefix(
+                self._system_prompt,
+                self._tools_manager,
+                self._skill_manager,
+            )
+            return self._history_compactor(
+                history,
+                self._keep_full_turns,
+                prefix=prefix,
+                current_input=current_input,
+            )
         if self._keep_full_turns > 0:
             return _compact_chat_history(history, self._keep_full_turns)
         return history
@@ -234,7 +249,7 @@ class FunctionCall(ModuleBase):
             'reasoning_content': input.get('reasoning_content', ''),
         })
         workspace['history'].extend(tool_call_results)
-        chat_history = self._compact_history(workspace['history'][:])
+        chat_history = self._compact_history(workspace['history'][:], current_input='')
         remainder, compacted_tools = _split_current_tool_input(chat_history, tool_call_results)
         locals['chat_history'][self._llm._module_id] = remainder
         self._notify_history_ready(workspace, current_round, remainder + compacted_tools)
@@ -245,19 +260,26 @@ class FunctionCall(ModuleBase):
         history_idx = len(workspace.setdefault('history', []))
         current_round, budget_notice = self._prepare_round(workspace)
 
+        current_input = None
         if isinstance(input, str):
             workspace['history'].append({'role': 'user', 'content': input})
+            current_input = input
         elif isinstance(input, dict) and 'input' in input:
             workspace['history'].append(
                 {'role': 'user', 'content': input.get('input', '')}
             )
+            current_input = input.get('input', '')
         elif isinstance(input, dict) and input.get('role') == 'user':
             workspace['history'].append(
                 {'role': 'user', 'content': input.get('content', '')}
             )
+            current_input = input.get('content', '')
         elif isinstance(input, dict):
             return self._build_tool_call_input(input, workspace, budget_notice, current_round)
-        chat_history = self._compact_history(workspace['history'][:history_idx])
+        chat_history = self._compact_history(
+            workspace['history'][:history_idx],
+            current_input=current_input,
+        )
         locals['chat_history'][self._llm._module_id] = chat_history
         self._notify_history_ready(workspace, current_round, chat_history)
         return input

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -9,6 +9,7 @@ from lazyllm.common.deprecated import deprecated
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase, create_sandbox
 import re
 import json
+import inspect
 
 FC_PROMPT = f'''# Tools
 
@@ -172,7 +173,7 @@ class FunctionCall(ModuleBase):
 
     def _prepare_round(self, workspace: Dict[str, Any]) -> tuple:
         if self._round_limit is None:
-            return None, None
+            return None, None, None
         current_round = int(workspace.get('_react_round_number', 0)) + 1
         workspace['_react_round_number'] = current_round
         round_limit = int(workspace.get('_react_round_limit', self._round_limit))
@@ -187,12 +188,18 @@ class FunctionCall(ModuleBase):
             round_limit=round_limit,
             remaining_rounds=remaining_rounds,
         )
-        return current_round, f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
+        return (
+            current_round,
+            f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.',
+            remaining_rounds,
+        )
 
     def _compact_history(
         self,
         history: List[Dict[str, Any]],
         current_input: Any = None,
+        workspace: Optional[Dict[str, Any]] = None,
+        remaining_rounds: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         if self._history_compactor is not None:
             prefix = _model_facing_prefix(
@@ -200,11 +207,30 @@ class FunctionCall(ModuleBase):
                 self._tools_manager,
                 self._skill_manager,
             )
+            kwargs = {
+                'prefix': prefix,
+                'current_input': current_input,
+            }
+            try:
+                signature = inspect.signature(self._history_compactor)
+                accepts_kwargs = any(
+                    parameter.kind == inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
+                if workspace is not None and (
+                    accepts_kwargs or 'runtime_state' in signature.parameters
+                ):
+                    kwargs['runtime_state'] = workspace.setdefault('_history_projection_state', {})
+                if remaining_rounds is not None and (
+                    accepts_kwargs or 'remaining_rounds' in signature.parameters
+                ):
+                    kwargs['remaining_rounds'] = remaining_rounds
+            except (TypeError, ValueError):
+                pass
             return self._history_compactor(
                 history,
                 self._keep_full_turns,
-                prefix=prefix,
-                current_input=current_input,
+                **kwargs,
             )
         if self._keep_full_turns > 0:
             return _compact_chat_history(history, self._keep_full_turns)
@@ -228,6 +254,7 @@ class FunctionCall(ModuleBase):
         workspace: Dict[str, Any],
         budget_notice: Optional[str],
         current_round: Optional[int],
+        remaining_rounds: Optional[int],
     ) -> Dict[str, Any]:
         tool_call_results = [
             {
@@ -249,7 +276,12 @@ class FunctionCall(ModuleBase):
             'reasoning_content': input.get('reasoning_content', ''),
         })
         workspace['history'].extend(tool_call_results)
-        chat_history = self._compact_history(workspace['history'][:], current_input='')
+        chat_history = self._compact_history(
+            workspace['history'][:],
+            current_input='',
+            workspace=workspace,
+            remaining_rounds=remaining_rounds,
+        )
         remainder, compacted_tools = _split_current_tool_input(chat_history, tool_call_results)
         locals['chat_history'][self._llm._module_id] = remainder
         self._notify_history_ready(workspace, current_round, remainder + compacted_tools)
@@ -258,7 +290,7 @@ class FunctionCall(ModuleBase):
     def _build_history(self, input: Union[str, dict, list]):
         workspace = locals['_lazyllm_agent']['workspace']
         history_idx = len(workspace.setdefault('history', []))
-        current_round, budget_notice = self._prepare_round(workspace)
+        current_round, budget_notice, remaining_rounds = self._prepare_round(workspace)
 
         current_input = None
         if isinstance(input, str):
@@ -275,10 +307,18 @@ class FunctionCall(ModuleBase):
             )
             current_input = input.get('content', '')
         elif isinstance(input, dict):
-            return self._build_tool_call_input(input, workspace, budget_notice, current_round)
+            return self._build_tool_call_input(
+                input,
+                workspace,
+                budget_notice,
+                current_round,
+                remaining_rounds,
+            )
         chat_history = self._compact_history(
             workspace['history'][:history_idx],
             current_input=current_input,
+            workspace=workspace,
+            remaining_rounds=remaining_rounds,
         )
         locals['chat_history'][self._llm._module_id] = chat_history
         self._notify_history_ready(workspace, current_round, chat_history)

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -54,6 +54,38 @@ def _tool_result_stop_text(result: Any) -> Optional[str]:
     return final_text.strip()
 
 
+def _split_current_tool_input(
+    chat_history: List[Dict[str, Any]],
+    tool_call_results: List[Dict[str, Any]],
+) -> tuple:
+    # Compacted history includes current-round tools; ChatPrompter also extends
+    # `input` onto history. Split those tools out so they are not duplicated.
+    id_order = [item.get('tool_call_id') for item in tool_call_results]
+    id_set = {item_id for item_id in id_order if item_id is not None}
+    by_id = {}
+    remainder = []
+    unmatched_tools = []
+    for message in chat_history:
+        tool_id = message.get('tool_call_id')
+        if message.get('role') == 'tool' and tool_id in id_set:
+            by_id[tool_id] = message
+        elif message.get('role') == 'tool' and not tool_id and id_set:
+            unmatched_tools.append(message)
+        else:
+            remainder.append(message)
+    ordered = []
+    unused = list(unmatched_tools)
+    for original in tool_call_results:
+        tool_id = original.get('tool_call_id')
+        if tool_id in by_id:
+            ordered.append(by_id[tool_id])
+        elif unused:
+            ordered.append(unused.pop(0))
+        else:
+            ordered.append(original)
+    return remainder, ordered
+
+
 def _compact_chat_history(history: List[Dict[str, Any]], keep_full_turns: int) -> List[Dict[str, Any]]:
     # identify tool-result message indices (role == 'tool'), from oldest to newest
     tool_indices = [i for i, m in enumerate(history) if m.get('role') == 'tool']
@@ -85,7 +117,9 @@ class FunctionCall(ModuleBase):
                  stream: bool = False, _prompt: str = None, _tool_manager: Optional[ToolManager] = None,
                  skill_manager=None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  keep_full_turns: int = 0, stop_tools: Optional[List[str]] = None,
-                 round_limit: Optional[int] = None):
+                 round_limit: Optional[int] = None,
+                 history_compactor: Optional[Callable[[List[Dict[str, Any]], int], List[Dict[str, Any]]]] = None,
+                 runtime_observer: Optional[Callable[..., Any]] = None):
         super().__init__(return_trace=return_trace)
         if _tool_manager is None:
             assert tools, 'tools cannot be empty.'
@@ -97,8 +131,10 @@ class FunctionCall(ModuleBase):
         self._skill_manager = skill_manager
         self._stream = stream
         self._keep_full_turns = keep_full_turns
+        self._history_compactor = history_compactor
         self._stop_tools: set = set(stop_tools) if stop_tools else set()
         self._round_limit = round_limit
+        self._runtime_observer = runtime_observer
         prompt = _prompt or FC_PROMPT
         self._prompter = ChatPrompter(
             instruction={'system': prompt, 'user': ''},
@@ -129,6 +165,7 @@ class FunctionCall(ModuleBase):
         workspace = locals['_lazyllm_agent']['workspace']
         history_idx = len(workspace.setdefault('history', []))
         budget_notice = None
+        current_round = None
         if self._round_limit is not None:
             current_round = int(workspace.get('_react_round_number', 0)) + 1
             workspace['_react_round_number'] = current_round
@@ -139,6 +176,17 @@ class FunctionCall(ModuleBase):
                 f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
             )
             budget_notice = f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
+            if self._runtime_observer:
+                try:
+                    self._runtime_observer(
+                        'turn_start',
+                        round=current_round,
+                        round_limit=round_limit,
+                        remaining_rounds=remaining_rounds,
+                        sid=lazyllm_globals._sid,
+                    )
+                except Exception:
+                    pass
 
         if isinstance(input, str):
             workspace['history'].append({'role': 'user', 'content': input})
@@ -170,13 +218,43 @@ class FunctionCall(ModuleBase):
                 'tool_calls': input.get('tool_calls', []),
                 'reasoning_content': input.get('reasoning_content', ''),
             })
-            input = {'input': tool_call_results}
-            history_idx += 1
             workspace['history'].extend(tool_call_results)
+            history_idx = len(workspace['history'])
+            chat_history = workspace['history'][:history_idx]
+            if self._history_compactor is not None:
+                chat_history = self._history_compactor(chat_history, self._keep_full_turns)
+            elif self._keep_full_turns > 0:
+                chat_history = _compact_chat_history(chat_history, self._keep_full_turns)
+            remainder, compacted_tools = _split_current_tool_input(chat_history, tool_call_results)
+            locals['chat_history'][self._llm._module_id] = remainder
+            input = {'input': compacted_tools}
+            if self._runtime_observer:
+                try:
+                    self._runtime_observer(
+                        'history_ready',
+                        round=current_round or workspace.get('_react_round_number'),
+                        history=remainder + compacted_tools,
+                        sid=lazyllm_globals._sid,
+                    )
+                except Exception:
+                    pass
+            return input
         chat_history = workspace['history'][:history_idx]
-        if self._keep_full_turns > 0:
+        if self._history_compactor is not None:
+            chat_history = self._history_compactor(chat_history, self._keep_full_turns)
+        elif self._keep_full_turns > 0:
             chat_history = _compact_chat_history(chat_history, self._keep_full_turns)
         locals['chat_history'][self._llm._module_id] = chat_history
+        if self._runtime_observer:
+            try:
+                self._runtime_observer(
+                    'history_ready',
+                    round=current_round or workspace.get('_react_round_number'),
+                    history=chat_history,
+                    sid=lazyllm_globals._sid,
+                )
+            except Exception:
+                pass
         return input
 
     def _post_action(self, llm_output: Dict[str, Any]):  # noqa: C901
@@ -186,6 +264,7 @@ class FunctionCall(ModuleBase):
                     llm_output['tool_calls'] = [{'function': {'name': match.group(1),
                                                               'arguments': json.loads(match.group(2))}}]
                 except Exception: pass
+        has_tools = bool(llm_output.get('tool_calls'))
         if tool_calls := llm_output.get('tool_calls'):
             if isinstance(tool_calls, list): [item.pop('index', None) for item in tool_calls]
             tool_calls = self._tools_manager._normalize_tool_calls(tool_calls)
@@ -220,9 +299,33 @@ class FunctionCall(ModuleBase):
                         and (tc.get('function') or {}).get('name') in self._stop_tools
                     )
                     if not stop_failed:
+                        if self._runtime_observer:
+                            try:
+                                workspace = locals['_lazyllm_agent']['workspace']
+                                self._runtime_observer(
+                                    'turn_end',
+                                    round=workspace.get('_react_round_number'),
+                                    has_tools=True,
+                                    stop_tool=True,
+                                    sid=lazyllm_globals._sid,
+                                )
+                            except Exception:
+                                pass
                         return '\n'.join(str(_unwrap_tool_result(r)) for r in tool_calls_results)
         else:
             llm_output = llm_output['content']
+        if self._runtime_observer:
+            try:
+                workspace = locals['_lazyllm_agent']['workspace']
+                self._runtime_observer(
+                    'turn_end',
+                    round=workspace.get('_react_round_number'),
+                    has_tools=has_tools,
+                    final=not has_tools,
+                    sid=lazyllm_globals._sid,
+                )
+            except Exception:
+                pass
         return llm_output
 
     def forward(self, input: str, llm_chat_history: List[Dict[str, Any]] = None):

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -3,7 +3,15 @@ from lazyllm.components import ChatPrompter, FunctionCallFormatter
 from lazyllm import LOG, globals as lazyllm_globals, pipeline, loop, locals, package, FileSystemQueue, once_wrapper
 from .toolsManager import ToolManager
 from typing import List, Any, Dict, Union, Callable, Optional
-from .base import LazyLLMAgentBase, _model_facing_prefix, _write_agent_data, _unwrap_tool_result
+from .base import (
+    LazyLLMAgentBase,
+    TOOL_OBSERVATION_KEY,
+    _model_facing_prefix,
+    attachable_tool_observation,
+    strip_tool_observations,
+    _write_agent_data,
+    _unwrap_tool_result,
+)
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.common.deprecated import deprecated
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase, create_sandbox
@@ -227,14 +235,15 @@ class FunctionCall(ModuleBase):
                     kwargs['remaining_rounds'] = remaining_rounds
             except (TypeError, ValueError):
                 pass
-            return self._history_compactor(
+            compacted = self._history_compactor(
                 history,
                 self._keep_full_turns,
                 **kwargs,
             )
+            return strip_tool_observations(compacted)
         if self._keep_full_turns > 0:
-            return _compact_chat_history(history, self._keep_full_turns)
-        return history
+            history = _compact_chat_history(history, self._keep_full_turns)
+        return strip_tool_observations(history)
 
     def _notify_history_ready(
         self,
@@ -256,14 +265,19 @@ class FunctionCall(ModuleBase):
         current_round: Optional[int],
         remaining_rounds: Optional[int],
     ) -> Dict[str, Any]:
-        tool_call_results = [
-            {
+        tool_call_results = []
+        for tool_call in workspace['tool_call_trace']:
+            raw_result = tool_call['tool_call_result']
+            tool_message = {
                 'role': 'tool',
-                'content': str(_unwrap_tool_result(tool_call['tool_call_result'])),
+                'content': str(_unwrap_tool_result(raw_result)),
                 'tool_call_id': tool_call['id'],
                 'name': tool_call['function']['name'],
-            } for tool_call in workspace['tool_call_trace']
-        ]
+            }
+            observation = attachable_tool_observation(raw_result)
+            if observation is not None:
+                tool_message[TOOL_OBSERVATION_KEY] = observation
+            tool_call_results.append(tool_message)
         if budget_notice and tool_call_results:
             tool_call_results[-1] = {
                 **tool_call_results[-1],

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -161,32 +161,89 @@ class FunctionCall(ModuleBase):
         if hasattr(self, '_tools_manager') and self._tools_manager is not None:
             self._tools_manager.sandbox = sandbox
 
+    def _observe_runtime(self, event: str, **payload):
+        if self._runtime_observer is None:
+            return
+        try:
+            self._runtime_observer(event, **payload, sid=lazyllm_globals._sid)
+        except Exception:
+            pass
+
+    def _prepare_round(self, workspace: Dict[str, Any]) -> tuple:
+        if self._round_limit is None:
+            return None, None
+        current_round = int(workspace.get('_react_round_number', 0)) + 1
+        workspace['_react_round_number'] = current_round
+        round_limit = int(workspace.get('_react_round_limit', self._round_limit))
+        remaining_rounds = max(0, round_limit - current_round)
+        LOG.info(
+            f'[ReactAgent] [ROUND_BUDGET] sid={lazyllm_globals._sid} current_round={current_round} '
+            f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
+        )
+        self._observe_runtime(
+            'turn_start',
+            round=current_round,
+            round_limit=round_limit,
+            remaining_rounds=remaining_rounds,
+        )
+        return current_round, f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
+
+    def _compact_history(self, history: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        if self._history_compactor is not None:
+            return self._history_compactor(history, self._keep_full_turns)
+        if self._keep_full_turns > 0:
+            return _compact_chat_history(history, self._keep_full_turns)
+        return history
+
+    def _notify_history_ready(
+        self,
+        workspace: Dict[str, Any],
+        current_round: Optional[int],
+        history: List[Dict[str, Any]],
+    ):
+        self._observe_runtime(
+            'history_ready',
+            round=current_round or workspace.get('_react_round_number'),
+            history=history,
+        )
+
+    def _build_tool_call_input(
+        self,
+        input: Dict[str, Any],
+        workspace: Dict[str, Any],
+        budget_notice: Optional[str],
+        current_round: Optional[int],
+    ) -> Dict[str, Any]:
+        tool_call_results = [
+            {
+                'role': 'tool',
+                'content': str(_unwrap_tool_result(tool_call['tool_call_result'])),
+                'tool_call_id': tool_call['id'],
+                'name': tool_call['function']['name'],
+            } for tool_call in workspace['tool_call_trace']
+        ]
+        if budget_notice and tool_call_results:
+            tool_call_results[-1] = {
+                **tool_call_results[-1],
+                'content': f'{tool_call_results[-1]["content"]}\n\n{budget_notice}',
+            }
+        workspace['history'].append({
+            'role': 'assistant',
+            'content': input.get('content', ''),
+            'tool_calls': input.get('tool_calls', []),
+            'reasoning_content': input.get('reasoning_content', ''),
+        })
+        workspace['history'].extend(tool_call_results)
+        chat_history = self._compact_history(workspace['history'][:])
+        remainder, compacted_tools = _split_current_tool_input(chat_history, tool_call_results)
+        locals['chat_history'][self._llm._module_id] = remainder
+        self._notify_history_ready(workspace, current_round, remainder + compacted_tools)
+        return {'input': compacted_tools}
+
     def _build_history(self, input: Union[str, dict, list]):
         workspace = locals['_lazyllm_agent']['workspace']
         history_idx = len(workspace.setdefault('history', []))
-        budget_notice = None
-        current_round = None
-        if self._round_limit is not None:
-            current_round = int(workspace.get('_react_round_number', 0)) + 1
-            workspace['_react_round_number'] = current_round
-            round_limit = int(workspace.get('_react_round_limit', self._round_limit))
-            remaining_rounds = max(0, round_limit - current_round)
-            LOG.info(
-                f'[ReactAgent] [ROUND_BUDGET] sid={lazyllm_globals._sid} current_round={current_round} '
-                f'round_limit={round_limit} remaining_rounds={remaining_rounds}'
-            )
-            budget_notice = f'[Internal runtime notice] Internal ReAct rounds left: {remaining_rounds}.'
-            if self._runtime_observer:
-                try:
-                    self._runtime_observer(
-                        'turn_start',
-                        round=current_round,
-                        round_limit=round_limit,
-                        remaining_rounds=remaining_rounds,
-                        sid=lazyllm_globals._sid,
-                    )
-                except Exception:
-                    pass
+        current_round, budget_notice = self._prepare_round(workspace)
 
         if isinstance(input, str):
             workspace['history'].append({'role': 'user', 'content': input})
@@ -199,62 +256,10 @@ class FunctionCall(ModuleBase):
                 {'role': 'user', 'content': input.get('content', '')}
             )
         elif isinstance(input, dict):
-            tool_call_results = [
-                {
-                    'role': 'tool',
-                    'content': str(_unwrap_tool_result(tool_call['tool_call_result'])),
-                    'tool_call_id': tool_call['id'],
-                    'name': tool_call['function']['name'],
-                } for tool_call in workspace['tool_call_trace']
-            ]
-            if budget_notice and tool_call_results:
-                tool_call_results[-1] = {
-                    **tool_call_results[-1],
-                    'content': f'{tool_call_results[-1]["content"]}\n\n{budget_notice}',
-                }
-            workspace['history'].append({
-                'role': 'assistant',
-                'content': input.get('content', ''),
-                'tool_calls': input.get('tool_calls', []),
-                'reasoning_content': input.get('reasoning_content', ''),
-            })
-            workspace['history'].extend(tool_call_results)
-            history_idx = len(workspace['history'])
-            chat_history = workspace['history'][:history_idx]
-            if self._history_compactor is not None:
-                chat_history = self._history_compactor(chat_history, self._keep_full_turns)
-            elif self._keep_full_turns > 0:
-                chat_history = _compact_chat_history(chat_history, self._keep_full_turns)
-            remainder, compacted_tools = _split_current_tool_input(chat_history, tool_call_results)
-            locals['chat_history'][self._llm._module_id] = remainder
-            input = {'input': compacted_tools}
-            if self._runtime_observer:
-                try:
-                    self._runtime_observer(
-                        'history_ready',
-                        round=current_round or workspace.get('_react_round_number'),
-                        history=remainder + compacted_tools,
-                        sid=lazyllm_globals._sid,
-                    )
-                except Exception:
-                    pass
-            return input
-        chat_history = workspace['history'][:history_idx]
-        if self._history_compactor is not None:
-            chat_history = self._history_compactor(chat_history, self._keep_full_turns)
-        elif self._keep_full_turns > 0:
-            chat_history = _compact_chat_history(chat_history, self._keep_full_turns)
+            return self._build_tool_call_input(input, workspace, budget_notice, current_round)
+        chat_history = self._compact_history(workspace['history'][:history_idx])
         locals['chat_history'][self._llm._module_id] = chat_history
-        if self._runtime_observer:
-            try:
-                self._runtime_observer(
-                    'history_ready',
-                    round=current_round or workspace.get('_react_round_number'),
-                    history=chat_history,
-                    sid=lazyllm_globals._sid,
-                )
-            except Exception:
-                pass
+        self._notify_history_ready(workspace, current_round, chat_history)
         return input
 
     def _post_action(self, llm_output: Dict[str, Any]):  # noqa: C901

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -4,8 +4,8 @@ from lazyllm import LOG, globals as lazyllm_globals, locals, loop, once_wrapper
 from lazyllm.components.prompter.builtinPrompt import FC_PROMPT_PLACEHOLDER
 from lazyllm.tools.sandbox.sandbox_base import LazyLLMSandboxBase
 
-from .base import LazyLLMAgentBase, _write_agent_data
-from .functionCall import FunctionCall, _compact_chat_history
+from .base import LazyLLMAgentBase, _model_facing_prefix, _write_agent_data
+from .functionCall import FunctionCall
 
 INSTRUCTION = f'''
 ## Role
@@ -114,17 +114,16 @@ class ReactAgent(LazyLLMAgentBase):
         '''Apply the identical tool-activation policy for execution and context inspection.'''
         self._tools_manager.sync_active_groups(current_input, llm_chat_history)
 
+    def _model_facing_prefix(self) -> Dict[str, Any]:
+        return _model_facing_prefix(self._prompt, self._tools_manager, self._skill_manager)
+
     def describe_context(self, llm_chat_history: Optional[List[Dict[str, Any]]] = None,
                          current_input: Any = None) -> Dict[str, Any]:
         '''Return the model-facing static context without invoking the model or tools.'''
         self._prepare_tool_context(current_input, llm_chat_history)
-        description = super().describe_context()
-        description['system_prompt'] = self._prompt
+        description = self._model_facing_prefix()
+        description['workspace'] = self._workspace
         history = list(llm_chat_history or [])
-        if self._history_compactor is not None:
-            history = self._history_compactor(history, self._keep_full_turns)
-        elif self._keep_full_turns > 0:
-            history = _compact_chat_history(history, self._keep_full_turns)
         description['history'] = history
         return description
 

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -81,7 +81,9 @@ class ReactAgent(LazyLLMAgentBase):
                  keep_full_turns: int = 0, fs: Optional[Any] = None, skills_dir: Optional[str] = None,
                  enable_builtin_tools: bool = True,
                  extra_stop_condition: Optional[Callable] = None,
-                 on_max_retries: Optional[Callable] = None):
+                 on_max_retries: Optional[Callable] = None,
+                 history_compactor: Optional[Callable] = None,
+                 runtime_observer: Optional[Callable] = None):
         super().__init__(llm=llm, tools=tools, max_retries=max_retries, return_trace=return_trace,
                          stream=stream, return_last_tool_calls=return_last_tool_calls, skills=skills,
                          desc=desc, workspace=workspace, sandbox=sandbox, fs=fs, skills_dir=skills_dir,
@@ -95,6 +97,8 @@ class ReactAgent(LazyLLMAgentBase):
         self._force_summarize = force_summarize
         self._force_summarize_context = force_summarize_context
         self._keep_full_turns = keep_full_turns
+        self._history_compactor = history_compactor
+        self._runtime_observer = runtime_observer
         self._extra_stop_condition = extra_stop_condition
         self._on_max_retries = on_max_retries
         self._stop_tools: set = set()
@@ -117,7 +121,9 @@ class ReactAgent(LazyLLMAgentBase):
         description = super().describe_context()
         description['system_prompt'] = self._prompt
         history = list(llm_chat_history or [])
-        if self._keep_full_turns > 0:
+        if self._history_compactor is not None:
+            history = self._history_compactor(history, self._keep_full_turns)
+        elif self._keep_full_turns > 0:
             history = _compact_chat_history(history, self._keep_full_turns)
         description['history'] = history
         return description
@@ -131,8 +137,10 @@ class ReactAgent(LazyLLMAgentBase):
                           stream=self._stream, _tool_manager=self._tools_manager,
                           skill_manager=self._skill_manager,
                           keep_full_turns=self._keep_full_turns,
+                          history_compactor=self._history_compactor,
                           stop_tools=list(self._stop_tools) if self._stop_tools else None,
-                          round_limit=self._max_retries + 1)
+                          round_limit=self._max_retries + 1,
+                          runtime_observer=self._runtime_observer)
         agent = loop(
             fc,
             stop_condition=self._stop,

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -203,7 +203,7 @@ class ReactAgent(LazyLLMAgentBase):
         )
         return summary if summary else None
 
-    def _post_process(self, ret):
+    def _post_process(self, ret):  # noqa: C901
         if isinstance(ret, str):
             completed = self._pop_tool_calls()
             if completed is not None:

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -111,7 +111,6 @@ class ReactAgent(LazyLLMAgentBase):
 
     def _prepare_tool_context(self, current_input: Any = None,
                               llm_chat_history: Optional[List[Dict[str, Any]]] = None) -> None:
-        '''Apply the identical tool-activation policy for execution and context inspection.'''
         self._tools_manager.sync_active_groups(current_input, llm_chat_history)
 
     def _model_facing_prefix(self) -> Dict[str, Any]:
@@ -119,7 +118,7 @@ class ReactAgent(LazyLLMAgentBase):
 
     def describe_context(self, llm_chat_history: Optional[List[Dict[str, Any]]] = None,
                          current_input: Any = None) -> Dict[str, Any]:
-        '''Return the model-facing static context without invoking the model or tools.'''
+        # Model-facing static context; does not invoke the model, tools, or history compactors.
         self._prepare_tool_context(current_input, llm_chat_history)
         description = self._model_facing_prefix()
         description['workspace'] = self._workspace

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -6,6 +6,11 @@ from types import SimpleNamespace
 
 import lazyllm
 from lazyllm.tools import PlanAndSolveAgent, ReactAgent
+from lazyllm.tools.agent.base import (
+    TOOL_OBSERVATION_KEY,
+    is_tool_result_envelope,
+    normalize_tool_observation,
+)
 
 
 def add_one(value: int) -> int:
@@ -434,6 +439,76 @@ class TestReactAgentEvents(object):
             f'{str({"status": "ok", "content": "Error handling reference"})}\n\n'
             '[Internal runtime notice] Internal ReAct rounds left: 2.'
         )
+
+    def test_history_compactor_receives_structured_observation_without_model_leak(self):
+        llm = _FakeLLM([
+            {
+                'role': 'assistant',
+                'content': 'Let me read the status.',
+                'tool_calls': [{
+                    'id': 'call-status',
+                    'type': 'function',
+                    'function': {'name': 'get_status', 'arguments': '{}'},
+                }],
+            },
+            {'role': 'assistant', 'content': 'Done.'},
+        ])
+        captured = []
+
+        def capture(history, _keep, **_kwargs):
+            captured.append(copy.deepcopy(history))
+            return history
+
+        agent = ReactAgent(
+            llm=llm,
+            tools=[get_status],
+            max_retries=3,
+            history_compactor=capture,
+            enable_builtin_tools=False,
+        )
+
+        assert agent('read status') == 'Done.'
+        captured_tool = next(
+            message
+            for history in captured
+            for message in history
+            if message.get('role') == 'tool'
+        )
+        assert captured_tool[TOOL_OBSERVATION_KEY] == {
+            'version': 1,
+            'ok': True,
+            'value': {'status': 'ok', 'content': 'Error handling reference'},
+            'error': '',
+        }
+        assert all(
+            TOOL_OBSERVATION_KEY not in message
+            for invocation in llm.inputs
+            if isinstance(invocation, dict)
+            for message in invocation.get('input', [])
+        )
+        persisted_tool = next(
+            message for message in lazyllm.locals['_lazyllm_agent']['history']
+            if message.get('role') == 'tool'
+        )
+        assert persisted_tool[TOOL_OBSERVATION_KEY] == captured_tool[TOOL_OBSERVATION_KEY]
+        assert normalize_tool_observation({
+            'ok': False,
+            'value': None,
+            'msg': '[Tool Error] failed',
+        }) == {
+            'version': 1,
+            'ok': False,
+            'value': None,
+            'error': '[Tool Error] failed',
+        }
+        incidental = {'ok': 'yes', 'path': '/tmp/file', 'content': 'not an envelope'}
+        assert is_tool_result_envelope(incidental) is False
+        assert normalize_tool_observation(incidental) == {
+            'version': 1,
+            'ok': None,
+            'value': incidental,
+            'error': '',
+        }
 
     def test_react_agent_stream_emits_text_reasoning_and_tool_events(self):
         llm = _FakeLLM([


### PR DESCRIPTION
## Summary

- Add optional `history_compactor` hooks to `ReactAgent` and `FunctionCall`.
- Add an optional `runtime_observer` for turn and history lifecycle events.
- Allow projected current-round tool results to be passed to the model without duplicating them in chat history.
- Keep context-compression policy outside LazyLLM; callers decide whether and how history is compacted.

## Motivation

Long-running agents can accumulate large tool results across ReAct rounds. Applications such as LazyMind need a framework-level extension point to project model-facing history without mutating the authoritative runtime history.

This change provides that extension point while keeping the compaction strategy in the caller.

## Compatibility

- Both new arguments default to `None`.
- Existing `ReactAgent` and `FunctionCall` constructor calls remain valid.
- Existing `keep_full_turns` behavior remains available when no custom compactor is supplied.
- Runtime observer failures are isolated and do not interrupt agent execution.

## Implementation

- `history_compactor(history, keep_full_turns)` receives the model-facing history and returns a projected history.
- Current-round tool results are separated from projected history so `ChatPrompter` does not append them twice.
- `runtime_observer(kind, **payload)` receives best-effort lifecycle events such as:
  - `turn_start`
  - `history_ready`
  - `turn_end`

## Validation

- Rebased onto the latest `LazyAGI/LazyLLM:main`.
- Resolved compatibility with the upstream agent-control stop behavior.
- Python compilation passed for the modified Agent modules.
- Verified that the branch contains the latest upstream `main`.
