### PR TITLE
fix(parse): Split long page pdf for ocr readers

### DIFF
--- a/lazyllm/tools/pdf_utils.py
+++ b/lazyllm/tools/pdf_utils.py
@@ -9,6 +9,8 @@ from typing import List, NamedTuple, Optional
 
 from lazyllm.thirdparty import pypdf
 
+_DEFAULT_TARGET_ASPECT_RATIO = math.sqrt(2)
+
 
 class PdfPageSegment(NamedTuple):
     source_page: int
@@ -28,11 +30,29 @@ def _page_size(page) -> tuple:
     return float(box.width), float(box.height)
 
 
+def _write_pdf(writer, output_path: Path) -> None:
+    fd, temp_name = tempfile.mkstemp(prefix=f'.{output_path.name}.', suffix='.tmp', dir=output_path.parent)
+    try:
+        with os.fdopen(fd, 'wb') as stream:
+            writer.write(stream)
+        os.replace(temp_name, output_path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+
+
 def normalize_long_pdf(
     input_path: Path,
     output_path: Optional[Path] = None,
     max_aspect_ratio: float = 3.0,
-    target_aspect_ratio: float = math.sqrt(2),
+    target_aspect_ratio: float = _DEFAULT_TARGET_ASPECT_RATIO,
 ) -> LongPdfNormalization:
     input_path = Path(input_path)
     if max_aspect_ratio <= 0 or target_aspect_ratio <= 0:
@@ -79,28 +99,14 @@ def normalize_long_pdf(
             writer.add_page(segment_page)
             segments.append(PdfPageSegment(source_page, segment_index * segment_height, width, height))
 
-    fd, temp_name = tempfile.mkstemp(prefix=f'.{output_path.name}.', suffix='.tmp', dir=output_path.parent)
-    try:
-        with os.fdopen(fd, 'wb') as stream:
-            writer.write(stream)
-        os.replace(temp_name, output_path)
-    except Exception:
-        try:
-            os.close(fd)
-        except OSError:
-            pass
-        try:
-            os.unlink(temp_name)
-        except OSError:
-            pass
-        raise
+    _write_pdf(writer, output_path)
     return LongPdfNormalization(output_path, segments, True)
 
 
 def normalize_long_pdf_inplace(
     input_path: Path,
     max_aspect_ratio: float = 3.0,
-    target_aspect_ratio: float = math.sqrt(2),
+    target_aspect_ratio: float = _DEFAULT_TARGET_ASPECT_RATIO,
 ) -> bool:
     input_path = Path(input_path)
     source_mode = stat.S_IMODE(input_path.stat().st_mode)

--- a/lazyllm/tools/pdf_utils.py
+++ b/lazyllm/tools/pdf_utils.py
@@ -7,6 +7,7 @@ import uuid
 from pathlib import Path
 from typing import List, NamedTuple, Optional
 
+from lazyllm import LOG
 from lazyllm.thirdparty import pypdf
 
 _DEFAULT_TARGET_ASPECT_RATIO = math.sqrt(2)
@@ -122,6 +123,7 @@ def normalize_long_pdf_inplace(
             return False
         os.chmod(result.path, source_mode)
         os.replace(result.path, input_path)
+        LOG.info(f'[pdf_utils] Replaced oversized PDF in place: {input_path}')
         return True
     finally:
         try:

--- a/lazyllm/tools/pdf_utils.py
+++ b/lazyllm/tools/pdf_utils.py
@@ -31,6 +31,10 @@ def _page_size(page) -> tuple:
     return float(box.width), float(box.height)
 
 
+def _is_oversized_page(width: float, height: float, rotation: int, max_aspect_ratio: float) -> bool:
+    return width > 0 and height / width > max_aspect_ratio and rotation not in (90, 270)
+
+
 def _write_pdf(writer, output_path: Path) -> None:
     fd, temp_name = tempfile.mkstemp(prefix=f'.{output_path.name}.', suffix='.tmp', dir=output_path.parent)
     try:
@@ -63,10 +67,11 @@ def normalize_long_pdf(
     if not reader.pages:
         return LongPdfNormalization(input_path, [], False)
 
-    first_width, first_height = _page_size(reader.pages[0])
-    first_rotation = int(reader.pages[0].rotation or 0) % 360
-    if first_width <= 0 or first_height / first_width <= max_aspect_ratio or first_rotation in (90, 270):
-        segments = [PdfPageSegment(i, 0.0, *_page_size(page)) for i, page in enumerate(reader.pages)]
+    pages = list(reader.pages)
+    page_specs = [(*_page_size(page), int(page.rotation or 0) % 360) for page in pages]
+    if not any(_is_oversized_page(*spec, max_aspect_ratio) for spec in page_specs):
+        segments = [PdfPageSegment(i, 0.0, width, height)
+                    for i, (width, height, _) in enumerate(page_specs)]
         return LongPdfNormalization(input_path, segments, False)
 
     output_path = Path(output_path) if output_path else input_path.with_suffix('.normalized.pdf')
@@ -76,10 +81,9 @@ def normalize_long_pdf(
 
     writer = pypdf.PdfWriter()
     segments = []
-    for source_page, page in enumerate(reader.pages):
-        width, height = _page_size(page)
-        rotation = int(page.rotation or 0) % 360
-        if width <= 0 or height / width <= max_aspect_ratio or rotation in (90, 270):
+    for source_page, (page, spec) in enumerate(zip(pages, page_specs)):
+        width, height, rotation = spec
+        if not _is_oversized_page(width, height, rotation, max_aspect_ratio):
             writer.add_page(page)
             segments.append(PdfPageSegment(source_page, 0.0, width, height))
             continue

--- a/lazyllm/tools/pdf_utils.py
+++ b/lazyllm/tools/pdf_utils.py
@@ -1,0 +1,124 @@
+import copy
+import math
+import os
+import stat
+import tempfile
+import uuid
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+from lazyllm.thirdparty import pypdf
+
+
+class PdfPageSegment(NamedTuple):
+    source_page: int
+    top_offset: float
+    source_width: float
+    source_height: float
+
+
+class LongPdfNormalization(NamedTuple):
+    path: Path
+    segments: List[PdfPageSegment]
+    changed: bool
+
+
+def _page_size(page) -> tuple:
+    box = page.mediabox
+    return float(box.width), float(box.height)
+
+
+def normalize_long_pdf(
+    input_path: Path,
+    output_path: Optional[Path] = None,
+    max_aspect_ratio: float = 3.0,
+    target_aspect_ratio: float = math.sqrt(2),
+) -> LongPdfNormalization:
+    input_path = Path(input_path)
+    if max_aspect_ratio <= 0 or target_aspect_ratio <= 0:
+        raise ValueError('PDF page aspect ratios must be positive')
+
+    reader = pypdf.PdfReader(str(input_path))
+    if not reader.pages:
+        return LongPdfNormalization(input_path, [], False)
+
+    first_width, first_height = _page_size(reader.pages[0])
+    first_rotation = int(reader.pages[0].rotation or 0) % 360
+    if first_width <= 0 or first_height / first_width <= max_aspect_ratio or first_rotation in (90, 270):
+        segments = [PdfPageSegment(i, 0.0, *_page_size(page)) for i, page in enumerate(reader.pages)]
+        return LongPdfNormalization(input_path, segments, False)
+
+    output_path = Path(output_path) if output_path else input_path.with_suffix('.normalized.pdf')
+    if output_path.resolve() == input_path.resolve():
+        raise ValueError('Normalized PDF output must differ from the input path')
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    writer = pypdf.PdfWriter()
+    segments = []
+    for source_page, page in enumerate(reader.pages):
+        width, height = _page_size(page)
+        rotation = int(page.rotation or 0) % 360
+        if width <= 0 or height / width <= max_aspect_ratio or rotation in (90, 270):
+            writer.add_page(page)
+            segments.append(PdfPageSegment(source_page, 0.0, width, height))
+            continue
+
+        left, bottom, right, top = (float(value) for value in page.mediabox)
+        segment_height = width * target_aspect_ratio
+        segment_count = max(1, math.ceil(height / segment_height))
+        for segment_index in range(segment_count):
+            segment_top = top - segment_index * segment_height
+            segment_bottom = max(bottom, segment_top - segment_height)
+            segment_page = copy.copy(page)
+            box = pypdf.generic.RectangleObject((left, segment_bottom, right, segment_top))
+            segment_page.mediabox = box
+            segment_page.cropbox = box
+            segment_page.trimbox = box
+            segment_page.bleedbox = box
+            segment_page.artbox = box
+            writer.add_page(segment_page)
+            segments.append(PdfPageSegment(source_page, segment_index * segment_height, width, height))
+
+    fd, temp_name = tempfile.mkstemp(prefix=f'.{output_path.name}.', suffix='.tmp', dir=output_path.parent)
+    try:
+        with os.fdopen(fd, 'wb') as stream:
+            writer.write(stream)
+        os.replace(temp_name, output_path)
+    except Exception:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        try:
+            os.unlink(temp_name)
+        except OSError:
+            pass
+        raise
+    return LongPdfNormalization(output_path, segments, True)
+
+
+def normalize_long_pdf_inplace(
+    input_path: Path,
+    max_aspect_ratio: float = 3.0,
+    target_aspect_ratio: float = math.sqrt(2),
+) -> bool:
+    input_path = Path(input_path)
+    source_mode = stat.S_IMODE(input_path.stat().st_mode)
+    output_path = input_path.with_name(f'.{input_path.name}.{uuid.uuid4().hex}.normalized.pdf')
+    try:
+        result = normalize_long_pdf(
+            input_path,
+            output_path,
+            max_aspect_ratio=max_aspect_ratio,
+            target_aspect_ratio=target_aspect_ratio,
+        )
+        if not result.changed:
+            return False
+        os.chmod(result.path, source_mode)
+        os.replace(result.path, input_path)
+        return True
+    finally:
+        try:
+            output_path.unlink()
+        except FileNotFoundError:
+            pass

--- a/lazyllm/tools/rag/readers/ocrReader/dynamic_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/dynamic_pdf_reader.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 from lazyllm import globals as lazyllm_globals
+from lazyllm.tools.pdf_utils import normalize_long_pdf_inplace
 
 from ..pdfReader import PDFReader
 from ..readerBase import LazyLLMReaderBase
@@ -100,12 +103,26 @@ class DynamicPDFReader(LazyLLMReaderBase):
             self._reader_cache[cache_key] = self._build_reader(reader_type, ocr_url)
         return self._reader_cache[cache_key]
 
+    @staticmethod
+    def _normalize_long_pdf(file) -> None:
+        path = Path(file)
+        if path.suffix.lower() == '.pdf' and path.is_file():
+            normalize_long_pdf_inplace(path)
+
     def _load_data(self, file, extra_info=None, **kwargs):
         ocr_type, ocr_url = self._resolve_route(extra_info)
         reader_type, ocr_url = self._reader_cache_key(ocr_type, ocr_url, file)
         reader = self._get_reader(reader_type, ocr_url)
         if isinstance(reader, PDFReader):
-            return reader.forward(file)
+            try:
+                # Sliced pages share the original content stream, and pypdf ignores page boxes while extracting
+                # text. Parse the original PDF first, then replace it so later consumers display the sliced file.
+                return reader.forward(file)
+            finally:
+                self._normalize_long_pdf(file)
+
+        # OCR services must receive the sliced PDF because they render the page boxes before recognition.
+        self._normalize_long_pdf(file)
         return reader.forward(
             file,
             extra_info=extra_info,

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -1,4 +1,5 @@
 import io
+import copy
 import json
 import os
 import re
@@ -19,12 +20,13 @@ import lazyllm
 from lazyllm.common import AuthStrategy, retry_transient
 from lazyllm.tools.http_request import post_sync, get_sync
 from lazyllm import LOG
+from lazyllm.tools.pdf_utils import normalize_long_pdf_inplace
 
 from ...doc_node import DocNode
 from .ocr_ir import (
     Block, BBox, PageRef,
     HeadingBlock, ParagraphBlock, TableBlock, FormulaBlock,
-    FigureBlock, CodeBlock, ListBlock, normalize_bbox,
+    FigureBlock, CodeBlock, ListBlock,
 )
 from .ocr_reader_base import _OcrReaderBase
 from .ocr_service import OcrServiceVariant, default_online_url, resolve_ocr_variant
@@ -42,7 +44,7 @@ _IMAGE_REF_PATTERN = re.compile(
     r'images/[^\s\)"\'\]<]+\.(?:jpg|jpeg|png|gif|bmp|webp|tiff|tif)',
     re.IGNORECASE,
 )
-# Official MinerU content_list bbox is in OCR raster space; normalize to PDF points.
+# Use the official layout artifact for PDF-point block and line bboxes.
 DEFAULT_BBOX = [0, 0, 0, 0]
 
 
@@ -92,6 +94,12 @@ class MineruPDFReader(_OcrReaderBase):
     def _online_request_kwargs(self) -> Dict:
         return {'verify': lazyllm.config['mineru_ssl_verify']}
 
+    def _online_model_version(self) -> str:
+        # The official API exposes only pipeline and vlm. Keep pipeline aligned
+        # with a self-hosted pipeline deployment; map every VLM engine variant
+        # (including hybrid engines) to the official vlm model.
+        return 'pipeline' if self._backend == 'pipeline' else 'vlm'
+
     def _http_execute(self, method: str, url: str, **kwargs):
         kwargs.setdefault('verify', lazyllm.config['mineru_ssl_verify'])
         return super()._http_execute(method, url, **kwargs)
@@ -107,6 +115,11 @@ class MineruPDFReader(_OcrReaderBase):
         file_path = Path(file)
         merged_info = dict(extra_info) if extra_info else {}
         _t0 = time.time()
+        try:
+            if normalize_long_pdf_inplace(file_path):
+                LOG.info(f'[MineruPDFReader] Replaced oversized PDF in place: {file_path}')
+        except Exception as exc:
+            LOG.warning(f'[MineruPDFReader] Long PDF normalization skipped: {file_path}: {exc}')
         if self._offline_mode:
             response_text = self._fetch_sync(file_path, use_cache)
             task_dir = self._image_cache_dir / str(uuid.uuid4())
@@ -345,7 +358,7 @@ class MineruPDFReader(_OcrReaderBase):
         # Step 1: Request presigned upload URL
         payload = {
             'files': [{'name': fname}],
-            'model_version': 'vlm',
+            'model_version': self._online_model_version(),
         }
         resp = self._request(
             'POST',
@@ -412,66 +425,98 @@ class MineruPDFReader(_OcrReaderBase):
                 raise ValueError('No *_content_list.json found in zip')
             content = json.loads(zf.read(json_members[0]))
             layout = None
-            model = None
             for member in zf.infolist():
                 name = Path(member.filename).name
                 if name == 'layout.json':
                     layout = json.loads(zf.read(member))
-                elif name.endswith('_model.json'):
-                    model = json.loads(zf.read(member))
-            if layout is not None and model is not None:
-                content = self._normalize_online_content_bboxes(content, layout, model)
+            if layout is not None:
+                content = self._apply_online_layout_metadata(content, layout)
             for member in zf.infolist():
                 if not member.filename.endswith('_content_list.json'):
                     zf.extract(member, task_dir)
         return json.dumps(content), task_dir
 
     @staticmethod
-    def _normalize_online_content_bboxes(content_list: List[dict], layout: dict,
-                                         model_pages: List) -> List[dict]:
-        '''Rewrite official content_list bboxes from OCR raster space into PDF points.
+    def _layout_lines(block: dict, page_idx: int) -> List[dict]:
+        lines = []
+        for line in block.get('lines') or []:
+            for span in line.get('spans') or []:
+                if not isinstance(span, dict):
+                    continue
+                line_meta = copy.deepcopy(span)
+                line_meta.pop('score', None)
+                cross_page = line_meta.pop('cross_page', None)
+                line_meta['page'] = page_idx + 1 if cross_page is True else page_idx
+                lines.append(line_meta)
+        if not lines:
+            for child in block.get('blocks') or []:
+                if isinstance(child, dict):
+                    lines.extend(MineruPDFReader._layout_lines(child, page_idx))
+        return lines
 
-        layout.json provides PDF page_size; model.json provides 0-1 normalized bboxes.
-        content_list absolute coords ≈ normalized * OCR canvas, so
-        pdf_bbox = content_bbox * page_size / canvas.
-        '''
-        page_sizes = {
-            int(p['page_idx']): p['page_size']
-            for p in (layout.get('pdf_info') or [])
-            if 'page_idx' in p and p.get('page_size')
-        }
-        if not page_sizes or not isinstance(model_pages, list):
+    @staticmethod
+    def _apply_online_layout_metadata(content_list: List[dict], layout: dict) -> List[dict]:
+        if not isinstance(content_list, list):
             return content_list
-
-        by_page: Dict[int, List[dict]] = {}
+        content_by_page: Dict[int, List[dict]] = {}
         for item in content_list:
-            if not isinstance(item, dict) or item.get('bbox') is None:
+            if not isinstance(item, dict) or item.get('page_idx') is None:
                 continue
-            page_idx = item.get('page_idx')
-            if page_idx is None:
-                continue
-            by_page.setdefault(int(page_idx), []).append(item)
+            content_by_page.setdefault(int(item['page_idx']), []).append(item)
 
-        for page_idx, items in by_page.items():
-            page_size = page_sizes.get(page_idx)
-            if not page_size or page_idx >= len(model_pages):
+        for page_info in layout.get('pdf_info') or []:
+            page_idx = page_info.get('page_idx')
+            page_size = page_info.get('page_size')
+            if page_idx is None or not page_size or len(page_size) != 2:
                 continue
-            dets = model_pages[page_idx]
-            if not isinstance(dets, list) or not dets:
-                continue
-            try:
-                max_nx = max(float(d['bbox'][2]) for d in dets if isinstance(d, dict) and d.get('bbox'))
-                max_ny = max(float(d['bbox'][3]) for d in dets if isinstance(d, dict) and d.get('bbox'))
-                max_cx = max(float(it['bbox'][2]) for it in items)
-                max_cy = max(float(it['bbox'][3]) for it in items)
-            except (KeyError, TypeError, ValueError):
-                continue
-            if max_nx <= 0 or max_ny <= 0:
-                continue
-            src_size = (max_cx / max_nx, max_cy / max_ny)
-            dst_size = (float(page_size[0]), float(page_size[1]))
-            for it in items:
-                it['bbox'] = normalize_bbox(it['bbox'], src_size, dst_size)
+            page_idx = int(page_idx)
+            items = content_by_page.get(page_idx, [])
+            blocks = page_info.get('para_blocks') or []
+            group_sizes = [
+                len(item.get('list_items') or [])
+                if item.get('type') == 'list' and item.get('list_items') else 1
+                for item in items
+            ]
+            can_group = sum(group_sizes) == len(blocks)
+            if len(items) != len(blocks) and not can_group:
+                LOG.warning(
+                    f'[MineruPDFReader] layout/content count mismatch on page {page_idx}: '
+                    f'{len(blocks)} != {len(items)}'
+                )
+            block_offset = 0
+            for item, group_size in zip(items, group_sizes):
+                item['page_width'] = float(page_size[0])
+                item['page_height'] = float(page_size[1])
+                if not can_group and len(items) != len(blocks):
+                    bbox = item.get('bbox')
+                    if isinstance(bbox, list) and len(bbox) == 4:
+                        item['bbox'] = [
+                            bbox[0] * float(page_size[0]) / 1000,
+                            bbox[1] * float(page_size[1]) / 1000,
+                            bbox[2] * float(page_size[0]) / 1000,
+                            bbox[3] * float(page_size[1]) / 1000,
+                        ]
+                    continue
+                group = blocks[block_offset:block_offset + group_size]
+                block_offset += group_size
+                bboxes = [
+                    block['bbox'] for block in group
+                    if isinstance(block, dict)
+                    and isinstance(block.get('bbox'), list)
+                    and len(block['bbox']) == 4
+                ]
+                if bboxes:
+                    item['bbox'] = [
+                        min(bbox[0] for bbox in bboxes),
+                        min(bbox[1] for bbox in bboxes),
+                        max(bbox[2] for bbox in bboxes),
+                        max(bbox[3] for bbox in bboxes),
+                    ]
+                item['lines'] = [
+                    line
+                    for block in group if isinstance(block, dict)
+                    for line in MineruPDFReader._layout_lines(block, page_idx)
+                ]
         return content_list
 
     @override
@@ -487,7 +532,7 @@ class MineruPDFReader(_OcrReaderBase):
         for item in content_list:
             block = self._adapt_one(item)
             if block is not None:
-                if self._offline_mode and 'lines' in item:
+                if 'lines' in item:
                     block.lines = self._normalize_content(item['lines'])
                 blocks.append(block)
         return blocks

--- a/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/mineru_pdf_reader.py
@@ -115,11 +115,7 @@ class MineruPDFReader(_OcrReaderBase):
         file_path = Path(file)
         merged_info = dict(extra_info) if extra_info else {}
         _t0 = time.time()
-        try:
-            if normalize_long_pdf_inplace(file_path):
-                LOG.info(f'[MineruPDFReader] Replaced oversized PDF in place: {file_path}')
-        except Exception as exc:
-            LOG.warning(f'[MineruPDFReader] Long PDF normalization skipped: {file_path}: {exc}')
+        normalize_long_pdf_inplace(file_path)
         if self._offline_mode:
             response_text = self._fetch_sync(file_path, use_cache)
             task_dir = self._image_cache_dir / str(uuid.uuid4())

--- a/lazyllm/tools/rag/readers/ocrReader/paddleocr_pdf_reader.py
+++ b/lazyllm/tools/rag/readers/ocrReader/paddleocr_pdf_reader.py
@@ -10,6 +10,7 @@ from typing_extensions import override
 
 import lazyllm
 from lazyllm.tools.http_request import get_sync
+from lazyllm.tools.pdf_utils import normalize_long_pdf_inplace
 from lazyllm.common import ApiKeyHeaderStrategy, AuthStrategy, retry_transient
 from lazyllm import LOG
 
@@ -82,6 +83,7 @@ class PaddleOCRPDFReader(_OcrReaderBase):
         file_path = Path(file)
         merged_info = dict(extra_info) if extra_info else {}
         _t0 = time.time()
+        normalize_long_pdf_inplace(file_path)
         response_text, task_dir = self._fetch_async(file_path)
         _t_fetch = time.time() - _t0
         if task_dir is not None:

--- a/lazyllm/tools/servers/mineru/mineru_server_module.py
+++ b/lazyllm/tools/servers/mineru/mineru_server_module.py
@@ -17,6 +17,7 @@ from lazyllm.thirdparty import fastapi
 from lazyllm import LOG
 from lazyllm import FastapiApp as app
 from lazyllm.module import ServerModule
+from lazyllm.tools.pdf_utils import normalize_long_pdf_inplace
 
 from lazyllm.thirdparty import mineru
 
@@ -1030,6 +1031,18 @@ class MineruServerBase:
                     f'[{req_id}] Conversion cache hits: '
                     f'{conversion_cache_hits}/{len(files_to_process)} files'
                 )
+
+            for pdf_path in pdf_paths:
+                try:
+                    normalized = await asyncio.to_thread(
+                        normalize_long_pdf_inplace,
+                        pdf_path,
+                    )
+                except Exception as exc:
+                    LOG.warning(f'[{req_id}] Long PDF normalization skipped: {pdf_path}: {exc}')
+                    normalized = None
+                if normalized:
+                    LOG.info(f'[{req_id}] Replaced oversized PDF in place: {pdf_path}')
 
             LOG.info(f'[{req_id}] Starting parsing {len(pdf_paths)} PDFs with {effective_backend}...')
             pdf_file_names = [p.stem for p in pdf_paths]

--- a/tests/basic_tests/RAG/test_dynamicpdfreader.py
+++ b/tests/basic_tests/RAG/test_dynamicpdfreader.py
@@ -263,22 +263,77 @@ class TestDynamicPDFReader:
         assert block.page.index == 2
         assert block.page.bbox.to_list() == [10.0, 20.0, 100.0, 50.0]
 
-    def test_normalize_online_content_bboxes_to_pdf_space(self):
+    def test_online_content_uses_layout_block_and_line_bboxes(self):
         content = [
             {'type': 'text', 'text': 'title', 'page_idx': 0, 'bbox': [361, 80, 636, 99]},
             {'type': 'text', 'text': 'body', 'page_idx': 0, 'bbox': [174, 224, 825, 502]},
         ]
-        layout = {'pdf_info': [{'page_idx': 0, 'page_size': [595, 841]}]}
-        model = [[
-            {'type': 'doc_title', 'bbox': [0.363, 0.081, 0.637, 0.101], 'content': 'title'},
-            {'type': 'text', 'bbox': [0.175, 0.225, 0.826, 0.503], 'content': 'body'},
-        ]]
-        out = MineruPDFReader._normalize_online_content_bboxes(content, layout, model)
-        # OCR canvas inferred from max extent ≈ 1000; result should be near PDF points.
-        assert out[0]['bbox'][0] == pytest.approx(215.0, abs=2.0)
-        assert out[0]['bbox'][1] == pytest.approx(67.5, abs=2.0)
-        assert out[0]['bbox'][2] == pytest.approx(379.0, abs=2.0)
-        assert out[0]['bbox'][3] == pytest.approx(83.5, abs=2.0)
+        layout = {'pdf_info': [{
+            'page_idx': 0,
+            'page_size': [595, 841],
+            'para_blocks': [
+                {
+                    'bbox': [215, 67, 379, 83],
+                    'lines': [{'spans': [{
+                        'bbox': [215, 67, 379, 83],
+                        'type': 'text',
+                        'content': 'title',
+                        'score': 0.99,
+                    }]}],
+                },
+                {
+                    'bbox': [104, 188, 491, 422],
+                    'lines': [{'spans': [{
+                        'bbox': [104, 188, 491, 205],
+                        'type': 'text',
+                        'content': 'body',
+                        'cross_page': False,
+                    }]}],
+                },
+            ],
+        }]}
+
+        out = MineruPDFReader._apply_online_layout_metadata(content, layout)
+
+        assert out[0]['bbox'] == [215, 67, 379, 83]
+        assert out[0]['lines'] == [{
+            'bbox': [215, 67, 379, 83],
+            'type': 'text',
+            'content': 'title',
+            'page': 0,
+        }]
+        assert out[1]['bbox'] == [104, 188, 491, 422]
+        assert out[1]['lines'][0]['page'] == 0
+        assert out[1]['page_width'] == 595.0
+        assert out[1]['page_height'] == 841.0
+
+    def test_online_layout_expands_grouped_list_items(self):
+        content = [{
+            'type': 'list',
+            'list_items': ['first', 'second'],
+            'page_idx': 0,
+            'bbox': [100, 100, 900, 900],
+        }]
+        layout = {'pdf_info': [{
+            'page_idx': 0,
+            'page_size': [600, 800],
+            'para_blocks': [
+                {
+                    'bbox': [50, 100, 250, 130],
+                    'lines': [{'spans': [{'bbox': [50, 100, 250, 130], 'content': 'first'}]}],
+                },
+                {
+                    'bbox': [300, 50, 550, 90],
+                    'lines': [{'spans': [{'bbox': [300, 50, 550, 90], 'content': 'second'}]}],
+                },
+            ],
+        }]}
+
+        out = MineruPDFReader._apply_online_layout_metadata(content, layout)
+
+        assert out[0]['bbox'] == [50, 50, 550, 130]
+        assert [line['content'] for line in out[0]['lines']] == ['first', 'second']
+        assert all(line['page'] == 0 for line in out[0]['lines'])
 
     def test_pdf_offline_missing_bbox_still_skipped(self):
         reader = MineruPDFReader(url='http://local-mineru:8000/api/v1/pdf_parse')
@@ -288,3 +343,11 @@ class TestDynamicPDFReader:
         monkeypatch.setenv('LAZYLLM_MINERU_SSL_VERIFY', 'false')
         reader = MineruPDFReader(url='https://mineru.net')
         assert reader._online_request_kwargs() == {'verify': False}
+
+    def test_online_model_version_matches_pipeline_backend(self):
+        reader = MineruPDFReader(url='https://mineru.net', backend='pipeline')
+        assert reader._online_model_version() == 'pipeline'
+
+    def test_online_model_version_maps_engine_variants_to_vlm(self):
+        reader = MineruPDFReader(url='https://mineru.net', backend='hybrid-auto-engine')
+        assert reader._online_model_version() == 'vlm'

--- a/tests/basic_tests/RAG/test_paddleocrpdfreader.py
+++ b/tests/basic_tests/RAG/test_paddleocrpdfreader.py
@@ -183,6 +183,27 @@ def _make_mock_response() -> str:
 
 class TestPaddleOCRPDFReaderMock:
 
+    def test_load_data_normalizes_long_pdf_before_fetch(self):
+        pdf = _make_test_pdf()
+        reader = PaddleOCRPDFReader()
+        calls = []
+
+        def normalize(path):
+            calls.append(('normalize', path))
+
+        def fetch(path):
+            calls.append(('fetch', path))
+            return _make_mock_response(), None
+
+        with patch(
+            'lazyllm.tools.rag.readers.ocrReader.paddleocr_pdf_reader.normalize_long_pdf_inplace',
+            side_effect=normalize,
+        ), patch.object(reader, '_fetch_async', side_effect=fetch), \
+                patch.object(PaddleOCRPDFReader, '_download_images'):
+            reader._load_data(str(pdf))
+
+        assert calls == [('normalize', Path(pdf)), ('fetch', Path(pdf))]
+
     def test_load_data_mock(self):
         pdf = _make_test_pdf()
         reader = PaddleOCRPDFReader()

--- a/tests/basic_tests/Tools/test_pdf_utils.py
+++ b/tests/basic_tests/Tools/test_pdf_utils.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from lazyllm.thirdparty import pypdf
+from lazyllm.tools.pdf_utils import normalize_long_pdf, normalize_long_pdf_inplace
+
+
+def _write_pdf(path: Path, sizes) -> None:
+    writer = pypdf.PdfWriter()
+    for width, height in sizes:
+        writer.add_blank_page(width=width, height=height)
+    with path.open('wb') as stream:
+        writer.write(stream)
+
+
+def test_normal_pdf_is_unchanged(tmp_path):
+    source = tmp_path / 'normal.pdf'
+    _write_pdf(source, [(100, 140), (100, 200)])
+
+    result = normalize_long_pdf(source, tmp_path / 'output.pdf')
+
+    assert result.path == source
+    assert result.changed is False
+    assert [segment.source_page for segment in result.segments] == [0, 1]
+    assert not (tmp_path / 'output.pdf').exists()
+
+
+def test_long_first_page_is_split_from_top_to_bottom(tmp_path):
+    source = tmp_path / 'long.pdf'
+    output = tmp_path / 'normalized.pdf'
+    _write_pdf(source, [(100, 950), (100, 150)])
+
+    result = normalize_long_pdf(source, output, max_aspect_ratio=3, target_aspect_ratio=2)
+    normalized = pypdf.PdfReader(str(output))
+
+    assert result.changed is True
+    assert len(normalized.pages) == 6
+    assert [round(float(page.mediabox.height)) for page in normalized.pages] == [200, 200, 200, 200, 150, 150]
+    assert [segment.source_page for segment in result.segments] == [0, 0, 0, 0, 0, 1]
+    assert [round(segment.top_offset) for segment in result.segments] == [0, 200, 400, 600, 800, 0]
+    assert tuple(float(value) for value in normalized.pages[0].mediabox) == (0.0, 750.0, 100.0, 950.0)
+    assert tuple(float(value) for value in normalized.pages[4].mediabox) == (0.0, 0.0, 100.0, 150.0)
+
+
+def test_long_pdf_is_replaced_inplace(tmp_path):
+    source = tmp_path / 'long.pdf'
+    _write_pdf(source, [(100, 500)])
+    source.chmod(0o640)
+
+    result = normalize_long_pdf_inplace(source, max_aspect_ratio=3, target_aspect_ratio=2)
+    replaced = pypdf.PdfReader(str(source))
+
+    assert result is True
+    assert len(replaced.pages) == 3
+    assert [round(float(page.mediabox.height)) for page in replaced.pages] == [200, 200, 100]
+    assert source.stat().st_mode & 0o777 == 0o640
+
+
+def test_normal_pdf_inplace_returns_false(tmp_path):
+    source = tmp_path / 'normal.pdf'
+    _write_pdf(source, [(100, 200)])
+
+    assert normalize_long_pdf_inplace(source) is False

--- a/tests/basic_tests/Tools/test_pdf_utils.py
+++ b/tests/basic_tests/Tools/test_pdf_utils.py
@@ -41,6 +41,20 @@ def test_long_first_page_is_split_from_top_to_bottom(tmp_path):
     assert tuple(float(value) for value in normalized.pages[4].mediabox) == (0.0, 0.0, 100.0, 150.0)
 
 
+def test_mixed_short_and_long_pages_are_all_checked_and_split(tmp_path):
+    source = tmp_path / 'mixed.pdf'
+    output = tmp_path / 'normalized.pdf'
+    _write_pdf(source, [(100, 150), (100, 450), (100, 650)])
+
+    result = normalize_long_pdf(source, output, max_aspect_ratio=3, target_aspect_ratio=2)
+    normalized = pypdf.PdfReader(str(output))
+
+    assert result.changed is True
+    assert [round(float(page.mediabox.height)) for page in normalized.pages] == [150, 200, 200, 50, 200, 200, 200, 50]
+    assert [segment.source_page for segment in result.segments] == [0, 1, 1, 1, 2, 2, 2, 2]
+    assert [round(segment.top_offset) for segment in result.segments] == [0, 0, 200, 400, 0, 200, 400, 600]
+
+
 def test_long_pdf_is_replaced_inplace(tmp_path):
     source = tmp_path / 'long.pdf'
     _write_pdf(source, [(100, 500)])


### PR DESCRIPTION
# 增加预处理机制，确保ocr服务接收到pdf前 会进行长度的检测和预处理

<img width="1652" height="802" alt="image" src="https://github.com/user-attachments/assets/3725748f-4c2a-42c9-b88a-5bd365654743" />
