### PR TITLE
fix(agent): accept structured history_compactor split

### DIFF
--- a/lazyllm/docs/tools/tool_agent.py
+++ b/lazyllm/docs/tools/tool_agent.py
@@ -1025,6 +1025,7 @@ Args:
         为 True 时触发强制总结；为 False（默认）时直接抛出 ValueError。
     force_summarize_context (str): 强制总结时注入的额外上下文（如原始任务描述），默认为空字符串。
     keep_full_turns (int): 传给 ``history_compactor`` 的最近完整工具结果数量。框架不再内置截断；未提供 compactor 时 history 原样送给模型。默认 0。
+    history_compactor (callable, optional): 压缩模型可见历史。推荐返回 ``(prior_history, current_round_messages)``；仍返回单个 list 时，仅在压缩后条数不变时按长度切分。
     on_max_retries (callable, optional): 达到当前工具调用轮次上限但仍未结束时调用。依次接收最终输出、已执行轮次和当前上限；返回更大的整数可仅为本次调用扩展上限，返回其他值则结束循环。默认为 ``None``。
         ReactAgent 会临时告知模型剩余 ReAct 轮次；该消息不会写入执行历史或输出流。
 ''')
@@ -1067,6 +1068,7 @@ Args:
         Useful when the task involves many tool-call steps and the LLM struggles to stop on its own.
     force_summarize_context (str): Extra context injected into the force-summarize prompt (e.g. the original task description). Defaults to empty string.
     keep_full_turns (int): Passed to ``history_compactor`` as the number of recent tool results to keep intact. LazyLLM no longer truncates history itself; without a compactor the model sees the raw history. Defaults to 0.
+    history_compactor (callable, optional): Compacts model-facing history. Prefer returning ``(prior_history, current_round_messages)``. A bare list is still split by length only when the compacted count is unchanged.
     on_max_retries (callable, optional): Called when the current tool-call round limit is reached without a final answer. It receives the final output, actual round count, and current limit. Returning a larger integer expands only the current invocation; any other value ends the loop. Defaults to ``None``.
         ReactAgent briefly tells the model its remaining ReAct rounds without persisting or emitting the message.
 

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -51,6 +51,15 @@ class StreamResponse():
 _ROUND_TOOLS_KEY = '_function_call_round_tools'
 
 
+def _structured_compact_parts(compacted: Any) -> Optional[tuple]:
+    if not isinstance(compacted, tuple) or len(compacted) != 2:
+        return None
+    prior_part, current_part = compacted
+    if isinstance(prior_part, list) and isinstance(current_part, list):
+        return prior_part, current_part
+    return None
+
+
 def _tool_result_observation(result: Any) -> Any:
     if is_tool_result_envelope(result):
         if result['ok']:
@@ -81,7 +90,7 @@ class FunctionCall(ModuleBase):
                  skill_manager=None, sandbox: Optional[LazyLLMSandboxBase] = None,
                  keep_full_turns: int = 0, stop_tools: Optional[List[str]] = None,
                  round_limit: Optional[int] = None,
-                 history_compactor: Optional[Callable[..., List[Dict[str, Any]]]] = None,
+                 history_compactor: Optional[Callable[..., Any]] = None,
                  runtime_observer: Optional[Callable[..., Any]] = None):
         super().__init__(return_trace=return_trace)
         if _tool_manager is None:
@@ -222,6 +231,9 @@ class FunctionCall(ModuleBase):
             self._keep_full_turns,
             **kwargs,
         )
+        split = _structured_compact_parts(compacted)
+        if split is not None:
+            return strip_tool_observations(split[0]), strip_tool_observations(split[1])
         compacted = strip_tool_observations(compacted)
         prior_len = len(prior_history)
         if current and len(compacted) == prior_len + len(current):

--- a/tests/basic_tests/Tools/test_agent_events.py
+++ b/tests/basic_tests/Tools/test_agent_events.py
@@ -554,6 +554,44 @@ class TestReactAgentEvents(object):
             'error': '',
         }
 
+    def test_history_compactor_tuple_return_sends_current_tools_once(self):
+        llm = _FakeLLM([
+            {
+                'role': 'assistant',
+                'content': 'Let me read the status.',
+                'tool_calls': [{
+                    'id': 'call-status',
+                    'type': 'function',
+                    'function': {'name': 'get_status', 'arguments': '{}'},
+                }],
+            },
+            {'role': 'assistant', 'content': 'Done.'},
+        ])
+
+        def compact(prior_history, _keep, current_round_messages=None, **_kwargs):
+            current = list(current_round_messages or [])
+            return [{'role': 'user', 'content': 'earlier turns summarized'}], current
+
+        agent = ReactAgent(
+            llm=llm,
+            tools=[get_status],
+            max_retries=3,
+            history_compactor=compact,
+            enable_builtin_tools=False,
+        )
+
+        assert agent('read status') == 'Done.'
+        tool_round = next(
+            invocation for invocation in llm.inputs
+            if isinstance(invocation, dict) and isinstance(invocation.get('input'), list)
+        )
+        tool_ids = [
+            message.get('tool_call_id')
+            for message in tool_round['input']
+            if isinstance(message, dict) and message.get('role') == 'tool'
+        ]
+        assert tool_ids == ['call-status']
+
     def test_react_agent_exposes_only_tool_failure_value_to_next_round(self):
         llm = _FakeLLM([
             {


### PR DESCRIPTION
## Summary
- History compactors that change message count (e.g. rolling summary) cannot be split by list length.
- FunctionCall now honors an explicit `(prior_history, current_round_messages)` return while keeping the old list heuristic for existing compactors.

## Test plan
- [x] `tests/basic_tests/Tools/test_agent_events.py` tuple-return case
- [x] Existing list-returning history_compactor tests still pass

备注：修复workflow执行过程中，有时对模型请求多出一个tool字段的问题