### PR TITLE
fix(data): call EvalHardness.parse_sql with the signature it actually has

### DIFF
--- a/lazyllm/tools/data/operators/sql_evalhardness.py
+++ b/lazyllm/tools/data/operators/sql_evalhardness.py
@@ -250,7 +250,7 @@ class EvalHardness:
             idx += 1
 
         if toks[idx] == 'select':
-            idx, val = self.parse_sql(toks, idx, tables_with_alias, schema)
+            idx, val = self.parse_sql(idx)
         elif isinstance(toks[idx], str) and toks[idx] not in schema.idMap:
             val = toks[idx]
             idx += 1
@@ -353,7 +353,7 @@ class EvalHardness:
                 idx += 1
 
             if toks[idx] == 'select':
-                idx, sql = self.parse_sql(toks, idx, tables_with_alias, schema)
+                idx, sql = self.parse_sql(idx)
                 table_units.append((self.TABLE_TYPE['sql'], sql))
             else:
                 if idx < len_ and toks[idx] == 'join':


### PR DESCRIPTION
## Problem

`EvalHardness.parse_sql` was refactored to take only a start index — it reads
`toks`, `tables_with_alias` and `schema` off `self`:

```python
# lazyllm/tools/data/operators/sql_evalhardness.py:468
def parse_sql(self, start_idx):
    toks = self.tokenize
    tables_with_alias = self.get_tables_with_alias(toks)
    schema = self.schema
```

Two of its four call sites were left on the old 4-argument convention that every
other `parse_*` method in the class still uses:

| call site | enclosing method | call |
|---|---|---|
| `:253` | `parse_value` | `self.parse_sql(toks, idx, tables_with_alias, schema)` ❌ |
| `:356` | `parse_from` | `self.parse_sql(toks, idx, tables_with_alias, schema)` ❌ |
| `:517` | `parse_sql` (INTERSECT/UNION/EXCEPT) | `self.parse_sql(idx)` ✅ |
| `:613` | `run` | `self.parse_sql(0)` ✅ |

Both broken sites are the "the next token is `select`" branches, i.e. every query
containing a sub-select:

```
TypeError: EvalHardness.parse_sql() takes 2 positional arguments but 5 were given
```

## Fix

Pass just the index at both sites, matching `:517` and `:613`. `self.tokenize` is
a property derived from `self.query` and `self.schema` is set in `__init__`, so
the values `parse_sql` recomputes are the same ones the callers were handing it.

## Verification

The module only imports `re` and `nltk`, so it runs standalone with a small
`word_tokenize` stub — no LazyLLM install needed. Same schema and queries before
and after the patch:

```
unpatched | sub-select in WHERE  -> TypeError: EvalHardness.parse_sql() takes 2 positional arguments but 5 were given
unpatched | sub-select in FROM   -> TypeError: EvalHardness.parse_sql() takes 2 positional arguments but 5 were given
unpatched | flat query           -> hardness = 'easy'
patched   | sub-select in WHERE  -> hardness = 'hard'
patched   | sub-select in FROM   -> (past the arity error) AssertionError: Default tables should not be None or empty
patched   | flat query           -> hardness = 'easy'
```

To be explicit about the middle row: this PR only removes the arity error.
A sub-select in `FROM` then runs into a **separate, pre-existing** limitation —
`parse_col` asserts on an empty `default_tables` for a derived table, which is
inherited from the upstream Spider evaluator this file is adapted from. Fixing
that is a different change and is deliberately not attempted here.

`flake8` with the repo `.flake8` (including `max-complexity = 12`) is clean on
the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
