### PR TITLE
fix(json): JsonConcentrator schema validation raises TypeError on any nested object

### DIFF
--- a/lazyllm/tools/tools/json.py
+++ b/lazyllm/tools/tools/json.py
@@ -173,7 +173,7 @@ Output only "true" or "false" (without quotes), nothing else.
 
         for key, value in data.items():
             if isinstance(value, dict):
-                if not self._validate_schema(schema[key], value, f'{prefix}.{key}' if prefix else key):
+                if not self._validate_schema_impl(schema[key], value, f'{prefix}.{key}' if prefix else key):
                     return False
         return True
 


### PR DESCRIPTION
## Problem

`JsonConcentrator._validate_schema_impl` recurses into `_validate_schema` — the **public
wrapper**, which takes only `(data)` — instead of into itself:

```python
def _validate_schema(self, data: Dict[str, Any]) -> bool:          # L156  takes (data)
    if self._schema is None:
        return True
    return self._validate_schema_impl(self._schema, data)

def _validate_schema_impl(self, schema, data, prefix='') -> bool:  # L162  takes (schema, data, prefix)
    ...
    for key, value in data.items():
        if isinstance(value, dict):
            if not self._validate_schema(schema[key], value, ...):  # L176  <-- wrong name, 3 args
                return False
    return True
```

The recursive branch only runs when a value is a `dict`, so **flat payloads validate fine
and any nested object raises**:

```
TypeError: JsonConcentrator._validate_schema() takes 2 positional arguments but 4 were given
```

This is reachable from normal use — with a schema configured, every item goes through
`_validate_schema` (L257), so `JsonConcentrator` fails on exactly the nested schemas that
motivate having a schema at all.

## Evidence this is a slipped rename

The sibling recursive method directly below does it correctly, recursing into **itself**:

```python
def _reduce_aggregate(self, schema, jsons, prefix=''):             # L180
    ...
    result[key] = self._reduce_aggregate(value, [...], ...)        # L186  <-- correct
```

`_validate_schema_impl` is the same wrapper+worker split; only its recursive call still
points at the pre-split name.

## Reproduction

Executed against the unmodified file from `main` (stubbing only the `lazyllm` imports):

```python
schema = {"user": {"name": None, "age": None}, "id": None}

_validate_schema({"id": 1})                        # -> True    (flat: works)
_validate_schema({"id": 1, "user": {"name": "a"}}) # -> TypeError: takes 2 positional
                                                   #    arguments but 4 were given
```

After the change:

```
nested, conforming   -> True
nested, extra key    -> False   + "found extra keys {'nope'} not in schema at user"
flat  (regression)   -> True    (unchanged)
3-level nesting      -> True
```

Note the second line: nested key checking has never actually run before this fix, so the
validator silently had no depth coverage.

## Fix

One identifier — `_validate_schema` → `_validate_schema_impl` at L176.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
