### PR TITLE
Fix/hf hub err 874

### DIFF
--- a/lazyllm/thirdparty/__init__.py
+++ b/lazyllm/thirdparty/__init__.py
@@ -133,10 +133,17 @@ class PackageWrapper(object):
             try:
                 self._Wrapper__lib = importlib.import_module(self._Wrapper__key, package=self._Wrapper__package)
                 for patch_func in self._Wrapper__patches: patch_func()
-            except ImportError:
-                pip_cmd = get_pip_install_cmd([self._Wrapper__key])
-                err_msg = f'Cannot import module `{self._Wrapper__key}`, please install it by `{pip_cmd}`'
-                raise ImportError(err_msg) from None
+            except ImportError as error:
+                if isinstance(error, ModuleNotFoundError) and (error.name in (self._Wrapper__key, None)):
+                    pip_cmd = get_pip_install_cmd([self._Wrapper__key])
+                    err_msg = (f'Cannot import module `{self._Wrapper__key}`, '
+                               f'please install it by `{pip_cmd}`')
+                else:
+                    err_msg = (f'Module `{self._Wrapper__key}` is installed, but importing it failed. '
+                               f'This is usually caused by an outdated or incompatible dependency '
+                               f'(e.g. an old `huggingface-hub` used by `transformers`). '
+                               f'Original error: {error}')
+                raise ImportError(err_msg) from error
         return getattr(self._Wrapper__lib, __name)
 
     def __setattr__(self, __name, __value):

--- a/tests/basic_tests/test_thirdparty.py
+++ b/tests/basic_tests/test_thirdparty.py
@@ -76,3 +76,23 @@ class TestThirdparty(object):
         # its import name (multipart) differs from its PyPI name
         assert thirdparty.package_name_map.get('multipart') == 'python-multipart'
         assert thirdparty.package_name_map_reverse.get('python-multipart') == 'multipart'
+
+    def test_import_error_hint_when_module_not_installed(self):
+        w = thirdparty.PackageWrapper('nonexistent_module_kasduf45123')
+        with pytest.raises(ImportError) as exc_info:
+            _ = w.prop
+        msg = str(exc_info.value)
+        assert 'Cannot import module `nonexistent_module_kasduf45123`' in msg
+        assert 'please install it by `pip install nonexistent_module_kasduf45123`' in msg
+
+    def test_import_error_hint_when_installed_but_internal_failure(self, monkeypatch):
+        def broken_import(*args, **kwargs):
+            raise ImportError('failed to resolve old huggingface-hub dependency')
+        monkeypatch.setattr('importlib.import_module', broken_import)
+        w = thirdparty.PackageWrapper('transformers')
+        with pytest.raises(ImportError) as exc_info:
+            _ = w.model
+        msg = str(exc_info.value)
+        assert 'Module `transformers` is installed, but importing it failed' in msg
+        assert 'huggingface-hub' in msg
+        assert 'old huggingface-hub dependency' in msg


### PR DESCRIPTION
fix(thirdparty): only show install hint when module is truly uninstalled

Improve the ImportError hint in lazyllm/thirdparty. Any failed import used to print "Cannot import module X, please install X" even when X was already installed but choked on an outdated dependency (the #874 case: an old huggingface-hub breaking transformers). Now the install hint only appears on a genuine ModuleNotFoundError; otherwise the message says the module is installed but its import failed, points at the usual culprit (huggingface-hub), and keeps the real error in the chain (previously from None dropped it). Two regression tests added; tests/basic_tests/test_thirdparty.py passes 10/10.

Closes #874