### PR TITLE
fix(qwen): avoid double-appending compatible-mode path for custom bas…

### DIFF
--- a/lazyllm/module/llms/onlinemodule/supplier/qwen.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/qwen.py
@@ -22,7 +22,19 @@ from lazyllm import LOG
 
 _DASHSCOPE_DEFAULT_HTTP_URL = 'https://dashscope.aliyuncs.com/api/v1'
 _DASHSCOPE_DEFAULT_WEBSOCKET_URL = 'wss://dashscope.aliyuncs.com/api-ws/v1/inference'
+_COMPATIBLE_MODE_ROOT = 'compatible-mode/v1'
 _dashscope_urls_initialized = False
+
+
+def _get_compatible_mode_url(url: str, path: str) -> str:
+    # Accept host root (dashscope default) or a base that already ends with compatible-mode/v1.
+    base = (url or '').rstrip('/')
+    full = f'{_COMPATIBLE_MODE_ROOT}/{path}'
+    if base.endswith(full):
+        return base
+    if base.endswith(_COMPATIBLE_MODE_ROOT):
+        return f'{base}/{path}'
+    return urljoin(base + '/', full)
 
 
 _QWEN_ERROR_MAP = {
@@ -148,13 +160,11 @@ class QwenChat(OnlineChatModuleBase, FileHandlerBase):
                 'your name is Tongyi Qianwen, and you are a useful assistant.')
 
     def _get_chat_url(self, url):
-        if url.rstrip('/').endswith('compatible-mode/v1/chat/completions'):
-            return url
-        return urljoin(url, 'compatible-mode/v1/chat/completions')
+        return _get_compatible_mode_url(url, 'chat/completions')
 
     def _validate_api_key(self):
         try:
-            models_url = urljoin(self._base_url, 'compatible-mode/v1/models')
+            models_url = _get_compatible_mode_url(self._base_url, 'models')
             response = requests.get(models_url, headers=self._header, timeout=10)
             return response.status_code == 200
         except Exception:


### PR DESCRIPTION
fix(qwen): avoid double-appending compatible-mode path for custom base URL

## 问题
在 Settings → Models → Providers 配置 Qwen 时，若使用 Token Plan 官方 Base URL：
`https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`

校验会失败。原因是 `QwenChat._validate_api_key` / `_get_chat_url` 无条件拼接 `compatible-mode/v1/...`，与用户已填写的路径冲突，实际请求变成：
`.../compatible-mode/compatible-mode/v1/models`（404），被误报为 API Key 校验失败。

## 处理
新增 `_get_compatible_mode_url`：
- Base 仅为 host（如默认 DashScope）→ 补全 `compatible-mode/v1/{path}`
- Base 已以 `compatible-mode/v1` 结尾 → 只追加 `models` / `chat/completions`
- Base 已是完整 endpoint → 原样返回

`_validate_api_key` 与 `_get_chat_url` 统一走该逻辑。

## 测试
- 平台：LazyMind 本地 Docker（`lazymind-v030-chat`），挂载 `algorithm/lazyllm` 后重启 chat
- 修复前双拼 URL → 404；修复后正确 URL → 401（假 Key）/ 200（有效 Key）
- UI：Token Plan Base URL + 有效 Key，「验证并保存」通过

---

## Problem
When configuring Qwen in Settings → Models → Providers with the Token Plan official base URL:
`https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1`

credential validation fails. `QwenChat._validate_api_key` / `_get_chat_url` always append `compatible-mode/v1/...`, which duplicates the path already present in the custom base URL and produces:
`.../compatible-mode/compatible-mode/v1/models` (404), incorrectly reported as an API key failure.

## Fix
Add `_get_compatible_mode_url`:
- Host-only base (e.g. default DashScope) → append `compatible-mode/v1/{path}`
- Base already ending with `compatible-mode/v1` → append only `models` / `chat/completions`
- Base already a full endpoint → return as-is

Wire both `_validate_api_key` and `_get_chat_url` through this helper.

## Test
- Platform: LazyMind local Docker (`lazymind-v030-chat`) with mounted `algorithm/lazyllm`, chat restarted
- Pre-fix doubled URL → 404; post-fix correct URL → 401 (fake key) / 200 (valid key)
- UI: Token Plan base URL + valid key, “Verify and Save” succeeds