### PR TITLE
fix(rag): reparse(strategy='reembed') fallback always raises TypeError

### DIFF
--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -340,7 +340,7 @@ class _Processor:
                 uids: Optional[List[str]] = None, doc_ids: Optional[List[str]] = None,
                 kb_id: Optional[str] = None, strategy: str = 'rebuild', **kwargs):
         if strategy == 'reembed':
-            self._reembed_group(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id)
+            self._reembed_group(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id, **kwargs)
         elif doc_ids:
             self._reparse_docs(group_name=group_name, node_groups=node_groups,
                                doc_ids=doc_ids, kb_id=kb_id, **kwargs)
@@ -348,7 +348,7 @@ class _Processor:
             self._get_or_create_nodes(group_name, node_groups, uids)
 
     def _reembed_group(self, group_name: str, node_groups: Dict[str, Dict],
-                       doc_ids: Optional[List[str]] = None, kb_id: Optional[str] = None):
+                       doc_ids: Optional[List[str]] = None, kb_id: Optional[str] = None, **kwargs):
         embed_keys = self._store._group_embed_keys.get(group_name) or set()
         if not embed_keys:
             raise ValueError(
@@ -360,7 +360,7 @@ class _Processor:
             # nodes not yet materialized — fall back to full reparse
             if doc_ids:
                 self._reparse_docs(group_name=group_name, node_groups=node_groups,
-                                   doc_ids=doc_ids, kb_id=kb_id)
+                                   doc_ids=doc_ids, kb_id=kb_id, **kwargs)
             else:
                 self._get_or_create_nodes(group_name, node_groups, uids=None)
             return
@@ -368,7 +368,7 @@ class _Processor:
         for g in self._store.activated_groups():
             cfg = node_groups.get(g, {})
             if cfg.get('parent') == group_name and cfg.get('lazy_mode') != 'all':
-                self._reembed_group(g, node_groups, doc_ids=doc_ids, kb_id=kb_id)
+                self._reembed_group(g, node_groups, doc_ids=doc_ids, kb_id=kb_id, **kwargs)
 
     def _reparse_docs(self, group_name: Optional[str], node_groups: Dict[str, Dict],
                       doc_ids: List[str], doc_paths: List[str], metadatas: List[Dict],

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -542,7 +542,10 @@ class DocumentProcessorWorker(ModuleBase):
                     operations = []
                     for name in candidate_groups:
                         if strategy == 'reembed':
-                            operations.append((name, dict(strategy='reembed')))
+                            operations.append((name, dict(
+                                strategy='reembed', doc_paths=reparse_files,
+                                metadatas=reparse_metadatas, reader=reader,
+                            )))
                         else:
                             operations.append((name, dict(
                                 doc_paths=reparse_files, metadatas=reparse_metadatas, reader=reader,

--- a/tests/basic_tests/RAG/test_transform.py
+++ b/tests/basic_tests/RAG/test_transform.py
@@ -11,7 +11,7 @@ from lazyllm.tools.rag.transform.base import NodeTransform, _TextSplitterBase, _
 from lazyllm.tools.rag.doc_node import DocNode, RichDocNode
 from lazyllm.tools.rag.global_metadata import RAG_DOC_ID, RAG_DOC_PATH
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from lazyllm.tools.rag.document import Document
 from lazyllm.tools.rag.retriever import Retriever
 from lazyllm.tools.rag.store import LAZY_ROOT_NAME, LAZY_IMAGE_GROUP
@@ -2115,6 +2115,32 @@ class TestBatchForwardRefPath:
                           kb_id='default', strategy='reembed')
 
         processor._reembed_group.assert_called_once_with('block', ng, doc_ids=[self._REPARSE_DOC], kb_id='default')
+
+    def test_reparse_reembed_falls_back_to_full_reparse_when_nodes_missing(self):
+        '''strategy='reembed' with nothing materialized -> full reparse of the docs.
+
+        _reparse_docs() requires doc_paths and metadatas, so the fallback only works if
+        reparse() forwards the reparse kwargs into _reembed_group(). autospec=True is what
+        makes this a regression test: without the forwarding the call cannot bind and
+        raises TypeError instead of reaching the assertion below.
+        '''
+        ng = self._make_node_groups()
+        store = MagicMock()
+        store.get_nodes.return_value = []  # nodes not materialized yet
+        store._group_embed_keys = {'block': {'default'}}
+        store.activated_groups.return_value = []
+        reader = MagicMock()
+
+        processor = _Processor(store=store)
+
+        with patch.object(_Processor, '_reparse_docs', autospec=True) as reparse_docs:
+            processor.reparse(group_name='block', node_groups=ng, doc_ids=[self._REPARSE_DOC],
+                              kb_id='default', strategy='reembed',
+                              doc_paths=[self._REPARSE_PATH], metadatas=[{}], reader=reader)
+
+        reparse_docs.assert_called_once_with(
+            processor, group_name='block', node_groups=ng, doc_ids=[self._REPARSE_DOC],
+            kb_id='default', doc_paths=[self._REPARSE_PATH], metadatas=[{}], reader=reader)
 
 
 class TestCallableSig:


### PR DESCRIPTION
## What's wrong

`_Processor.reparse(strategy='reembed')` hands off to `_reembed_group()`. When the target group has no materialized nodes yet, `_reembed_group()` falls back to a full reparse:

```python
# lazyllm/tools/rag/parsing_service/impl.py:359
nodes = self._store.get_nodes(group=group_name, doc_ids=doc_ids, kb_id=kb_id)
if not nodes:
    # nodes not yet materialized — fall back to full reparse
    if doc_ids:
        self._reparse_docs(group_name=group_name, node_groups=node_groups,
                           doc_ids=doc_ids, kb_id=kb_id)
```

but `_reparse_docs` has required `doc_paths` and `metadatas` since it was written:

```python
# impl.py:373
def _reparse_docs(self, group_name, node_groups, doc_ids, doc_paths, metadatas,
                  kb_id=None, reader=None):
```

Neither `reparse()` nor `_reembed_group()` carries those two values, so **the fallback can never succeed** — it raises `TypeError: _reparse_docs() missing 2 required positional arguments: 'doc_paths' and 'metadatas'`, which `worker.py` catches and turns into a `FAILED` node-group status.

Every other call site of `_reparse_docs` (`impl.py:345`, `:397`, `:410`) and every call in `tests/basic_tests/RAG/test_transform.py` passes `doc_paths` and `metadatas`. This one is the odd one out.

## The fix

Two halves, and both are needed:

1. `impl.py` — `reparse()` already forwards `**kwargs` on the `rebuild` path (`:344`); do the same for the `reembed` path, and let `_reembed_group()` accept and forward them (including through its own recursion into child groups).
2. `worker.py` — the `reembed` operation was the only one built without `doc_paths` / `metadatas` / `reader`:
   ```python
   if strategy == 'reembed':
       operations.append((name, dict(strategy='reembed')))
   else:
       operations.append((name, dict(doc_paths=reparse_files, metadatas=reparse_metadatas, reader=reader)))
   ```
   Those three values are already in scope there, so the reembed operation now carries them too and the fallback has something to work with.

Happy path of `reembed` (nodes present → `update_nodes` + recurse) is untouched, and the existing `test_reparse_reembed_strategy_reembeds_existing_nodes` assertion still matches exactly, since it passes no extra kwargs.

## Verification

No GPU/store here, so both methods were lifted **verbatim** out of the checked-in file with `ast` (no hand-copying) into a stub class with a mock store, and `_reparse_docs` kept its real parameter list so a call that cannot bind still raises the real `TypeError`:

```
=== worker.py's reembed operation as it is on main (no doc_paths in kwargs) ===
  unpatched impl.py: TypeError: _reparse_docs() missing 2 required positional arguments: 'doc_paths' and 'metadatas'
  patched impl.py  : TypeError: _reparse_docs() missing 2 required positional arguments: 'doc_paths' and 'metadatas'

=== with the patched worker.py, which now forwards doc_paths/metadatas/reader ===
  unpatched impl.py: TypeError: _reparse_docs() missing 2 required positional arguments: 'doc_paths' and 'metadatas'
  patched impl.py  : _reparse_docs bound OK; doc_paths=['/tmp/a.txt'] metadatas=[{}]
```

The last row is the point: neither half alone fixes it.

The new test, `test_reparse_reembed_falls_back_to_full_reparse_when_nodes_missing`, uses `patch.object(..., autospec=True)` so the mock enforces the real signature. Replayed against the same lifted class it is non-vacuous:

```
=== the new pytest test's mechanism, replayed on the lifted class ===
  unpatched impl.py: test FAILS -> TypeError: missing a required argument: 'doc_paths'
  patched impl.py  : test PASSES
```

I could not install the full `lazyllm` runtime locally, so the pytest file itself is left for CI to run; `flake8` (with the repo's `.flake8`, plus bugbear/quotes) reports nothing new on any of the three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
