### PR TITLE
fix(rag): validate reparse state before committing legacy metadata write

### DIFF
--- a/lazyllm/tools/rag/doc_service/doc_server.py
+++ b/lazyllm/tools/rag/doc_service/doc_server.py
@@ -643,6 +643,10 @@ class DocServer(ModuleBase):
             # raised on a WORKING/DELETING existing doc, the new-file uploads
             # would already be committed -- a partial-commit failure mode.
             if reparse_inputs:
+                # Same reordering as reparse-before-upload above: raise here,
+                # before the metadata write below, not after it.
+                for _, _, _, eid in reparse_inputs:
+                    self._manager._assert_action_allowed(eid, kb_id, 'reparse')
                 # Apply the caller's metadata directly to the documents row
                 # so the reparse worker (which reloads ``doc.meta`` in
                 # ``_prepare_reparse_items``) picks up the new values.

--- a/tests/basic_tests/RAG/test_doc_service_doc_server.py
+++ b/tests/basic_tests/RAG/test_doc_service_doc_server.py
@@ -61,6 +61,9 @@ class _FakeManager:
         self.cancel_response = BaseResponse(
             code=200, msg='success', data={'task_id': 'task-1', 'cancel_status': True, 'status': 'CANCELED'}
         )
+        # doc_ids that should fail the reparse/upload state check, mirroring a
+        # real WORKING/DELETING doc; tests set this to simulate the rejection.
+        self.reject_action_for = set()
 
     def run_idempotent(self, endpoint, idempotency_key, payload, handler):
         self.run_calls.append({
@@ -79,6 +82,10 @@ class _FakeManager:
 
     def _list_kb_docs_by_path(self, kb_id, exclude_failed=True):
         return dict(self.existing_docs_by_path)
+
+    def _assert_action_allowed(self, doc_id, kb_id, action):
+        if doc_id in self.reject_action_for:
+            raise DocServiceError('E_STATE_CONFLICT', f'cannot {action} while state is WORKING')
 
     def reparse(self, request):
         self.reparse_request = request
@@ -706,3 +713,25 @@ def test_legacy_upload_reparse_validates_before_new_uploads(server_impl):
     assert fake.upload_request is None, (
         'new-file upload must not commit when the reparse phase fails'
     )
+
+
+def test_legacy_upload_reparse_state_conflict_does_not_commit_metadata(server_impl):
+    '''Regression (#1090): reparse's own state check (WORKING/DELETING) must
+    run and raise before the legacy shim writes the caller's metadata into
+    the documents row, not after. Without this, a rejected reparse still
+    leaves the metadata change committed with no rollback.'''
+    fake = server_impl._manager
+    storage = server_impl._storage_dir
+    existing_path = os.path.join(storage, 'existing.txt')
+    fake.existing_docs_by_path = {existing_path: 'preexisting-doc-id'}
+    fake.reject_action_for = {'preexisting-doc-id'}
+
+    files = [_UploadFile('existing.txt', b'updated')]
+    response = asyncio.run(server_impl.upload_files_legacy(
+        files=files, override=True, metadatas=json.dumps([{'tag': 'should-not-commit'}]),
+        group_name=None, user_path=None,
+    ))
+    assert fake.synced_meta_writes == [], 'metadata must not commit when reparse is rejected'
+    assert fake.reparse_request is None, 'reparse must not be enqueued after its own validation rejects'
+    body = _decode_response(response)
+    assert body['data']['biz_code'] == 'E_STATE_CONFLICT'


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- `_legacy_dispatch_uploads` wrote the caller's metadata into the documents row before calling `DocManager.reparse`. If reparse rejected the doc (WORKING/DELETING), the metadata was already committed with no rollback. This adds the same `_assert_action_allowed` check `_prepare_reparse_items` runs, before the write, so a rejection raises first.

---

# 🎯 问题背景 / Problem Context

- One of the gaps tracked in #1090 under "override=true metadata write commits before reparse is validated". Scoped to just that item; the sibling item right below it (stale `content_hash`/`size_bytes`/`file_type` after override) is a separate fix, not touched here.

# 🔍 相关 Issue / Related Issue

Refs #1090 (tracking issue, most other items are unrelated and still open)

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

1. New test `test_legacy_upload_reparse_state_conflict_does_not_commit_metadata`: the metadata write on main happens whether or not reparse would accept it; the added check stops that.
2. Full `tests/basic_tests/RAG/test_doc_service_doc_server.py`, clean `python:3.11-slim` container against current HEAD: 33 passed.
3. `flake8` on both changed files: clean.
4. Not run: `tests/doc_check` (no docstrings touched here).

---

# 📷 Demo (Optional)

*

---

# ⚡ 更新后的用法示例 / Usage After Update

```python
```

---

# 🔄 重构对比 / Refactor Comparison (如适用 / if applicable)

## Before

```python
```

## After

```python
```

# ⚠️ 注意事项 / Additional Notes

- The issue offers two directions: snapshot-and-rollback, or move the write behind reparse's own validation. Went with the second, smaller change, reusing the check `reparse()` already runs.

---


# 🧠 AI 参与情况 / AI Involvement (需查看近期所有的对话历史填写)

- [ ] 未使用 AI / No AI used
- [ ] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [x] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**
- [ ] Cursor
- [ ] CodeX
- [x] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other：

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt
```text
Read issue #1090's tracked gaps, find the highest-severity standalone one, reproduce it, fix the root cause, open a PR.
```

## 一开始制定了什么方案
Reproduce the write-before-validate ordering, confirm the row stays mutated after a rejected reparse, fix by validating first.

## 方案实施后存在什么问题
A flag-based guess at "which states are unsafe" would drift from the real rule over time.

## 我（用户）发现了哪些问题
The test double didn't expose `_assert_action_allowed` at all; adding the real call would have broken every existing test on this path with an `AttributeError` until the fake got it too.

## 对这些问题优化后相比于之前有哪些优势
The fix shares its validation with the code it protects, so it can't drift out of sync with a future state-machine change.

## 哪些可以沉淀为自己后续的编码规范
When a write precedes a validation call later in the same function, check whether the validation can move ahead of the write instead of adding a rollback path.
