### PR TITLE
fix: classify OpenAI-compatible context capacity errors while preserving provider codes

### DIFF
--- a/lazyllm/module/llms/onlinemodule/base/provider_response.py
+++ b/lazyllm/module/llms/onlinemodule/base/provider_response.py
@@ -65,13 +65,21 @@ class ProviderResponseProfile:
         provider_error_code: Optional[str] = None,
         provider_error_type: Optional[str] = None,
         provider_http_status: Optional[int] = None,
+        provider_response: Optional[Dict[str, Any]] = None,
     ) -> ModelFailureCode:
         if origin == ModelFailureOrigin.PROTOCOL:
             return ModelFailureCode.PROTOCOL_ERROR
         if origin == ModelFailureOrigin.TRANSPORT:
             return ModelFailureCode.TRANSPORT_ERROR
         if provider_error_code:
-            mapped = self.code_map.get(provider_error_code.lower())
+            classification_key = provider_error_code.lower()
+            if classification_key == '400' and provider_response:
+                payload = provider_response.get('error', provider_response if self.error_at_top_level else None)
+                if (isinstance(payload, dict) and payload.get('param') == 'input_tokens'
+                        and 'maximum context length' in str(payload.get('message', '')).lower()):
+                    # Normalize the classification key without replacing the raw provider code.
+                    classification_key = 'context_length_exceeded'
+            mapped = self.code_map.get(classification_key)
             if mapped is not None: return mapped
         if provider_error_type:
             mapped = self.type_map.get(provider_error_type.lower())
@@ -101,6 +109,7 @@ class ProviderResponseProfile:
         provider_error_code: Optional[str] = None,
         provider_error_type: Optional[str] = None,
         provider_http_status: Optional[int] = None,
+        provider_response: Optional[Dict[str, Any]] = None,
     ) -> _ModelResponseError:
         return _ModelResponseError(message, ModelFailure(
             origin=origin,
@@ -109,6 +118,7 @@ class ProviderResponseProfile:
                 provider_error_code=provider_error_code,
                 provider_error_type=provider_error_type,
                 provider_http_status=provider_http_status,
+                provider_response=provider_response,
             ),
             provider_error_code=provider_error_code,
             provider_error_type=provider_error_type,
@@ -120,9 +130,6 @@ class ProviderResponseProfile:
     def _error_fields(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
         code = payload.get('code')
         error_type = payload.get('type')
-        if (code == 400 and payload.get('param') == 'input_tokens'
-                and 'maximum context length' in str(payload.get('message', '')).lower()):
-            code = 'context_length_exceeded'
         return (
             str(code) if code is not None else None,
             str(error_type) if error_type is not None else None,
@@ -169,6 +176,7 @@ def raise_for_http_error(response: Any, profile: ProviderResponseProfile) -> Non
         provider_error_code=code,
         provider_error_type=error_type,
         provider_http_status=response.status_code,
+        provider_response=error_message if isinstance(error_message, dict) else None,
     )
 
 
@@ -223,6 +231,7 @@ class _OpenAICompatibleResponseParser:
                 ModelFailureOrigin.PROVIDER,
                 provider_error_code=code,
                 provider_error_type=error_type,
+                provider_response=raw_message,
             )
         try:
             message = self._convert_message(raw_message)

--- a/lazyllm/module/llms/onlinemodule/base/provider_response.py
+++ b/lazyllm/module/llms/onlinemodule/base/provider_response.py
@@ -120,6 +120,9 @@ class ProviderResponseProfile:
     def _error_fields(payload: Dict[str, Any]) -> Tuple[Optional[str], Optional[str]]:
         code = payload.get('code')
         error_type = payload.get('type')
+        if (code == 400 and payload.get('param') == 'input_tokens'
+                and 'maximum context length' in str(payload.get('message', '')).lower()):
+            code = 'context_length_exceeded'
         return (
             str(code) if code is not None else None,
             str(error_type) if error_type is not None else None,
@@ -127,6 +130,7 @@ class ProviderResponseProfile:
 
 
 OPENAI_COMPATIBLE_PROFILE = ProviderResponseProfile(
+    code_map={'context_length_exceeded': ModelFailureCode.TOKEN_LIMIT},
     http_map={
         400: ModelFailureCode.INVALID_REQUEST,
         401: ModelFailureCode.AUTHENTICATION_FAILED,

--- a/tests/basic_tests/Models/test_online_chat_model_runtime.py
+++ b/tests/basic_tests/Models/test_online_chat_model_runtime.py
@@ -417,6 +417,14 @@ def test_http_status_survives_error_body_transport_failure():
 
 @pytest.mark.parametrize(('module_cls', 'status', 'body', 'expected'), [
     (LazyLLMOnlineChatModuleBase, 400, '{"error":{}}', ModelFailureCode.INVALID_REQUEST),
+    (OpenAIChat, 400, '{"error":{"code":"context_length_exceeded"}}', ModelFailureCode.TOKEN_LIMIT),
+    (OpenAIChat, 400, json.dumps({'error': {
+        'code': 400, 'type': 'BadRequestError', 'param': 'input_tokens',
+        'message': "This model's maximum context length is 262144 tokens. Your prompt contains at least 262145 tokens.",
+    }}), ModelFailureCode.TOKEN_LIMIT),
+    (OpenAIChat, 400, json.dumps({'error': {
+        'code': 400, 'type': 'BadRequestError', 'param': 'input_tokens', 'message': 'Invalid input.',
+    }}), ModelFailureCode.INVALID_REQUEST),
     (LazyLLMOnlineChatModuleBase, 401, '{"error":{}}', ModelFailureCode.AUTHENTICATION_FAILED),
     (LazyLLMOnlineChatModuleBase, 403, '{"error":{}}', ModelFailureCode.PERMISSION_DENIED),
     (LazyLLMOnlineChatModuleBase, 404, '{"error":{}}', ModelFailureCode.NOT_FOUND),

--- a/tests/basic_tests/Models/test_online_chat_model_runtime.py
+++ b/tests/basic_tests/Models/test_online_chat_model_runtime.py
@@ -450,6 +450,29 @@ def test_provider_http_mapping_uses_supplier_source(monkeypatch, module_cls, sta
 
     assert exc_info.value.failure.code is expected
     assert exc_info.value.failure.provider_http_status == status
+    raw_code = json.loads(body)['error'].get('code')
+    assert exc_info.value.failure.provider_error_code == (str(raw_code) if raw_code is not None else None)
+
+
+@pytest.mark.parametrize('code', [400, '400'])
+@pytest.mark.parametrize('http_error', [True, False])
+def test_vllm_capacity_error_preserves_raw_code(code, http_error):
+    body = json.dumps({'error': {
+        'code': code, 'type': 'BadRequestError', 'param': 'input_tokens',
+        'message': "This model's maximum context length is 4096 tokens. However, you requested "
+                   '4096 output tokens and your prompt contains 24 input tokens, for a total of 4120 tokens.',
+    }})
+    with pytest.raises(_ModelResponseError) as exc_info:
+        if http_error:
+            raise_for_http_error(_Response(status_code=400, body=body), OpenAIChat.RESPONSE_PROFILE)
+        else:
+            _parser(OpenAIChat).parse_response_frame('data: ' + body)
+
+    failure = exc_info.value.failure
+    assert failure.code is ModelFailureCode.TOKEN_LIMIT
+    assert failure.provider_error_code == '400'
+    assert failure.provider_error_type == 'BadRequestError'
+    assert failure.origin is (ModelFailureOrigin.HTTP if http_error else ModelFailureOrigin.PROVIDER)
 
 
 def test_deepseek_http_402_is_balance_exhausted(monkeypatch):


### PR DESCRIPTION
# Bug Fix

## Problem Description

OpenAI-compatible services can report context overflow as HTTP 400 with `code: 400`,
`param: input_tokens`, and a message containing `maximum context length`.
LazyLLM classified this vLLM response as `INVALID_REQUEST`, preventing callers from recognizing a capacity failure.

## Problem Analysis

The shared response profile mapped HTTP status and explicit error codes but did not recognize this payload shape.
The failure affects both HTTP error responses and provider error frames parsed through the OpenAI-compatible parser.

To reproduce, parse an error payload with the fields above. Its normalized failure should be `TOKEN_LIMIT`,
while `provider_error_code` should retain the original value as the string `400`.

## Fix Solution

- Recognize the explicit vLLM capacity payload in `ProviderResponseProfile.classify()`.
- Map its internal classification key to `context_length_exceeded`, then use the existing profile mapping.
- Pass the response payload through the shared HTTP and provider-frame error paths.
- Preserve the raw provider error code, error type, and failure origin for diagnostics.
- Keep ordinary HTTP 400 responses classified as `INVALID_REQUEST`.

Using the existing response profile keeps protocol classification shared across callers and avoids business-specific rules.

## Fix Verification

All checks ran inside the development container.

- [x] Post-fix testing: 66 tests passed in `tests/basic_tests/Models/test_online_chat_model_runtime.py`.
- [x] Regression testing: existing supplier status and error mappings continue to pass.
- [x] Edge case testing: numeric and string `400` codes, HTTP and provider-frame paths, and raw-field preservation.
- [x] `make lint-only-diff` passed for both changed files, including the repository's print-statement check.

`CHANGED_FILES` was supplied explicitly to select the two files inside the container.

## Impact Assessment

Callers can recognize these capacity failures through `ModelFailureCode.TOKEN_LIMIT`.
Raw provider diagnostics remain available. Ordinary bad requests retain their previous classification.
The change adds no requests, retry policy, dependencies, or application token limits.

## Prevention Measures

Regression tests assert normalized classification and raw diagnostic fields separately.
Review provider-specific payload handling in the shared response profile rather than duplicating it in applications.

## Related Issues

No linked issue. Consumer integration: https://github.com/LazyAGI/LazyMind/pull/694.

## Change Type

- [x] Bug fix

## Impact Scope

- [x] API interface

## Priority

- [x] Medium - Next version

## Release Notes Points

OpenAI-compatible vLLM context-capacity errors now report `TOKEN_LIMIT` while preserving raw provider diagnostics.
No configuration changes or migration are required.

## AI Involvement

- [x] AI-led (majority of code)
- [x] CodeX

## AI Generation Process

### Initial Prompt

Implement conversation titles, initial-intent summaries, and historical backfill in LazyMind using shared model calls.
Do not impose application input or output token limits; classify actual provider capacity errors for model fallback.

### Initial Plan

Normalize explicit provider capacity errors in LazyLLM and let the consuming application choose its fallback model.

### Issues Found During Implementation

A real vLLM response used numeric error code `400`, which the existing mapping treated as an invalid request.
The initial patch normalized the extracted provider code itself; this update preserves that raw diagnostic field.

### User Feedback

The user requested removal of application token limits, reuse of shared LLM capabilities, minimal redundant code,
and an English PR description that follows repository conventions.

### Improvements

Classification now uses the shared response profile while preserving raw fields.
LazyMind consumes the standard `token_limit` code directly, with regression coverage on both sides.

### Coding Practices Retained

Validate provider payloads with concrete examples, preserve raw diagnostics, reuse existing shared abstractions,
and distinguish service capacity from application budgets.
