### PR TITLE
fix mcp bugs

### DIFF
--- a/lazyllm/tools/mcp/client.py
+++ b/lazyllm/tools/mcp/client.py
@@ -2,7 +2,7 @@ from typing import Any, Optional, Literal
 from urllib.parse import urlparse
 from contextlib import asynccontextmanager
 
-from lazyllm.thirdparty import httpx, mcp
+from lazyllm.thirdparty import mcp
 
 from .utils import patch_sync
 from .tool_adaptor import generate_lazyllm_tool
@@ -60,12 +60,18 @@ class MCPClient(object):
 
             async with create_mcp_http_client(
                 headers=self._headers or None,
-                timeout=httpx.Timeout(self._timeout),
+                # Let the MCP SDK construct its own timeout object. Some
+                # releases vendor httpx as httpx2, which cannot consume a
+                # Timeout instance created by LazyLLM's httpx shim.
+                timeout=self._timeout,
             ) as http_client:
                 async with streamable_http_client(
                     url=self._command_or_url,
                     http_client=http_client,
-                ) as (read_stream, write_stream, _get_session_id):
+                ) as streams:
+                    # mcp SDK releases have returned both a 2-tuple and a
+                    # 3-tuple here. Only the read/write streams are required.
+                    read_stream, write_stream = streams[:2]
                     async with mcp.ClientSession(read_stream, write_stream) as session:
                         await session.initialize()
                         yield session

--- a/lazyllm/tools/mcp/tool_adaptor.py
+++ b/lazyllm/tools/mcp/tool_adaptor.py
@@ -1,5 +1,6 @@
 import inspect
 import asyncio
+import re
 
 from typing import Any, Callable, Dict, List, Set
 from lazyllm import LOG
@@ -66,8 +67,15 @@ def _handle_tool_result(result, tool_name: str) -> str:
 
 def generate_lazyllm_tool(client, mcp_tool) -> Callable:
     tool_name = mcp_tool.name
+    exposed_tool_name = re.sub(r'\W', '_', tool_name)
+    if exposed_tool_name[:1].isdigit():
+        exposed_tool_name = '_' + exposed_tool_name
     tool_desc = mcp_tool.description
-    input_schema = mcp_tool.inputSchema
+    # MCP's Pydantic models used the JSON alias ``inputSchema`` in older
+    # releases and the Pythonic ``input_schema`` attribute in newer ones.
+    input_schema = getattr(mcp_tool, 'inputSchema', None)
+    if input_schema is None:
+        input_schema = getattr(mcp_tool, 'input_schema', {})
     properties = input_schema.get('properties', {})
     required = input_schema.get('required', [])
 
@@ -109,7 +117,10 @@ def generate_lazyllm_tool(client, mcp_tool) -> Callable:
         return _handle_tool_result(result, tool_name)
 
     # Set function attributes
-    dynamic_lazyllm_func.__name__ = tool_name
+    # LazyLLM's registry interprets dots as registry-group separators. MCP
+    # servers commonly namespace tools with dots, so expose a valid Python
+    # identifier while retaining the original name in the call closure.
+    dynamic_lazyllm_func.__name__ = exposed_tool_name
     dynamic_lazyllm_func.__doc__ = func_desc
     dynamic_lazyllm_func.__annotations__ = annotations
 


### PR DESCRIPTION
# 📌 PR 内容 / PR Description

- Fix Streamable HTTP MCP initialization across different `mcp` and `httpx` dependency versions.
- Support both legacy `inputSchema` and current `input_schema` MCP tool model attributes.
- Sanitize MCP tool names before exposing them to LazyLLM's Python tool registry.
- Preserve the original MCP tool name when sending the actual `call_tool` request.

---

# 🎯 问题背景 / Problem Context

LazyLLM may run with MCP SDK releases whose HTTP client and Pydantic model APIs differ from those
expected by the current MCP adapter.

The following failures can occur:

1. The MCP SDK may use a vendored or separately imported `httpx` implementation. Passing an
   `httpx.Timeout` instance created by LazyLLM's shim can then fail type validation.
2. `streamable_http_client` has returned both two-element and three-element tuples across MCP SDK
   releases. Fixed three-value unpacking is therefore not compatible with every supported release.
3. MCP tool models expose their schema as `inputSchema` in older releases and `input_schema` in newer
   releases. Reading only the legacy attribute can raise `AttributeError`.
4. MCP servers commonly namespace tools with names such as `server.search`. LazyLLM interprets dots
   as registry-group separators, so exposing the raw name can prevent the generated tool from being
   registered or called correctly.

This PR adds compatibility handling at the LazyLLM MCP boundary without changing the MCP protocol or
the original remote tool names.

# 🔍 相关 Issue / Related Issue

- No linked issue.

---

# ✅ 变更类型 / Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Breaking change
* [ ] Documentation
* [ ] Performance optimization

---

# 🧪 如何测试 / How Has This Been Tested?

Recommended regression coverage:

1. Connect to a Streamable HTTP MCP server and confirm session initialization succeeds when the MCP
   SDK constructs its own timeout object.
2. Verify clients returning either a two-element or three-element stream tuple initialize correctly.
3. Generate tools from MCP models exposing either `inputSchema` or `input_schema`.
4. Register and call tools named `server.search`, `search-items`, and `1st_tool`; verify that LazyLLM
   uses safe local function names while the MCP request receives the original names.
5. Run `make lint-only-diff`.

---

# 📷 Demo (Optional)

- Not applicable; this is an MCP compatibility fix.

---

# ⚡ 更新后的用法示例 / Usage After Update

No user-facing API changes are required. Existing MCP client configuration continues to work:

```python
client = MCPClient('http://127.0.0.1:8000/mcp')
tools = client.get_tools()
```

Namespaced MCP tools are exposed through registry-safe Python function names, while calls still use
the original MCP name expected by the server.

---

# 🔄 重构对比 / Refactor Comparison

## Before

```python
timeout=httpx.Timeout(self._timeout)
read_stream, write_stream, _get_session_id = streams
input_schema = mcp_tool.inputSchema
dynamic_lazyllm_func.__name__ = tool_name
```

## After

```python
timeout=self._timeout
read_stream, write_stream = streams[:2]
input_schema = getattr(mcp_tool, 'inputSchema', None)
input_schema = input_schema or getattr(mcp_tool, 'input_schema', {})
dynamic_lazyllm_func.__name__ = exposed_tool_name
```

# ⚠️ 注意事项 / Additional Notes

- The sanitization affects only the generated Python callable name.
- The closure retains `tool_name`, so `client.call_tool` continues to send the exact original MCP name.
- This change is backward compatible with MCP models that still expose `inputSchema`.

---

# 🧠 AI 参与情况 / AI Involvement

- [ ] 未使用 AI / No AI used
- [x] 使用 AI 辅助（局部代码）/ AI-assisted (partial code)
- [ ] 使用 AI 主导（大部分代码）/ AI-led (majority of code)

**使用工具 / Tools Used：**

- [ ] Cursor
- [x] CodeX
- [ ] ClaudeCode
- [ ] OpenCode
- [ ] 其他 / Other

# 🤖 AI 生成过程 / AI Generation Process

## 初始 Prompt / Initial Prompt

```text
Investigate MCP connection and generated-tool compatibility failures with the current MCP SDK and
LazyLLM registry, then implement the smallest backward-compatible fixes.
```

## 一开始制定了什么方案

- Keep compatibility logic inside the MCP client and tool adapter.
- Avoid changing public APIs or remote MCP tool names.
- Support both old and new dependency return shapes and model attribute names.

## 方案实施后存在什么问题

- Raw MCP tool names containing dots were still interpreted as LazyLLM registry namespaces.
- A fixed MCP stream tuple shape and a single schema attribute were too version-specific.

## 我（用户）发现了哪些问题

- Streamable HTTP MCP initialization failed with incompatible timeout object types.
- Some MCP tools could not be adapted or registered under newer SDK/model versions.

## 对这些问题优化后相比于之前有哪些优势

- Works across a wider range of MCP SDK and `httpx` combinations.
- Accepts both legacy and current MCP Pydantic field names.
- Supports namespaced and otherwise non-Python MCP tool names without changing remote invocation.

## 哪些可以沉淀为自己后续的编码规范

- Normalize third-party protocol data at the adapter boundary.
- Do not leak dependency-specific object instances across separately vendored package boundaries.
- Keep local registry identifiers separate from protocol-level identifiers.
- Add compatibility fallbacks when upstream libraries have changed public model field names or tuple
  return shapes.
