### PR TITLE
fix(llm auth): ？？skip default key lookup when auth is disabled

### DIFF
--- a/lazyllm/module/llms/onlinemodule/supplier/openai.py
+++ b/lazyllm/module/llms/onlinemodule/supplier/openai.py
@@ -32,7 +32,8 @@ class OpenAIChat(OnlineChatModuleBase, FileHandlerBase):
                  api_key: str = None, stream: bool = True, return_trace: bool = False, skip_auth: bool = False, **kw):
         base_url = base_url or 'https://api.openai.com/v1/'
         model = model or 'gpt-3.5-turbo'
-        super().__init__(api_key=api_key or self._default_api_key(),
+        api_key = '' if skip_auth else (api_key or self._default_api_key())
+        super().__init__(api_key=api_key,
                          base_url=base_url, model_name=model, stream=stream, return_trace=return_trace,
                          skip_auth=skip_auth, **kw)
         FileHandlerBase.__init__(self)

--- a/tests/basic_tests/Models/test_online_chat_model_runtime.py
+++ b/tests/basic_tests/Models/test_online_chat_model_runtime.py
@@ -71,6 +71,24 @@ def _frame(delta, finish_reason=None):
     })).encode()
 
 
+@pytest.mark.parametrize('api_key', [None, ''])
+def test_openai_skip_auth_does_not_resolve_default_api_key(monkeypatch, api_key):
+    def fail_default_api_key(cls):
+        raise AssertionError('skip_auth must not resolve the default API key')
+
+    monkeypatch.setattr(OpenAIChat, '_default_api_key', classmethod(fail_default_api_key))
+
+    module = OpenAIChat(
+        base_url='http://provider.test/v1/',
+        model='test-model',
+        api_key=api_key,
+        skip_auth=True,
+    )
+
+    assert module._api_key == ''
+    assert module._header == {'Content-Type': 'application/json'}
+
+
 @pytest.mark.parametrize(('raw', 'expected'), [
     ('stop', ModelFinish.STOP),
     ('tool_calls', ModelFinish.TOOL_CALLS),


### PR DESCRIPTION
在配置无鉴权的私有 OpenAI 兼容服务时，Core 会传入空 api_key 并设置 skip_auth=true。但 LazyLLM 的 OpenAIChat 仍通过 api_key or self._default_api_key() 处理 Key，错误地将空 Key 识别为需要读取默认 API Key。Chat 服务的异步请求上下文中无法获取默认配置栈，因此抛出 Current stack is empty，导致模型验证失败，即使目标服务的 /v1/models 接口可以正常访问。
修复后，当 skip_auth=true 时直接使用空 Key，不再读取默认 API Key，也不会携带鉴权信息。