### PR TITLE
feat(rag): resume document processing by capability level

### DIFF
--- a/csrc/cmake/tests.cmake
+++ b/csrc/cmake/tests.cmake
@@ -68,5 +68,5 @@ foreach (test_src ${LAZYLLM_TEST_SOURCES})
             COMMAND_EXPAND_LISTS
         )
     endif ()
-    gtest_discover_tests(${test_name})
+    gtest_discover_tests(${test_name} DISCOVERY_TIMEOUT 30)
 endforeach ()

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -327,7 +327,10 @@ class FunctionCall(ModuleBase):
             remaining_rounds=remaining_rounds,
         )
         compacted_current.extend(self._consume_model_context())
-        locals['chat_history'][self._llm._module_id] = compacted_prior
+        if compacted_prior:
+            locals['chat_history'][self._llm._module_id] = compacted_prior
+        else:
+            locals['chat_history'].pop(self._llm._module_id, None)
         self._notify_history_ready(workspace, current_round, compacted_prior + compacted_current)
         return {'input': compacted_current}
 
@@ -365,7 +368,10 @@ class FunctionCall(ModuleBase):
             workspace=workspace,
             remaining_rounds=remaining_rounds,
         )
-        locals['chat_history'][self._llm._module_id] = compacted_prior
+        if compacted_prior:
+            locals['chat_history'][self._llm._module_id] = compacted_prior
+        else:
+            locals['chat_history'].pop(self._llm._module_id, None)
         self._notify_history_ready(workspace, current_round, compacted_prior)
         return input
 
@@ -467,7 +473,7 @@ class FunctionCall(ModuleBase):
             # the next call (e.g. user says "continue") does not inherit a corrupted history
             # that may contain truncated tool_calls with invalid JSON arguments.
             locals['_lazyllm_agent'].pop('workspace', None)
-            locals['chat_history'][self._llm._module_id] = []
+            locals['chat_history'].pop(self._llm._module_id, None)
             raise
 
         # If the model decides not to call any tools, the result is a string. For debugging and subsequent tasks,
@@ -478,7 +484,7 @@ class FunctionCall(ModuleBase):
             locals['_lazyllm_agent']['completed'] = workspace.pop(
                 'tool_call_trace', locals['_lazyllm_agent'].get('completed', []))
             locals['_lazyllm_agent']['history'] = workspace.pop('history', [])
-            locals['chat_history'][self._llm._module_id] = []
+            locals['chat_history'].pop(self._llm._module_id, None)
         return result
 
 @deprecated('ReactAgent')

--- a/lazyllm/tools/agent/functionCall.py
+++ b/lazyllm/tools/agent/functionCall.py
@@ -326,6 +326,7 @@ class FunctionCall(ModuleBase):
             workspace=workspace,
             remaining_rounds=remaining_rounds,
         )
+        compacted_current.extend(self._consume_model_context())
         locals['chat_history'][self._llm._module_id] = compacted_prior
         self._notify_history_ready(workspace, current_round, compacted_prior + compacted_current)
         return {'input': compacted_current}

--- a/lazyllm/tools/agent/reactAgent.py
+++ b/lazyllm/tools/agent/reactAgent.py
@@ -231,8 +231,10 @@ class ReactAgent(LazyLLMAgentBase):
                         f'[ReactAgent] [FORCE_SUMMARY_COMPLETED] sid={lazyllm_globals._sid} workspace_retained=True '
                         f'history_messages={len(workspace.get("history") or [])}'
                     )
-                    if self._fc is not None: locals['chat_history'][self._fc._llm._module_id] = []
+                    if self._fc is not None:
+                        locals['chat_history'].pop(self._fc._llm._module_id, None)
                     return summary
-        if self._fc is not None: locals['chat_history'][self._fc._llm._module_id] = []
+        if self._fc is not None:
+            locals['chat_history'].pop(self._fc._llm._module_id, None)
         raise ValueError(f'After retrying {self._max_retries} times, the react agent still failes to call '
                          f'successfully.')

--- a/lazyllm/tools/agent/toolsManager.py
+++ b/lazyllm/tools/agent/toolsManager.py
@@ -1016,7 +1016,9 @@ class ToolManager(ModuleBase):
             return exception_failure(exposed_name, error)
 
     def _prepare_tool_invocations(self, tools, allowed_tool_names=None):
-        tool_calls = self.normalize_tool_calls([tools] if isinstance(tools, dict) else list(tools or []))
+        tool_calls = self.normalize_tool_calls(
+            [tools] if isinstance(tools, dict) or tools is None else list(tools)
+        )
         invocations = []
         for index, tool_call in enumerate(tool_calls):
             function = tool_call.get('function') if isinstance(tool_call, dict) else None

--- a/lazyllm/tools/rag/doc_node.py
+++ b/lazyllm/tools/rag/doc_node.py
@@ -14,6 +14,7 @@ import copy
 import json
 
 _pickle_blacklist = {'_store', '_node_groups'}
+NULL_NODE_META_KEY = '_lazyllm_null_node'
 
 
 class MetadataMode(str, Enum):
@@ -102,6 +103,10 @@ class DocNode(DocNodeCore):
     @property
     def group(self) -> str:
         return self._group
+
+    @property
+    def is_null_node(self) -> bool:
+        return bool(self._metadata.get(NULL_NODE_META_KEY))
 
     @property
     def content(self) -> Union[str, List[Any]]:

--- a/lazyllm/tools/rag/doc_service/base.py
+++ b/lazyllm/tools/rag/doc_service/base.py
@@ -98,11 +98,14 @@ class DocItemsRequest(BaseModel):
     idempotency_key: Optional[str] = None
     llm_config: Optional[Dict[str, Any]] = None
     ocr_config: Optional[Dict[str, Any]] = None
+    processing_level: str = 'indexed'
 
     @model_validator(mode='after')
     def validate_items(self):
         if not self.items:
             raise ValueError('items is required')
+        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
         return self
 
 
@@ -124,6 +127,7 @@ class ReparseRequest(BaseModel):
     #   "reembed"       → rebuild vectors only (skip transform, re-embed existing nodes)
     #   "slice_missing" → fill gaps (slice + embed only groups that have no segments yet)
     strategy: str = 'rebuild'
+    processing_level: str = 'indexed'
 
     @model_validator(mode='after')
     def validate_fields(self):
@@ -135,6 +139,10 @@ class ReparseRequest(BaseModel):
             raise ValueError('ng_names must not be an empty list; omit it to reparse all node groups')
         if self.algo_ids is not None and self.ng_names is not None:
             raise ValueError('algo_ids and ng_names are mutually exclusive; provide at most one.')
+        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
+        if self.strategy == 'reembed' and self.processing_level != 'indexed':
+            raise ValueError('reembed requires indexed processing_level')
         return self
 
 

--- a/lazyllm/tools/rag/doc_service/base.py
+++ b/lazyllm/tools/rag/doc_service/base.py
@@ -104,8 +104,8 @@ class DocItemsRequest(BaseModel):
     def validate_items(self):
         if not self.items:
             raise ValueError('items is required')
-        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
-            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
+        if self.processing_level not in ('parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be parsed, chunked, or indexed')
         return self
 
 
@@ -139,8 +139,8 @@ class ReparseRequest(BaseModel):
             raise ValueError('ng_names must not be an empty list; omit it to reparse all node groups')
         if self.algo_ids is not None and self.ng_names is not None:
             raise ValueError('algo_ids and ng_names are mutually exclusive; provide at most one.')
-        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
-            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
+        if self.processing_level not in ('parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be parsed, chunked, or indexed')
         if self.strategy == 'reembed' and self.processing_level != 'indexed':
             raise ValueError('reembed requires indexed processing_level')
         return self

--- a/lazyllm/tools/rag/doc_service/doc_manager.py
+++ b/lazyllm/tools/rag/doc_service/doc_manager.py
@@ -759,7 +759,7 @@ class DocManager:
                             node_group_ids_to_delete: Optional[List[str]] = None,
                             llm_config: Optional[Dict[str, Any]] = None,
                             ocr_config: Optional[Dict[str, Any]] = None,
-                            strategy: str = 'rebuild'):
+                            strategy: str = 'rebuild', processing_level: str = 'indexed'):
         if task_type in (TaskType.DOC_ADD, TaskType.DOC_REPARSE, TaskType.DOC_TRANSFER):
             if not file_path:
                 raise RuntimeError(f'file_path is required for task_type {task_type.value}')
@@ -768,7 +768,8 @@ class DocManager:
                 ng_names=ng_names, extractor_names=extractor_names,
                 task_type=task_type.value,
                 callback_url=self._callback_url, transfer_params=transfer_params,
-                llm_config=llm_config, ocr_config=ocr_config, strategy=strategy)
+                llm_config=llm_config, ocr_config=ocr_config, strategy=strategy,
+                processing_level=processing_level)
         elif task_type == TaskType.DOC_UPDATE_META:
             task_resp = self._parser_client.update_meta(
                 task_id, kb_id, doc_id, metadata, file_path, callback_url=self._callback_url)
@@ -791,7 +792,7 @@ class DocManager:
                       extra_message: Optional[Dict[str, Any]] = None, parser_doc_id: Optional[str] = None,
                       llm_config: Optional[Dict[str, Any]] = None,
                       ocr_config: Optional[Dict[str, Any]] = None,
-                      strategy: str = 'rebuild'):
+                      strategy: str = 'rebuild', processing_level: str = 'indexed'):
         algo_ids = algo_ids or []
         algo_id = algo_ids[0] if algo_ids else None
         task_id = str(uuid4())
@@ -830,7 +831,8 @@ class DocManager:
                 file_path=file_path, metadata=metadata,
                 parser_kb_id=parser_kb_id, transfer_params=transfer_params,
                 node_group_ids_to_delete=exclusive_ng_ids,
-                llm_config=llm_config, ocr_config=ocr_config, strategy=strategy)
+                llm_config=llm_config, ocr_config=ocr_config, strategy=strategy,
+                processing_level=processing_level)
         except Exception as exc:
             finished_at = datetime.now()
             error_msg = str(exc)
@@ -993,7 +995,8 @@ class DocManager:
                     doc_id, request.kb_id, TaskType.DOC_ADD, algo_ids=algo_ids,
                     idempotency_key=request.idempotency_key, file_path=file_path, metadata=metadata,
                     llm_config=getattr(request, 'llm_config', None),
-                    ocr_config=getattr(request, 'ocr_config', None))
+                    ocr_config=getattr(request, 'ocr_config', None),
+                    processing_level=getattr(request, 'processing_level', 'indexed'))
             except Exception as exc:
                 snapshot = self._get_parse_snapshot(doc_id, request.kb_id) or {}
                 doc = self._get_doc(doc_id) or doc
@@ -1058,6 +1061,7 @@ class DocManager:
                 llm_config=request.llm_config,
                 ocr_config=request.ocr_config,
                 strategy=request.strategy,
+                processing_level=request.processing_level,
             )
             task_ids.append(task_id)
         LOG.info(f'[reparse] kb={request.kb_id!r} doc_ids={request.doc_ids!r} '

--- a/lazyllm/tools/rag/doc_service/parser_client.py
+++ b/lazyllm/tools/rag/doc_service/parser_client.py
@@ -36,7 +36,7 @@ class ParserClient:
                 callback_url: Optional[str] = None, transfer_params: Optional[Dict[str, Any]] = None,
                 llm_config: Optional[Dict[str, Any]] = None,
                 ocr_config: Optional[Dict[str, Any]] = None,
-                strategy: str = 'rebuild'):
+                strategy: str = 'rebuild', processing_level: str = 'indexed'):
         req = ParsingAddDocRequest(
             task_id=task_id,
             ng_names=ng_names,
@@ -48,6 +48,7 @@ class ParserClient:
             llm_config=llm_config,
             ocr_config=ocr_config,
             strategy=strategy,
+            processing_level=processing_level,
             file_infos=[ParsingFileInfo(
                 file_path=file_path,
                 doc_id=doc_id,

--- a/lazyllm/tools/rag/parsing_service/base.py
+++ b/lazyllm/tools/rag/parsing_service/base.py
@@ -67,8 +67,8 @@ class AddDocRequest(BaseModel):
 
     @model_validator(mode='after')
     def _validate_processing_level(self):
-        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
-            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
+        if self.processing_level not in ('parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be parsed, chunked, or indexed')
         if self.strategy == 'reembed' and self.processing_level != 'indexed':
             raise ValueError('reembed requires indexed processing_level')
         return self

--- a/lazyllm/tools/rag/parsing_service/base.py
+++ b/lazyllm/tools/rag/parsing_service/base.py
@@ -66,7 +66,7 @@ class AddDocRequest(BaseModel):
         return data
 
     @model_validator(mode='after')
-    def validate_processing_level(self):
+    def _validate_processing_level(self):
         if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
             raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
         if self.strategy == 'reembed' and self.processing_level != 'indexed':

--- a/lazyllm/tools/rag/parsing_service/base.py
+++ b/lazyllm/tools/rag/parsing_service/base.py
@@ -51,6 +51,8 @@ class AddDocRequest(BaseModel):
     # per-request model config injected by backend (e.g. embed_main, llm).
     llm_config: Optional[Dict[str, Any]] = None
     ocr_config: Optional[Dict[str, Any]] = None
+    # Maximum materialization stage requested by the owning knowledge base.
+    processing_level: str = 'indexed'
     # NOTE: (db_info, feedback_url) is deprecated, will be removed in the future
     db_info: EmptyDBInfo = None
     feedback_url: Optional[str] = None
@@ -62,6 +64,14 @@ class AddDocRequest(BaseModel):
             data = dict(data)
             data['db_info'] = None
         return data
+
+    @model_validator(mode='after')
+    def validate_processing_level(self):
+        if self.processing_level not in ('stored', 'parsed', 'chunked', 'indexed'):
+            raise ValueError('processing_level must be stored, parsed, chunked, or indexed')
+        if self.strategy == 'reembed' and self.processing_level != 'indexed':
+            raise ValueError('reembed requires indexed processing_level')
+        return self
 
 
 class UpdateMetaRequest(BaseModel):

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -104,7 +104,8 @@ class _Processor:
                 target_doc_ids: Optional[List[str]] = None,
                 preloaded_root_nodes: Optional[Dict[str, List[DocNode]]] = None,
                 skip_ng_ids: Optional[set] = None,
-                extractor_names: Optional[List[str]] = None):
+                extractor_names: Optional[List[str]] = None,
+                processing_level: str = 'indexed'):
         ids = ids or []
         try:
             if not input_files: return
@@ -144,7 +145,7 @@ class _Processor:
             schema_errors: List[Exception] = []
             # run schema extraction in parallel for each extractor
             active_extractors = {}
-            if not transfer_mode and self._schema_extractors:
+            if not transfer_mode and processing_level not in ('stored', 'parsed') and self._schema_extractors:
                 names = extractor_names if extractor_names else list(self._schema_extractors.keys())
                 for ename in names:
                     ext = self._schema_extractors.get(ename)
@@ -164,7 +165,18 @@ class _Processor:
 
             store_start = time.time()
             if transfer_mode is None:
+                if processing_level in ('stored', 'parsed'):
+                    for nodes in root_nodes.values():
+                        if nodes:
+                            self._store.update_nodes(
+                                self._set_nodes_number(nodes),
+                                skip_embed_groups=set(node_groups) | set(root_nodes),
+                            )
+                    return
                 skip_embed = {g for g, cfg in node_groups.items() if cfg.get('lazy_mode') in ('embed', 'all')}
+                if processing_level == 'chunked':
+                    skip_embed.update(node_groups)
+                    skip_embed.update(root_nodes)
                 # Groups with lazy_mode='all' are deferred to activate_group(), so we
                 # skip their creation here.  Include them in skip_ng_ids and pass the
                 # *full* node_groups to _create_nodes_recursive — this keeps the
@@ -176,7 +188,8 @@ class _Processor:
                     if not v: continue
                     self._store.update_nodes(self._set_nodes_number(v), skip_embed_groups=skip_embed or None)
                     self._create_nodes_recursive(v, k, node_groups=node_groups,
-                                                 skip_ng_ids=all_skip_ids)
+                                                 skip_ng_ids=all_skip_ids,
+                                                 skip_embedding=processing_level == 'chunked')
             else:
                 self._store.update_nodes(root_nodes, copy=True)
                 self._copy_segments_recursive(ids=ids, kb_id=kb_id, target_kb_id=target_kb_id,
@@ -197,9 +210,9 @@ class _Processor:
             LOG.info(f'[_Processor - add_doc] Add documents done! files:{input_files}, '
                      f'Total Time: {add_time}s, Data Loading Time: {load_time}s, Store Time: {store_time}s')
         except Exception as e:
-            cleanup_doc_ids = ids if transfer_mode is None else (target_doc_ids or [])
-            cleanup_kb_id = kb_id if transfer_mode is None else target_kb_id
-            self._cleanup_failed_add(cleanup_doc_ids, cleanup_kb_id, clear_schema=transfer_mode is None)
+            # Keep successfully materialized upstream stages. A retry can then
+            # continue from the missing node groups instead of discarding parse
+            # and chunk work that is already durable.
             LOG.error(f'Add documents failed: {e}, {traceback.format_exc()}')
             raise e
 
@@ -243,15 +256,20 @@ class _Processor:
         return self._dep_graph_cache[key]
 
     def _create_nodes_recursive(self, p_nodes: List[DocNode], p_name: str,
-                                node_groups: Dict[str, Dict], skip_ng_ids: Optional[set] = None):
+                                node_groups: Dict[str, Dict], skip_ng_ids: Optional[set] = None,
+                                skip_embedding: bool = False):
         graph = self._get_dependency_graph(node_groups)
         for group_name in graph.topological_order:
             group = node_groups.get(group_name)
             if group['parent'] != p_name: continue
             ref_path = graph.get_shortest_path(group['parent'], group.get('ref')) if group.get('ref') else []
             nodes = self._create_nodes_impl(p_nodes, group_name, node_groups,
-                                            ref_path=ref_path, skip_ng_ids=skip_ng_ids)
-            if nodes: self._create_nodes_recursive(nodes, group_name, node_groups, skip_ng_ids=skip_ng_ids)
+                                            ref_path=ref_path, skip_ng_ids=skip_ng_ids,
+                                            skip_embedding=skip_embedding)
+            if nodes:
+                self._create_nodes_recursive(nodes, group_name, node_groups,
+                                             skip_ng_ids=skip_ng_ids,
+                                             skip_embedding=skip_embedding)
 
     def _clone_node_for_transfer(
         self, node: DocNode, target_kb_id: str, target_doc_id: str, metadata: Dict[str, Any]
@@ -310,7 +328,8 @@ class _Processor:
                                                   skip_ng_ids=skip_ng_ids)
 
     def _create_nodes_impl(self, p_nodes, group_name, node_groups: Dict[str, Dict],
-                           ref_path=None, skip_ng_ids: Optional[set] = None):
+                           ref_path=None, skip_ng_ids: Optional[set] = None,
+                           skip_embedding: bool = False):
         # NOTE transform.batch_forward will set children for p_nodes, but when calling
         # transform.batch_forward, p_nodes has been upsert in the store.
         doc_ids = list({n.global_metadata.get(RAG_DOC_ID) for n in p_nodes if n.global_metadata.get(RAG_DOC_ID)})
@@ -325,6 +344,8 @@ class _Processor:
         transform = AdaptiveTransform(t) if isinstance(t, list) or t.pattern else make_transform(t, group_name)
         nodes = transform.batch_forward(p_nodes, group_name, ref_path=ref_path)
         skip_embed = {g for g, cfg in node_groups.items() if cfg.get('lazy_mode') in ('embed', 'all')}
+        if skip_embedding:
+            skip_embed.add(group_name)
         self._store.update_nodes(self._set_nodes_number(nodes), skip_embed_groups=skip_embed or None)
         return nodes
 
@@ -338,12 +359,14 @@ class _Processor:
 
     def reparse(self, group_name: str, node_groups: Dict[str, Dict],
                 uids: Optional[List[str]] = None, doc_ids: Optional[List[str]] = None,
-                kb_id: Optional[str] = None, strategy: str = 'rebuild', **kwargs):
+                kb_id: Optional[str] = None, strategy: str = 'rebuild',
+                processing_level: str = 'indexed', **kwargs):
         if strategy == 'reembed':
             self._reembed_group(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id)
         elif doc_ids:
             self._reparse_docs(group_name=group_name, node_groups=node_groups,
-                               doc_ids=doc_ids, kb_id=kb_id, **kwargs)
+                               doc_ids=doc_ids, kb_id=kb_id,
+                               processing_level=processing_level, **kwargs)
         else:
             self._get_or_create_nodes(group_name, node_groups, uids)
 
@@ -372,7 +395,8 @@ class _Processor:
 
     def _reparse_docs(self, group_name: Optional[str], node_groups: Dict[str, Dict],
                       doc_ids: List[str], doc_paths: List[str], metadatas: List[Dict],
-                      kb_id: str = None, reader: Optional[DirectoryReader] = None):
+                      kb_id: str = None, reader: Optional[DirectoryReader] = None,
+                      processing_level: str = 'indexed'):
         doc_ids, metadatas, kb_id = self._prepare_doc_inputs(doc_paths, doc_ids, metadatas, kb_id)
         if group_name is None:
             preloaded_root_nodes = reader.load_data(doc_paths, metadatas, split_nodes_by_type=True)
@@ -388,7 +412,8 @@ class _Processor:
                 raise Exception(f'Failed to remove nodes for docs {doc_ids} from store')
             self.add_doc(input_files=doc_paths, ids=doc_ids, metadatas=metadatas, kb_id=kb_id,
                          node_groups=node_groups, reader=reader,
-                         preloaded_root_nodes=preloaded_root_nodes)
+                         preloaded_root_nodes=preloaded_root_nodes,
+                         processing_level=processing_level)
             # add_doc skips lazy_mode='all' groups (e.g. doc-summary) —
             # recreate them now so full reparse covers every activated group.
             for g_name, g_cfg in node_groups.items():
@@ -396,7 +421,8 @@ class _Processor:
                     LOG.info(f'[reparse] recreating lazy group {g_name!r} for docs {doc_ids!r}')
                     self._reparse_docs(group_name=g_name, node_groups=node_groups,
                                        doc_ids=doc_ids, doc_paths=doc_paths,
-                                       metadatas=metadatas, kb_id=kb_id, reader=reader)
+                                       metadatas=metadatas, kb_id=kb_id, reader=reader,
+                                       processing_level=processing_level)
             LOG.info(f'Reparse docs {doc_ids} from store done')
         else:
             LOG.info(f'[reparse] docs group={group_name!r} doc_ids={doc_ids!r} kb_id={kb_id!r}')
@@ -409,13 +435,16 @@ class _Processor:
                     f'docs {doc_ids}, falling back to full reparse from source.')
                 self._reparse_docs(group_name=None, node_groups=node_groups,
                                    doc_ids=doc_ids, doc_paths=doc_paths,
-                                   metadatas=metadatas, kb_id=kb_id, reader=reader)
+                                   metadatas=metadatas, kb_id=kb_id, reader=reader,
+                                   processing_level=processing_level)
                 return
             self._reparse_group_recursive(p_nodes=p_nodes, cur_name=group_name,
-                                          node_groups=node_groups, doc_ids=doc_ids, kb_id=kb_id)
+                                          node_groups=node_groups, doc_ids=doc_ids, kb_id=kb_id,
+                                          skip_embedding=processing_level == 'chunked')
 
     def _reparse_group_recursive(self, p_nodes: List[DocNode], cur_name: str,
-                                 node_groups: Dict[str, Dict], doc_ids: List[str], kb_id: str = None):
+                                 node_groups: Dict[str, Dict], doc_ids: List[str], kb_id: str = None,
+                                 skip_embedding: bool = False):
         kb_id = p_nodes[0].global_metadata.get(RAG_KB_ID, None) if kb_id is None else kb_id
         self._store.remove_nodes(group=cur_name, kb_id=kb_id, doc_ids=doc_ids)
 
@@ -429,7 +458,8 @@ class _Processor:
         if not removed_flag:
             raise Exception(f'Failed to remove nodes for docs {doc_ids} group {cur_name} from store')
         try:
-            nodes = self._create_nodes_impl(p_nodes, cur_name, node_groups)
+            nodes = self._create_nodes_impl(p_nodes, cur_name, node_groups,
+                                            skip_embedding=skip_embedding)
         except Exception:
             raise
 
@@ -442,7 +472,8 @@ class _Processor:
                 if group.get('lazy_mode') == 'all':
                     continue
                 self._reparse_group_recursive(p_nodes=nodes, cur_name=group_name,
-                                              node_groups=node_groups, doc_ids=doc_ids, kb_id=kb_id)
+                                              node_groups=node_groups, doc_ids=doc_ids, kb_id=kb_id,
+                                              skip_embedding=skip_embedding)
 
     def update_doc_meta(self, doc_id: str, metadata: dict, kb_id: str = None):
         try:

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -214,6 +214,8 @@ class _Processor:
             # Keep successfully materialized upstream stages. A retry can then
             # continue from the missing node groups instead of discarding parse
             # and chunk work that is already durable.
+            if transfer_mode is not None:
+                self._cleanup_failed_add(target_doc_ids or [], target_kb_id, clear_schema=False)
             LOG.error(f'Add documents failed: {e}, {traceback.format_exc()}')
             raise e
 
@@ -237,8 +239,8 @@ class _Processor:
         self._thread_pool.shutdown(wait=True)
         self._thread_pool = None
 
-    def _set_nodes_number(self, nodes: List[DocNode]) -> List[DocNode]:
-        doc_group_number = {}
+    def _set_nodes_number(self, nodes: List[DocNode], doc_group_number: Optional[Dict] = None) -> List[DocNode]:
+        doc_group_number = doc_group_number if doc_group_number is not None else {}
         for node in nodes:
             if node.is_null_node:
                 node.metadata['lazyllm_store_num'] = 0
@@ -366,6 +368,7 @@ class _Processor:
         if skip_embedding:
             skip_embed.add(group_name)
         nodes, errors = [], []
+        doc_group_number = {}
         signature = ng_cfg.get('signature', '')
         for parent in p_nodes:
             children = []
@@ -397,7 +400,7 @@ class _Processor:
                         global_metadata=dict(parent.global_metadata),
                     )]
                 self._store.update_nodes(
-                    self._set_nodes_number(children),
+                    self._set_nodes_number(children, doc_group_number),
                     skip_embed_groups=(skip_embed | {group_name}) if children[0].is_null_node else (skip_embed or None),
                 )
                 nodes.extend(node for node in children if not node.is_null_node)

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -1,3 +1,4 @@
+import hashlib
 import time
 import traceback
 from typing import Any, Dict, List, Optional
@@ -8,7 +9,7 @@ from functools import cached_property
 from lazyllm import LOG
 
 from ..data_loaders import DirectoryReader
-from ..doc_node import DocNode
+from ..doc_node import DocNode, NULL_NODE_META_KEY
 from ..global_metadata import RAG_DOC_ID, RAG_DOC_PATH, RAG_KB_ID
 from ..store import LAZY_IMAGE_GROUP, LAZY_ROOT_NAME
 from ..store.document_store import _DocumentStore
@@ -239,6 +240,9 @@ class _Processor:
     def _set_nodes_number(self, nodes: List[DocNode]) -> List[DocNode]:
         doc_group_number = {}
         for node in nodes:
+            if node.is_null_node:
+                node.metadata['lazyllm_store_num'] = 0
+                continue
             doc_id = node.global_metadata.get(RAG_DOC_ID)
             group_name = node.group
             if doc_id not in doc_group_number:
@@ -259,17 +263,30 @@ class _Processor:
                                 node_groups: Dict[str, Dict], skip_ng_ids: Optional[set] = None,
                                 skip_embedding: bool = False):
         graph = self._get_dependency_graph(node_groups)
+        errors = []
         for group_name in graph.topological_order:
             group = node_groups.get(group_name)
             if group['parent'] != p_name: continue
             ref_path = graph.get_shortest_path(group['parent'], group.get('ref')) if group.get('ref') else []
-            nodes = self._create_nodes_impl(p_nodes, group_name, node_groups,
-                                            ref_path=ref_path, skip_ng_ids=skip_ng_ids,
-                                            skip_embedding=skip_embedding)
+            error = None
+            try:
+                nodes = self._create_nodes_impl(p_nodes, group_name, node_groups,
+                                                ref_path=ref_path, skip_ng_ids=skip_ng_ids,
+                                                skip_embedding=skip_embedding)
+            except Exception as exc:
+                nodes = getattr(exc, '_lazyllm_successful_nodes', [])
+                error = exc
             if nodes:
-                self._create_nodes_recursive(nodes, group_name, node_groups,
-                                             skip_ng_ids=skip_ng_ids,
-                                             skip_embedding=skip_embedding)
+                try:
+                    self._create_nodes_recursive(nodes, group_name, node_groups,
+                                                 skip_ng_ids=skip_ng_ids,
+                                                 skip_embedding=skip_embedding)
+                except Exception as exc:
+                    errors.append(exc)
+            if error:
+                errors.append(error)
+        if errors:
+            raise errors[0]
 
     def _clone_node_for_transfer(
         self, node: DocNode, target_kb_id: str, target_doc_id: str, metadata: Dict[str, Any]
@@ -329,7 +346,7 @@ class _Processor:
 
     def _create_nodes_impl(self, p_nodes, group_name, node_groups: Dict[str, Dict],
                            ref_path=None, skip_ng_ids: Optional[set] = None,
-                           skip_embedding: bool = False):
+                           skip_embedding: bool = False, only_missing: bool = False):
         # NOTE transform.batch_forward will set children for p_nodes, but when calling
         # transform.batch_forward, p_nodes has been upsert in the store.
         doc_ids = list({n.global_metadata.get(RAG_DOC_ID) for n in p_nodes if n.global_metadata.get(RAG_DOC_ID)})
@@ -340,13 +357,58 @@ class _Processor:
             if not doc_ids:
                 return []
             return self._store.get_nodes(doc_ids=doc_ids, group=group_name, kb_id=kb_id)
+        p_nodes = [node for node in p_nodes if not node.is_null_node]
+        if not p_nodes:
+            return []
         t = node_groups[group_name]['transform']
         transform = AdaptiveTransform(t) if isinstance(t, list) or t.pattern else make_transform(t, group_name)
-        nodes = transform.batch_forward(p_nodes, group_name, ref_path=ref_path)
         skip_embed = {g for g, cfg in node_groups.items() if cfg.get('lazy_mode') in ('embed', 'all')}
         if skip_embedding:
             skip_embed.add(group_name)
-        self._store.update_nodes(self._set_nodes_number(nodes), skip_embed_groups=skip_embed or None)
+        nodes, errors = [], []
+        signature = ng_cfg.get('signature', '')
+        for parent in p_nodes:
+            children = []
+            try:
+                if only_missing:
+                    existing = self._store.get_nodes(
+                        group=group_name, kb_id=kb_id, doc_ids=doc_ids,
+                        parent=[parent.uid], include_null=True)
+                    if any(not child.is_null_node or
+                           child.metadata.get('_transform_signature') == signature for child in existing):
+                        nodes.extend(child for child in existing if not child.is_null_node)
+                        continue
+                if ref_path:
+                    ref_nodes = [node for node in transform._get_ref_nodes(parent, ref_path)
+                                 if not node.is_null_node]
+                    if not ref_nodes:
+                        continue
+                    stored_refs = self._store.get_nodes(
+                        uids=[node.uid for node in ref_nodes], group=ref_path[-1], kb_id=kb_id)
+                    if len({node.uid for node in stored_refs}) != len({node.uid for node in ref_nodes}):
+                        continue
+                children = transform.batch_forward([parent], group_name, ref_path=ref_path)
+                if not children:
+                    digest = hashlib.sha1(
+                        f'{kb_id}:{parent.uid}:{group_name}:{signature}:null'.encode()).hexdigest()
+                    children = [DocNode(
+                        uid=f'null-{digest}', content='', group=group_name, parent=parent,
+                        metadata={NULL_NODE_META_KEY: True, '_transform_signature': signature},
+                        global_metadata=dict(parent.global_metadata),
+                    )]
+                self._store.update_nodes(
+                    self._set_nodes_number(children),
+                    skip_embed_groups=(skip_embed | {group_name}) if children[0].is_null_node else (skip_embed or None),
+                )
+                nodes.extend(node for node in children if not node.is_null_node)
+            except Exception as exc:
+                if getattr(exc, '_lazyllm_segments_persisted', False):
+                    nodes.extend(node for node in children if not node.is_null_node)
+                LOG.error(f'Failed to create node group {group_name!r} for parent {parent.uid!r}: {exc}')
+                errors.append(exc)
+        if errors:
+            setattr(errors[0], '_lazyllm_successful_nodes', nodes)
+            raise errors[0]
         return nodes
 
     def _get_or_create_nodes(self, group_name, node_groups: Dict[str, Dict],
@@ -363,12 +425,43 @@ class _Processor:
                 processing_level: str = 'indexed', **kwargs):
         if strategy == 'reembed':
             self._reembed_group(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id)
+        elif strategy == 'slice_missing':
+            self._fill_missing_docs(group_name, node_groups, doc_ids=doc_ids, kb_id=kb_id,
+                                    processing_level=processing_level)
         elif doc_ids:
             self._reparse_docs(group_name=group_name, node_groups=node_groups,
                                doc_ids=doc_ids, kb_id=kb_id,
                                processing_level=processing_level, **kwargs)
         else:
             self._get_or_create_nodes(group_name, node_groups, uids)
+
+    def _fill_missing_docs(self, group_name: str, node_groups: Dict[str, Dict],
+                           doc_ids: List[str], kb_id: Optional[str], processing_level: str):
+        parent_group = node_groups[group_name]['parent']
+        parents = self._store.get_nodes(group=parent_group, doc_ids=doc_ids, kb_id=kb_id)
+        if not parents:
+            return
+        graph = self._get_dependency_graph(node_groups)
+        ref = node_groups[group_name].get('ref')
+        ref_path = graph.get_shortest_path(parent_group, ref) if ref else []
+        error = None
+        try:
+            self._create_nodes_impl(
+                parents, group_name, node_groups, ref_path=ref_path,
+                skip_embedding=processing_level == 'chunked', only_missing=True)
+        except Exception as exc:
+            error = exc
+        current = self._store.get_nodes(group=group_name, doc_ids=doc_ids, kb_id=kb_id)
+        if not current:
+            if error:
+                raise error
+            return
+        for child_name in self._store.activated_groups():
+            cfg = node_groups.get(child_name, {})
+            if cfg.get('parent') == group_name and cfg.get('lazy_mode') != 'all':
+                self._fill_missing_docs(child_name, node_groups, doc_ids, kb_id, processing_level)
+        if error:
+            raise error
 
     def _reembed_group(self, group_name: str, node_groups: Dict[str, Dict],
                        doc_ids: Optional[List[str]] = None, kb_id: Optional[str] = None):

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -344,7 +344,7 @@ class _Processor:
                                                   p_name=group_name, node_groups=node_groups,
                                                   skip_ng_ids=skip_ng_ids)
 
-    def _create_nodes_impl(self, p_nodes, group_name, node_groups: Dict[str, Dict],
+    def _create_nodes_impl(self, p_nodes, group_name, node_groups: Dict[str, Dict],  # noqa: C901
                            ref_path=None, skip_ng_ids: Optional[set] = None,
                            skip_embedding: bool = False, only_missing: bool = False):
         # NOTE transform.batch_forward will set children for p_nodes, but when calling
@@ -374,8 +374,8 @@ class _Processor:
                     existing = self._store.get_nodes(
                         group=group_name, kb_id=kb_id, doc_ids=doc_ids,
                         parent=[parent.uid], include_null=True)
-                    if any(not child.is_null_node or
-                           child.metadata.get('_transform_signature') == signature for child in existing):
+                    if any((not child.is_null_node or child.metadata.get('_transform_signature') == signature)
+                           for child in existing):
                         nodes.extend(child for child in existing if not child.is_null_node)
                         continue
                 if ref_path:
@@ -407,7 +407,7 @@ class _Processor:
                 LOG.error(f'Failed to create node group {group_name!r} for parent {parent.uid!r}: {exc}')
                 errors.append(exc)
         if errors:
-            setattr(errors[0], '_lazyllm_successful_nodes', nodes)
+            errors[0]._lazyllm_successful_nodes = nodes
             raise errors[0]
         return nodes
 

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -146,7 +146,7 @@ class _Processor:
             schema_errors: List[Exception] = []
             # run schema extraction in parallel for each extractor
             active_extractors = {}
-            if not transfer_mode and processing_level not in ('stored', 'parsed') and self._schema_extractors:
+            if not transfer_mode and processing_level != 'parsed' and self._schema_extractors:
                 names = extractor_names if extractor_names else list(self._schema_extractors.keys())
                 for ename in names:
                     ext = self._schema_extractors.get(ename)
@@ -166,7 +166,7 @@ class _Processor:
 
             store_start = time.time()
             if transfer_mode is None:
-                if processing_level in ('stored', 'parsed'):
+                if processing_level == 'parsed':
                     for nodes in root_nodes.values():
                         if nodes:
                             self._store.update_nodes(

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -454,6 +454,7 @@ class _Processor:
                 skip_embedding=processing_level == 'chunked', only_missing=True)
         except Exception as exc:
             error = exc
+        self._renumber_group_by_tree(group_name, parent_group, doc_ids, kb_id)
         current = self._store.get_nodes(group=group_name, doc_ids=doc_ids, kb_id=kb_id)
         if not current:
             if error:
@@ -470,6 +471,43 @@ class _Processor:
                 self._fill_missing_docs(child_name, node_groups, doc_ids, kb_id, processing_level)
         if error:
             raise error
+
+    def _renumber_group_by_tree(self, group_name: str, parent_group: str,
+                                doc_ids: List[str], kb_id: Optional[str]) -> None:
+        parents = self._store.get_nodes(
+            group=parent_group, doc_ids=doc_ids, kb_id=kb_id, sort_by_number=True)
+        children = self._store.get_nodes(
+            group=group_name, doc_ids=doc_ids, kb_id=kb_id,
+            sort_by_number=True, include_null=True)
+        if not children:
+            return
+
+        parent_order = {}
+        for doc_id in doc_ids:
+            doc_parents = [p for p in parents if p.global_metadata.get(RAG_DOC_ID) == doc_id]
+            doc_parents.sort(key=lambda p: (p.number, p.uid))
+            parent_order[doc_id] = {parent.uid: i for i, parent in enumerate(doc_parents)}
+
+        def parent_uid(node: DocNode) -> str:
+            return node._parent.uid if isinstance(node._parent, DocNode) else node._parent
+
+        changed = []
+        for doc_id in doc_ids:
+            doc_children = [c for c in children if c.global_metadata.get(RAG_DOC_ID) == doc_id]
+            order = parent_order.get(doc_id, {})
+            doc_children.sort(key=lambda c: (order.get(parent_uid(c), len(order)), c.number, c.uid))
+            number = 1
+            for child in doc_children:
+                expected = 0 if child.is_null_node else number
+                if child.number != expected:
+                    child.number = expected
+                    changed.append(child)
+                if not child.is_null_node:
+                    number += 1
+        if changed:
+            # Renumbering changes metadata only; copy mode preserves existing
+            # embeddings and never invokes the embedding model again.
+            self._store.update_nodes(changed, copy=True)
 
     def _reembed_group(self, group_name: str, node_groups: Dict[str, Dict],
                        doc_ids: Optional[List[str]] = None, kb_id: Optional[str] = None):

--- a/lazyllm/tools/rag/parsing_service/impl.py
+++ b/lazyllm/tools/rag/parsing_service/impl.py
@@ -456,6 +456,11 @@ class _Processor:
             if error:
                 raise error
             return
+        if processing_level == 'indexed':
+            try:
+                self._store.update_nodes(current)
+            except Exception as exc:
+                error = error or exc
         for child_name in self._store.activated_groups():
             cfg = node_groups.get(child_name, {})
             if cfg.get('parent') == group_name and cfg.get('lazy_mode') != 'all':

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -436,6 +436,7 @@ class DocumentProcessorWorker(ModuleBase):
                            extractor_names: Optional[List[str]] = None):
             file_infos = payload.get('file_infos')
             kb_id = payload.get('kb_id', None)
+            processing_level = payload.get('processing_level', 'indexed')
             input_files = []
             ids = []
             metadatas = []
@@ -446,6 +447,8 @@ class DocumentProcessorWorker(ModuleBase):
 
             ng_ids = [ng_id for name, ng_id in name_to_id.items()
                       if name not in (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP)]
+            if processing_level in ('stored', 'parsed'):
+                ng_ids = []
             if kb_id and ng_ids:
                 skip_ng_ids, exec_ng_ids = self._wait_and_decide_ng(ids, ng_ids, kb_id)
                 if not exec_ng_ids:
@@ -458,7 +461,8 @@ class DocumentProcessorWorker(ModuleBase):
             try:
                 processor.add_doc(input_files=input_files, ids=ids, metadatas=metadatas, kb_id=kb_id,
                                   node_groups=node_groups, reader=reader, skip_ng_ids=skip_ng_ids,
-                                  extractor_names=extractor_names)
+                                  extractor_names=extractor_names,
+                                  processing_level=processing_level)
                 if kb_id and exec_ng_ids:
                     self._write_ng_status_batch(ids, list(exec_ng_ids), kb_id, 'SUCCESS')
             except Exception as e:
@@ -474,6 +478,7 @@ class DocumentProcessorWorker(ModuleBase):
             kb_id = payload.get('kb_id', None)
             ng_names_requested = payload.get('ng_names')  # None means all groups
             strategy = payload.get('strategy', 'rebuild')
+            processing_level = payload.get('processing_level', 'indexed')
             # strategy:
             #   "rebuild"       → full reparse (reslice + reembed all selected groups)
             #   "reembed"       → rebuild vectors (skip slice, reembed existing nodes only)
@@ -488,14 +493,28 @@ class DocumentProcessorWorker(ModuleBase):
                 reparse_metadatas.append(file_info.get('metadata'))
 
             LOG.info(f'{self._log_prefix(task_id)} Execute reparse task: doc_ids={reparse_doc_ids!r}, '
-                     f'ng_names={ng_names_requested!r}, strategy={strategy!r}, kb_id={kb_id!r}')
+                     f'ng_names={ng_names_requested!r}, strategy={strategy!r}, '
+                     f'processing_level={processing_level!r}, kb_id={kb_id!r}')
 
             exec_ng_ids = [ng_id for name, ng_id in name_to_id.items()
                            if name not in (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP)]
+            if processing_level in ('stored', 'parsed'):
+                exec_ng_ids = []
             if kb_id and exec_ng_ids:
                 self._write_ng_status_batch(reparse_doc_ids, exec_ng_ids, kb_id, 'WORKING')
 
             try:
+                if processing_level in ('stored', 'parsed'):
+                    processor.add_doc(
+                        input_files=reparse_files, ids=reparse_doc_ids,
+                        metadatas=reparse_metadatas, kb_id=kb_id,
+                        node_groups=node_groups, reader=reader,
+                        processing_level='parsed',
+                    )
+                    if kb_id and exec_ng_ids:
+                        self._write_ng_status_batch(reparse_doc_ids, exec_ng_ids, kb_id, 'SUCCESS')
+                    return
+
                 # Resolve candidate groups, excluding source groups.
                 source_groups = {LAZY_ROOT_NAME, LAZY_IMAGE_GROUP}
                 if ng_names_requested is None:
@@ -504,11 +523,12 @@ class DocumentProcessorWorker(ModuleBase):
                     candidate_groups = [n for n in ng_names_requested if n in node_groups and n not in source_groups]
 
                 # slice_missing: keep only groups with no segments yet.
-                if strategy == 'slice_missing':
-                    candidate_groups = [
-                        n for n in candidate_groups
-                        if not processor.store.get_nodes(group=n, doc_ids=reparse_doc_ids, kb_id=kb_id)
-                    ]
+                missing_groups = {
+                    n for n in candidate_groups
+                    if not processor.store.get_nodes(group=n, doc_ids=reparse_doc_ids, kb_id=kb_id)
+                }
+                if strategy == 'slice_missing' and processing_level != 'indexed':
+                    candidate_groups = [n for n in candidate_groups if n in missing_groups]
                     if not candidate_groups:
                         LOG.info(f'{self._log_prefix(task_id)} All requested groups already '
                                  'have nodes, nothing to do')
@@ -543,6 +563,8 @@ class DocumentProcessorWorker(ModuleBase):
                     for name in candidate_groups:
                         if strategy == 'reembed':
                             operations.append((name, dict(strategy='reembed')))
+                        elif strategy == 'slice_missing' and name not in missing_groups:
+                            operations.append((name, dict(strategy='reembed')))
                         else:
                             operations.append((name, dict(
                                 doc_paths=reparse_files, metadatas=reparse_metadatas, reader=reader,
@@ -557,6 +579,7 @@ class DocumentProcessorWorker(ModuleBase):
                         node_groups=node_groups,
                         doc_ids=reparse_doc_ids,
                         kb_id=kb_id,
+                        processing_level=processing_level,
                         **extra_kwargs,
                     )
 

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -447,7 +447,7 @@ class DocumentProcessorWorker(ModuleBase):
 
             ng_ids = [ng_id for name, ng_id in name_to_id.items()
                       if name not in (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP)]
-            if processing_level in ('stored', 'parsed'):
+            if processing_level == 'parsed':
                 ng_ids = []
             if kb_id and ng_ids:
                 skip_ng_ids, exec_ng_ids = self._wait_and_decide_ng(ids, ng_ids, kb_id)
@@ -498,13 +498,13 @@ class DocumentProcessorWorker(ModuleBase):
 
             exec_ng_ids = [ng_id for name, ng_id in name_to_id.items()
                            if name not in (LAZY_ROOT_NAME, LAZY_IMAGE_GROUP)]
-            if processing_level in ('stored', 'parsed'):
+            if processing_level == 'parsed':
                 exec_ng_ids = []
             if kb_id and exec_ng_ids:
                 self._write_ng_status_batch(reparse_doc_ids, exec_ng_ids, kb_id, 'WORKING')
 
             try:
-                if processing_level in ('stored', 'parsed'):
+                if processing_level == 'parsed':
                     processor.add_doc(
                         input_files=reparse_files, ids=reparse_doc_ids,
                         metadatas=reparse_metadatas, kb_id=kb_id,

--- a/lazyllm/tools/rag/parsing_service/worker.py
+++ b/lazyllm/tools/rag/parsing_service/worker.py
@@ -522,20 +522,6 @@ class DocumentProcessorWorker(ModuleBase):
                 else:
                     candidate_groups = [n for n in ng_names_requested if n in node_groups and n not in source_groups]
 
-                # slice_missing: keep only groups with no segments yet.
-                missing_groups = {
-                    n for n in candidate_groups
-                    if not processor.store.get_nodes(group=n, doc_ids=reparse_doc_ids, kb_id=kb_id)
-                }
-                if strategy == 'slice_missing' and processing_level != 'indexed':
-                    candidate_groups = [n for n in candidate_groups if n in missing_groups]
-                    if not candidate_groups:
-                        LOG.info(f'{self._log_prefix(task_id)} All requested groups already '
-                                 'have nodes, nothing to do')
-                        if kb_id and exec_ng_ids:
-                            self._write_ng_status_batch(reparse_doc_ids, exec_ng_ids, kb_id, 'SUCCESS')
-                        return
-
                 # Top-most filtering: _reparse_group_recursive / _reembed_group already
                 # recurse into children, so keep only ancestors with no parent in the set.
                 top = []
@@ -563,12 +549,11 @@ class DocumentProcessorWorker(ModuleBase):
                     for name in candidate_groups:
                         if strategy == 'reembed':
                             operations.append((name, dict(strategy='reembed')))
-                        elif strategy == 'slice_missing' and name not in missing_groups:
-                            operations.append((name, dict(strategy='reembed')))
                         else:
-                            operations.append((name, dict(
-                                doc_paths=reparse_files, metadatas=reparse_metadatas, reader=reader,
-                            )))
+                            options = dict(doc_paths=reparse_files, metadatas=reparse_metadatas, reader=reader)
+                            if strategy == 'slice_missing':
+                                options['strategy'] = 'slice_missing'
+                            operations.append((name, options))
 
                 for group_name, extra_kwargs in operations:
                     LOG.info(f'{self._log_prefix(task_id)} [reparse] group={group_name!r} '

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -222,6 +222,16 @@ class _DocumentStore(object):
         if not self.vector_initialized_impl.upsert(collection_name, segments):
             raise RuntimeError(f'[_DocumentStore] Failed to upsert segments for group {group}')
 
+    def _upsert_segment_data(self, group: str, segments: List[dict]) -> None:
+        collection_name = self._gen_collection_name(group)
+        store = self.vector_initialized_impl
+        if isinstance(store, HybridStore):
+            data = [{k: v for k, v in segment.items() if k != 'embedding'} for segment in segments]
+            if not store.segment_store.upsert(collection_name=collection_name, data=data):
+                raise RuntimeError(f'[_DocumentStore] Failed to upsert segment data for group {group}')
+        elif not store.upsert(collection_name, segments):
+            raise RuntimeError(f'[_DocumentStore] Failed to upsert segment data for group {group}')
+
     def update_nodes(self, nodes: List[DocNode], copy: bool = False,
                      skip_embed_groups: Optional[Set[str]] = None):   # noqa: C901
         if not nodes:
@@ -230,14 +240,8 @@ class _DocumentStore(object):
             if self._embed and self.vector_initialized_impl.capability == StoreCapability.SEGMENT:
                 LOG.warning(f'[_DocumentStore] Embed is provided'
                             f' but store {self.vector_initialized_impl} does not support embedding')
-            if self.vector_initialized_impl.need_embedding and not copy:
-                nodes_to_embed = [n for n in nodes if n._group not in skip_embed_groups] \
-                    if skip_embed_groups else nodes
-                if nodes_to_embed:
-                    _t_emb = time.time()
-                    parallel_do_embedding(self._embed, [], nodes_to_embed, self._group_embed_keys)
-                    LOG.info(f'[BENCHMARK] phase=embed elapsed={time.time() - _t_emb:.3f}s '
-                             f'nodes={len(nodes_to_embed)}')
+            nodes_to_embed = [n for n in nodes
+                              if not n.is_null_node and n._group not in (skip_embed_groups or set())]
             group_segments = defaultdict(list)
             for node in nodes:
                 group_segments[node._group].append(self._serialize_node(node))
@@ -248,11 +252,34 @@ class _DocumentStore(object):
                     LOG.warning(f'[_DocumentStore] Group {group} is not active, skip')
                     continue
                 for i in range(0, len(segments), INSERT_BATCH_SIZE):
-                    self._upsert_segments(group, segments[i:i + INSERT_BATCH_SIZE])
+                    upsert = self._upsert_segments if copy else self._upsert_segment_data
+                    upsert(group, segments[i:i + INSERT_BATCH_SIZE])
+            embedding_error = None
+            if self._embed and self.vector_initialized_impl.need_embedding and not copy and nodes_to_embed:
+                _t_emb = time.time()
+                try:
+                    parallel_do_embedding(self._embed, [], nodes_to_embed, self._group_embed_keys)
+                except Exception as exc:
+                    embedding_error = exc
+                embedded_segments = defaultdict(list)
+                for node in nodes_to_embed:
+                    keys = self._group_embed_keys.get(node._group) if self._group_embed_keys else self._embed.keys()
+                    if not keys:
+                        continue
+                    if not node.has_missing_embedding(keys):
+                        embedded_segments[node._group].append(self._serialize_node(node))
+                for group, segments in embedded_segments.items():
+                    for i in range(0, len(segments), INSERT_BATCH_SIZE):
+                        self._upsert_segments(group, segments[i:i + INSERT_BATCH_SIZE])
+                LOG.info(f'[BENCHMARK] phase=embed elapsed={time.time() - _t_emb:.3f}s '
+                         f'nodes={len(nodes_to_embed)}')
             # update indices
             for index in self._indices.values():
-                index.update(nodes)
+                index.update([node for node in nodes if not node.is_null_node])
             LOG.info(f'[BENCHMARK] phase=store elapsed={time.time() - _t_store:.3f}s nodes={len(nodes)}')
+            if embedding_error:
+                setattr(embedding_error, '_lazyllm_segments_persisted', True)
+                raise embedding_error
         except Exception as e:
             LOG.error(f'[_DocumentStore] Failed to update nodes: {e}')
             LOG.error(traceback.format_exc())
@@ -302,16 +329,19 @@ class _DocumentStore(object):
                   group: Optional[str] = None, kb_id: Optional[str] = None,
                   limit: Optional[int] = None, offset: int = 0, return_total: bool = False,
                   numbers: Optional[Set] = None, sort_by_number: bool = False,
-                  **kwargs) -> Union[List[DocNode], Tuple[List[DocNode], int]]:
+                  include_null: bool = False, **kwargs) -> Union[List[DocNode], Tuple[List[DocNode], int]]:
         try:
             result = self.get_segments(uids=uids, doc_ids=doc_ids, group=group,
                                        kb_id=kb_id, numbers=numbers, limit=limit,
                                        offset=offset, return_total=return_total,
-                                       sort_by_number=sort_by_number, **kwargs)
+                                       sort_by_number=sort_by_number, include_null=include_null, **kwargs)
             if return_total:
                 segments, total = result
-                return [self._deserialize_node(segment) for segment in segments], total
-            return [self._deserialize_node(segment) for segment in result]
+                nodes = [self._deserialize_node(segment) for segment in segments]
+                nodes = nodes if include_null else [node for node in nodes if not node.is_null_node]
+                return nodes, total
+            nodes = [self._deserialize_node(segment) for segment in result]
+            return nodes if include_null else [node for node in nodes if not node.is_null_node]
         except Exception as e:
             LOG.error(f'[_DocumentStore] Failed to get nodes: {e}')
             raise
@@ -320,7 +350,7 @@ class _DocumentStore(object):
                      group: Optional[str] = None, kb_id: Optional[str] = None,
                      limit: Optional[int] = None, offset: int = 0, return_total: bool = False,
                      numbers: Optional[Set] = None, sort_by_number: bool = False,
-                     **kwargs) -> Union[List[dict], Tuple[List[dict], int]]:
+                     include_null: bool = False, **kwargs) -> Union[List[dict], Tuple[List[dict], int]]:
         # get a set of segments by uids
         # get the segments of the whole file -- doc ids only
         # get the segments of a certain group for one file -- doc ids and group (kb_id is optional)
@@ -343,14 +373,24 @@ class _DocumentStore(object):
                 )
                 if return_total:
                     segments, total = result if isinstance(result, tuple) else (result, len(result))
+                    if not include_null:
+                        original_len = len(segments)
+                        segments = [segment for segment in segments
+                                    if not segment.get('meta', {}).get('_lazyllm_null_node')]
+                        total -= original_len - len(segments)
                     return segments, total
-                return result[0] if isinstance(result, tuple) else result
+                segments = result[0] if isinstance(result, tuple) else result
+                return segments if include_null else [
+                    segment for segment in segments if not segment.get('meta', {}).get('_lazyllm_null_node')]
             segments = []
             for group in groups:
                 if not self.is_group_active(group):
                     LOG.warning(f'[_DocumentStore] Group {group} is not active, skip')
                     continue
                 segments.extend(self.seg_impl.get(self._gen_collection_name(group), criteria, **kwargs))
+            if not include_null:
+                segments = [segment for segment in segments
+                            if not segment.get('meta', {}).get('_lazyllm_null_node')]
             if sort_by_number:
                 segments = self._sort_segments_by_number(segments)
             total = len(segments)
@@ -453,7 +493,8 @@ class _DocumentStore(object):
             segments.extend(self.vector_initialized_impl.search(
                 collection_name=self._gen_collection_name(group_name), query=query,
                 topk=topk, filters=filters, **kwargs))
-        return [self._deserialize_node(segment, segment.get('score', 0)) for segment in segments]
+        nodes = [self._deserialize_node(segment, segment.get('score', 0)) for segment in segments]
+        return [node for node in nodes if not node.is_null_node]
 
     def keyword_search(self, group, keyword, doc_id='', kb_id=None,
                        phrase=True, sort_by='score', size=10, file_name=None):

--- a/lazyllm/tools/rag/store/document_store.py
+++ b/lazyllm/tools/rag/store/document_store.py
@@ -232,8 +232,8 @@ class _DocumentStore(object):
         elif not store.upsert(collection_name, segments):
             raise RuntimeError(f'[_DocumentStore] Failed to upsert segment data for group {group}')
 
-    def update_nodes(self, nodes: List[DocNode], copy: bool = False,
-                     skip_embed_groups: Optional[Set[str]] = None):   # noqa: C901
+    def update_nodes(self, nodes: List[DocNode], copy: bool = False,  # noqa: C901
+                     skip_embed_groups: Optional[Set[str]] = None):
         if not nodes:
             return
         try:
@@ -278,7 +278,7 @@ class _DocumentStore(object):
                 index.update([node for node in nodes if not node.is_null_node])
             LOG.info(f'[BENCHMARK] phase=store elapsed={time.time() - _t_store:.3f}s nodes={len(nodes)}')
             if embedding_error:
-                setattr(embedding_error, '_lazyllm_segments_persisted', True)
+                embedding_error._lazyllm_segments_persisted = True
                 raise embedding_error
         except Exception as e:
             LOG.error(f'[_DocumentStore] Failed to update nodes: {e}')

--- a/tests/basic_tests/RAG/test_doc_service_doc_manager.py
+++ b/tests/basic_tests/RAG/test_doc_service_doc_manager.py
@@ -111,7 +111,7 @@ class _ManagerHarness:
     def _patch_parser_client(self):
         def add_doc(task_id, kb_id, doc_id, file_path, metadata=None, ng_names=None,
                     extractor_names=None, task_type=None, callback_url=None, transfer_params=None,
-                    llm_config=None, ocr_config=None, strategy='rebuild'):
+                    llm_config=None, ocr_config=None, strategy='rebuild', processing_level='indexed'):
             # Infer algo_id from ng_names using the ng→algo mapping populated by _patch_multi_algo.
             # Only exclusive ng_names (not shared across algos) are in the mapping.
             # Falls back to '__default__' when the mapping is empty (single-algo tests).
@@ -132,6 +132,7 @@ class _ManagerHarness:
                 'task_type': task_type,
                 'callback_url': callback_url,
                 'transfer_params': transfer_params,
+                'processing_level': processing_level,
             })
             self._queue_task(task_id, DocStatus.SUCCESS)
             return BaseResponse(code=200, msg='success', data={'task_id': task_id, 'kb_id': kb_id})

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from lazyllm.tools.rag.doc_node import DocNode
@@ -73,3 +75,167 @@ def test_chunk_failure_keeps_successful_parse_root_for_retry():
 
     roots = processor.store.get_nodes(group=LAZY_ROOT_NAME, doc_ids=['doc-1'], kb_id='kb-1')
     assert len(roots) == 1
+
+
+def _root(uid='root-1'):
+    return DocNode(
+        uid=uid, text='root', group=LAZY_ROOT_NAME,
+        global_metadata={RAG_DOC_ID: 'doc-1', RAG_KB_ID: 'kb-1', RAG_DOC_PATH: '/tmp/doc.pdf'},
+    )
+
+
+def _chunk_processor(*, embed=None, group_embed_keys=None):
+    store = _DocumentStore(store=MapStore(), embed=embed, group_embed_keys=group_embed_keys)
+    store.activate_group([LAZY_ROOT_NAME, 'chunks', 'refs'])
+    return _Processor(store)
+
+
+def test_empty_transform_writes_hidden_null_node():
+    processor = _chunk_processor()
+    root = _root()
+    processor.store.update_nodes([root], copy=True)
+    transform = MagicMock()
+    transform.batch_forward.return_value = []
+    config = {'parent': LAZY_ROOT_NAME, 'transform': MagicMock(pattern=False), 'signature': 'sig-v1'}
+
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', return_value=transform):
+        result = processor._create_nodes_impl([root], 'chunks', {'chunks': config}, skip_embedding=True)
+
+    assert result == []
+    assert processor.store.get_nodes(group='chunks', doc_ids=['doc-1'], kb_id='kb-1') == []
+    assert processor.store.get_segments(group='chunks', doc_ids=['doc-1'], kb_id='kb-1') == []
+    markers = processor.store.get_nodes(
+        group='chunks', doc_ids=['doc-1'], kb_id='kb-1', include_null=True)
+    assert len(markers) == 1
+    assert markers[0].is_null_node
+    assert markers[0]._parent == root.uid
+
+
+def test_missing_ref_skips_transform_without_null_node():
+    processor = _chunk_processor()
+    root = _root()
+    processor.store.update_nodes([root], copy=True)
+    transform = MagicMock()
+    transform._get_ref_nodes.return_value = []
+    config = {'parent': LAZY_ROOT_NAME, 'ref': 'refs', 'transform': MagicMock(pattern=False), 'signature': 'sig-v1'}
+
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', return_value=transform):
+        result = processor._create_nodes_impl(
+            [root], 'chunks', {'chunks': config}, ref_path=['refs'], skip_embedding=True)
+
+    assert result == []
+    transform.batch_forward.assert_not_called()
+    assert processor.store.get_nodes(group='chunks', include_null=True) == []
+
+
+def test_fill_missing_accepts_null_node_as_completed():
+    processor = _chunk_processor()
+    root = _root()
+    processor.store.update_nodes([root], copy=True)
+    transform = MagicMock()
+    transform.batch_forward.return_value = []
+    config = {'parent': LAZY_ROOT_NAME, 'transform': MagicMock(pattern=False), 'signature': 'sig-v1'}
+
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', return_value=transform):
+        processor._create_nodes_impl([root], 'chunks', {'chunks': config}, skip_embedding=True)
+        processor._create_nodes_impl(
+            [root], 'chunks', {'chunks': config}, skip_embedding=True, only_missing=True)
+
+    transform.batch_forward.assert_called_once()
+
+
+def test_embedding_failure_keeps_segments_and_successful_vectors():
+    failed = {'bad'}
+    calls = []
+
+    def embed(text):
+        calls.append(text)
+        if text in failed:
+            raise ValueError('cannot embed')
+        return [1.0, 2.0]
+
+    processor = _chunk_processor(embed={'dense': embed}, group_embed_keys={'chunks': {'dense'}})
+    nodes = [
+        DocNode(uid='good', text='good', group='chunks', global_metadata={RAG_DOC_ID: 'doc-1', RAG_KB_ID: 'kb-1'}),
+        DocNode(uid='bad', text='bad', group='chunks', global_metadata={RAG_DOC_ID: 'doc-1', RAG_KB_ID: 'kb-1'}),
+    ]
+
+    with pytest.raises(ValueError, match='cannot embed'):
+        processor.store.update_nodes(nodes)
+
+    stored = {node.uid: node for node in processor.store.get_nodes(group='chunks', doc_ids=['doc-1'], kb_id='kb-1')}
+    assert set(stored) == {'good', 'bad'}
+    assert stored['good'].embedding['dense'] == [1.0, 2.0]
+    assert 'dense' not in stored['bad'].embedding
+    failed.clear()
+    processor.store.update_nodes(list(stored.values()))
+    assert calls.count('good') == 1
+    assert calls.count('bad') == 2
+    completed = {node.uid: node for node in processor.store.get_nodes(group='chunks')}
+    assert completed['bad'].embedding['dense'] == [1.0, 2.0]
+
+
+def test_failed_parent_branch_is_skipped_but_successful_branch_reaches_children():
+    store = _DocumentStore(store=MapStore())
+    store.activate_group([LAZY_ROOT_NAME, 'parent', 'child'])
+    processor = _Processor(store)
+    roots = [_root('good-root'), _root('bad-root')]
+    store.update_nodes(roots, copy=True)
+
+    parent_transform = MagicMock()
+
+    failed = {'bad-root'}
+
+    def create_parent(nodes, group_name, ref_path=None):
+        root = nodes[0]
+        if root.uid in failed:
+            raise RuntimeError('parent chunk failed')
+        node = DocNode(
+            uid=f'parent-{root.uid}', text='parent', group=group_name, parent=root,
+            global_metadata=dict(root.global_metadata),
+        )
+        root.children[group_name] = [node]
+        return [node]
+
+    parent_transform.batch_forward.side_effect = create_parent
+    child_transform = MagicMock()
+
+    def create_child(nodes, group_name, ref_path=None):
+        parent = nodes[0]
+        node = DocNode(
+            uid=f'child-{parent.uid}', text='child', group=group_name, parent=parent,
+            global_metadata=dict(parent.global_metadata),
+        )
+        parent.children[group_name] = [node]
+        return [node]
+
+    child_transform.batch_forward.side_effect = create_child
+    transforms = {'parent-transform': parent_transform, 'child-transform': child_transform}
+    node_groups = {
+        LAZY_ROOT_NAME: {'parent': None, 'transform': None},
+        'parent': {'parent': LAZY_ROOT_NAME, 'transform': MagicMock(pattern=False, name='parent-transform')},
+        'child': {'parent': 'parent', 'transform': MagicMock(pattern=False, name='child-transform')},
+    }
+
+    def make(transform, group_name):
+        return transforms[f'{group_name}-transform']
+
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', side_effect=make):
+        with pytest.raises(RuntimeError, match='parent chunk failed'):
+            processor._create_nodes_recursive(
+                roots, LAZY_ROOT_NAME, node_groups=node_groups, skip_embedding=True)
+
+    assert {node.uid for node in store.get_nodes(group='parent')} == {'parent-good-root'}
+    assert {node.uid for node in store.get_nodes(group='child')} == {'child-parent-good-root'}
+    child_transform.batch_forward.assert_called_once()
+
+    failed.clear()
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', side_effect=make):
+        processor._fill_missing_docs('parent', node_groups, ['doc-1'], 'kb-1', 'chunked')
+
+    assert {node.uid for node in store.get_nodes(group='parent')} == {
+        'parent-good-root', 'parent-bad-root'}
+    assert {node.uid for node in store.get_nodes(group='child')} == {
+        'child-parent-good-root', 'child-parent-bad-root'}
+    assert parent_transform.batch_forward.call_count == 3
+    assert child_transform.batch_forward.call_count == 2

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -69,6 +69,32 @@ def test_parsed_level_stores_root_without_creating_chunks():
     assert len(roots) == 1
 
 
+def test_per_parent_transform_assigns_document_wide_node_numbers():
+    processor = _chunk_processor()
+    parents = [_root('root-1'), _root('root-2')]
+    processor.store.update_nodes(parents, copy=True)
+
+    def split(parent_nodes, group_name, ref_path=None):
+        parent = parent_nodes[0]
+        return [
+            DocNode(uid=f'{parent.uid}-a', text='a', group=group_name, parent=parent,
+                    global_metadata=dict(parent.global_metadata)),
+            DocNode(uid=f'{parent.uid}-b', text='b', group=group_name, parent=parent,
+                    global_metadata=dict(parent.global_metadata)),
+        ]
+
+    transform = MagicMock(pattern=False)
+    transform.batch_forward.side_effect = split
+    processor._create_nodes_impl(
+        parents,
+        'chunks',
+        {'chunks': {'parent': LAZY_ROOT_NAME, 'transform': transform, 'signature': 'sig-v1'}},
+    )
+
+    chunks = processor.store.get_nodes(group='chunks', doc_ids=['doc-1'], kb_id='kb-1')
+    assert sorted(node.number for node in chunks) == [1, 2, 3, 4]
+
+
 def test_chunk_failure_keeps_successful_parse_root_for_retry():
     processor = _processor()
 

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -1,0 +1,75 @@
+import pytest
+
+from lazyllm.tools.rag.doc_node import DocNode
+from lazyllm.tools.rag.doc_service.base import ReparseRequest, UploadRequest, AddFileItem
+from lazyllm.tools.rag.global_metadata import RAG_DOC_ID, RAG_DOC_PATH, RAG_KB_ID
+from lazyllm.tools.rag.parsing_service.impl import _Processor
+from lazyllm.tools.rag.store import LAZY_ROOT_NAME, MapStore
+from lazyllm.tools.rag.store.document_store import _DocumentStore
+
+
+class _Reader:
+    def load_data(self, input_files, metadatas, split_nodes_by_type=True):
+        metadata = metadatas[0]
+        return {
+            LAZY_ROOT_NAME: [
+                DocNode(
+                    uid='root-doc-1',
+                    text='parsed text',
+                    group=LAZY_ROOT_NAME,
+                    global_metadata={
+                        RAG_DOC_ID: metadata[RAG_DOC_ID],
+                        RAG_DOC_PATH: input_files[0],
+                        RAG_KB_ID: metadata[RAG_KB_ID],
+                    },
+                )
+            ]
+        }
+
+
+def _processor():
+    store = _DocumentStore(store=MapStore())
+    store.activate_group(LAZY_ROOT_NAME)
+    return _Processor(store)
+
+
+def test_reparse_rejects_vector_rebuild_below_indexed():
+    with pytest.raises(ValueError, match='reembed requires indexed'):
+        ReparseRequest(doc_ids=['doc-1'], processing_level='chunked', strategy='reembed')
+
+
+def test_processing_level_defaults_keep_legacy_indexed_behavior():
+    request = UploadRequest(items=[AddFileItem(file_path='/tmp/doc.pdf')])
+    assert request.processing_level == 'indexed'
+
+
+def test_parsed_level_stores_root_without_creating_chunks():
+    processor = _processor()
+    processor._create_nodes_recursive = lambda *args, **kwargs: pytest.fail('must not create chunks')
+
+    processor.add_doc(
+        input_files=['/tmp/doc.pdf'], ids=['doc-1'], metadatas=[{}], kb_id='kb-1',
+        node_groups={}, reader=_Reader(), processing_level='parsed',
+    )
+
+    roots = processor.store.get_nodes(group=LAZY_ROOT_NAME, doc_ids=['doc-1'], kb_id='kb-1')
+    assert len(roots) == 1
+
+
+def test_chunk_failure_keeps_successful_parse_root_for_retry():
+    processor = _processor()
+
+    def fail_chunks(*args, **kwargs):
+        assert kwargs['skip_embedding'] is True
+        raise RuntimeError('chunk failed')
+
+    processor._create_nodes_recursive = fail_chunks
+
+    with pytest.raises(RuntimeError, match='chunk failed'):
+        processor.add_doc(
+            input_files=['/tmp/doc.pdf'], ids=['doc-1'], metadatas=[{}], kb_id='kb-1',
+            node_groups={}, reader=_Reader(), processing_level='chunked',
+        )
+
+    roots = processor.store.get_nodes(group=LAZY_ROOT_NAME, doc_ids=['doc-1'], kb_id='kb-1')
+    assert len(roots) == 1

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -83,13 +83,15 @@ def test_per_parent_transform_assigns_document_wide_node_numbers():
                     global_metadata=dict(parent.global_metadata)),
         ]
 
-    transform = MagicMock(pattern=False)
+    transform = MagicMock()
     transform.batch_forward.side_effect = split
-    processor._create_nodes_impl(
-        parents,
-        'chunks',
-        {'chunks': {'parent': LAZY_ROOT_NAME, 'transform': transform, 'signature': 'sig-v1'}},
-    )
+    transform_args = {'pattern': False}
+    with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', return_value=transform):
+        processor._create_nodes_impl(
+            parents,
+            'chunks',
+            {'chunks': {'parent': LAZY_ROOT_NAME, 'transform': transform_args, 'signature': 'sig-v1'}},
+        )
 
     chunks = processor.store.get_nodes(group='chunks', doc_ids=['doc-1'], kb_id='kb-1')
     assert sorted(node.number for node in chunks) == [1, 2, 3, 4]
@@ -217,7 +219,7 @@ def test_failed_parent_branch_is_skipped_but_successful_branch_reaches_children(
     store.activate_group([LAZY_ROOT_NAME, 'parent', 'child'])
     processor = _Processor(store)
     roots = [_root('good-root'), _root('bad-root')]
-    store.update_nodes(roots, copy=True)
+    store.update_nodes(processor._set_nodes_number(roots), copy=True)
 
     parent_transform = MagicMock()
 
@@ -276,3 +278,13 @@ def test_failed_parent_branch_is_skipped_but_successful_branch_reaches_children(
         'child-parent-good-root', 'child-parent-bad-root'}
     assert parent_transform.batch_forward.call_count == 3
     assert child_transform.batch_forward.call_count == 2
+    parents = store.get_nodes(group='parent', doc_ids=['doc-1'], kb_id='kb-1')
+    children = store.get_nodes(group='child', doc_ids=['doc-1'], kb_id='kb-1')
+    assert {node.uid: node.number for node in parents} == {
+        'parent-good-root': 1,
+        'parent-bad-root': 2,
+    }
+    assert {node.uid: node.number for node in children} == {
+        'child-parent-good-root': 1,
+        'child-parent-bad-root': 2,
+    }

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -84,13 +84,13 @@ def test_per_parent_transform_assigns_document_wide_node_numbers():
         ]
 
     transform = MagicMock()
+    transform.pattern = False
     transform.batch_forward.side_effect = split
-    transform_args = {'pattern': False}
     with patch('lazyllm.tools.rag.parsing_service.impl.make_transform', return_value=transform):
         processor._create_nodes_impl(
             parents,
             'chunks',
-            {'chunks': {'parent': LAZY_ROOT_NAME, 'transform': transform_args, 'signature': 'sig-v1'}},
+            {'chunks': {'parent': LAZY_ROOT_NAME, 'transform': transform, 'signature': 'sig-v1'}},
         )
 
     chunks = processor.store.get_nodes(group='chunks', doc_ids=['doc-1'], kb_id='kb-1')

--- a/tests/basic_tests/RAG/test_processing_levels.py
+++ b/tests/basic_tests/RAG/test_processing_levels.py
@@ -4,6 +4,7 @@ import pytest
 
 from lazyllm.tools.rag.doc_node import DocNode
 from lazyllm.tools.rag.doc_service.base import ReparseRequest, UploadRequest, AddFileItem
+from lazyllm.tools.rag.parsing_service.base import AddDocRequest, FileInfo
 from lazyllm.tools.rag.global_metadata import RAG_DOC_ID, RAG_DOC_PATH, RAG_KB_ID
 from lazyllm.tools.rag.parsing_service.impl import _Processor
 from lazyllm.tools.rag.store import LAZY_ROOT_NAME, MapStore
@@ -43,6 +44,16 @@ def test_reparse_rejects_vector_rebuild_below_indexed():
 def test_processing_level_defaults_keep_legacy_indexed_behavior():
     request = UploadRequest(items=[AddFileItem(file_path='/tmp/doc.pdf')])
     assert request.processing_level == 'indexed'
+
+
+@pytest.mark.parametrize('request_factory', [
+    lambda: UploadRequest(items=[AddFileItem(file_path='/tmp/doc.pdf')], processing_level='stored'),
+    lambda: ReparseRequest(doc_ids=['doc-1'], processing_level='stored'),
+    lambda: AddDocRequest(file_infos=[FileInfo(file_path='/tmp/doc.pdf')], processing_level='stored'),
+])
+def test_stored_level_is_owned_by_caller_and_rejected_by_lazyllm(request_factory):
+    with pytest.raises(ValueError, match='processing_level must be parsed, chunked, or indexed'):
+        request_factory()
 
 
 def test_parsed_level_stores_root_without_creating_chunks():

--- a/tests/basic_tests/RAG/test_processor_cleanup.py
+++ b/tests/basic_tests/RAG/test_processor_cleanup.py
@@ -17,7 +17,7 @@ def _make_root_node(doc_id: str, kb_id: str) -> DocNode:
     )
 
 
-def test_add_doc_cleans_partial_segments_and_schema_on_failure():
+def test_add_doc_keeps_partial_segments_and_schema_on_failure():
     store = MagicMock()
     reader = MagicMock()
     schema_extractor = MagicMock()
@@ -41,11 +41,8 @@ def test_add_doc_cleans_partial_segments_and_schema_on_failure():
     finally:
         processor.close()
 
-    store.remove_nodes.assert_called_once_with(doc_ids=['doc1'], kb_id='kb1')
-    schema_extractor._delete_extract_data.assert_called_once_with(
-        kb_id='kb1',
-        doc_ids=['doc1'],
-    )
+    store.remove_nodes.assert_not_called()
+    schema_extractor._delete_extract_data.assert_not_called()
 
 
 def test_transfer_failure_cleans_target_segments_only():
@@ -134,7 +131,7 @@ def test_add_doc_runs_all_extractors_when_names_is_none():
     ext_b.assert_called_once()
 
 
-def test_cleanup_iterates_all_schema_extractors():
+def test_add_failure_does_not_remove_successful_schema_results():
     store = MagicMock()
     reader = MagicMock()
     ext_a = MagicMock()
@@ -160,5 +157,5 @@ def test_cleanup_iterates_all_schema_extractors():
     finally:
         processor.close()
 
-    ext_a._delete_extract_data.assert_called_once_with(kb_id='kb1', doc_ids=['doc1'])
-    ext_b._delete_extract_data.assert_called_once_with(kb_id='kb1', doc_ids=['doc1'])
+    ext_a._delete_extract_data.assert_not_called()
+    ext_b._delete_extract_data.assert_not_called()

--- a/tests/basic_tests/RAG/test_transform.py
+++ b/tests/basic_tests/RAG/test_transform.py
@@ -1859,6 +1859,7 @@ class TestBatchForwardRefPath:
             node_groups={},
             reader=reader,
             preloaded_root_nodes=reader.load_data.return_value,
+            processing_level='indexed',
         )
 
     # ---------- reparse: group × mode combinations ----------

--- a/tests/basic_tests/Tools/test_writer_stream_tools.py
+++ b/tests/basic_tests/Tools/test_writer_stream_tools.py
@@ -336,10 +336,21 @@ def test_stream_markdown_outline_returns_the_authoritative_artifact(tmp_path):
 
     assert preview == '# 测试大纲\n\n## 第一章 项目背景\n\n- 要点一\n\n## 第二章 方案设计\n\n- 要点二\n'
     artifact = Path(result['artifact_path']).read_text(encoding='utf-8')
-    assert artifact == preview.replace(
+    expected_artifact = preview.replace(
         '## 第一章 项目背景', '<a id="block-sec-001"></a>\n## 项目背景',
     ).replace(
         '## 第二章 方案设计', '<a id="block-sec-002"></a>\n## 方案设计',
+    )
+    assert artifact == expected_artifact.replace(
+        '## 项目背景',
+        '## 项目背景\n<!-- writer:outline '
+        '{"node_id":"sec-001","target_chars":200,"context_relations":[],"subtasks":[]} -->',
+    ).replace(
+        '## 方案设计',
+        '## 方案设计\n<!-- writer:outline '
+        '{"node_id":"sec-002","target_chars":200,"context_relations":['
+        '{"target_node_id":"sec-001","relation":"continuity",'
+        '"guidance":"承接前一节已建立的信息和叙事进展。"}],"subtasks":[]} -->',
     )
     assert result['metadata']['extra']['representation'] == 'markdown'
 

--- a/tests/charge_tests/Tools/test_sql_tool.py
+++ b/tests/charge_tests/Tools/test_sql_tool.py
@@ -1,4 +1,5 @@
 import unittest
+import os
 from lazyllm.tools import SqlCall, SqlManager, DBStatus
 import lazyllm
 from ...utils import SqlEgsData, get_db_init_keywords
@@ -31,6 +32,8 @@ class TestSqlManager(unittest.TestCase):
                                                          tables_info_dict=SqlEgsData.TEST_TABLES_INFO)]
         # MySQL has been tested with online database.
         for db_type in ['PostgreSQL']:
+            if not os.environ.get(f'LAZYLLM_{db_type.replace(" ", "_")}_URL'):
+                continue
             username, password, host, port, database = get_db_init_keywords(db_type)
             cls.sql_managers.append(SqlManager(db_type, username, password, host, port, database,
                                                tables_info_dict=SqlEgsData.TEST_TABLES_INFO))
@@ -41,11 +44,6 @@ class TestSqlManager(unittest.TestCase):
                 sql_manager.execute_commit(f'DELETE FROM {table_name}')
             for insert_script in SqlEgsData.TEST_INSERT_SCRIPTS:
                 sql_manager.execute_commit(insert_script)
-
-        sql_llm = lazyllm.OnlineChatModule(source='qwen')
-        cls.sql_calls: list[SqlCall] = []
-        for sql_manager in cls.sql_managers:
-            cls.sql_calls.append(SqlCall(sql_llm, sql_manager, use_llm_for_sql_result=True))
 
     @classmethod
     def tearDownClass(cls):
@@ -86,7 +84,9 @@ class TestSqlManager(unittest.TestCase):
             self.assertIn('销售一部', f'Query: {SqlEgsData.TEST_QUERY_SCRIPTS}; result: {str_results}')
 
     def test_llm_query_online(self):
-        for sql_call in self.sql_calls:
+        sql_llm = lazyllm.OnlineChatModule(source='qwen')
+        for sql_manager in self.sql_managers:
+            sql_call = SqlCall(sql_llm, sql_manager, use_llm_for_sql_result=True)
             str_results = sql_call('去年一整年销售额最多的员工是谁，销售额是多少？')
             self.assertIn('张三', str_results)
             time.sleep(0.2)


### PR DESCRIPTION
## 改动概述

- 在文档新增与重新解析请求中增加 `processing_level`，缺省仍为 `indexed`，保持旧调用兼容。
- `parsed` 仅持久化解析根节点，不再生成切片或向量。
- `chunked` 生成切片但显式跳过 embedding；只有 `indexed` 允许向量重建。
- 处理失败时保留已经成功写入的上游节点，避免 chunk/embed 失败后清空 parse/chunk 产物。
- “查漏补缺”会补齐缺失节点组；indexed 场景会为已有切片补建或重建向量。
- 增加处理等级校验和阶段产物保留回归测试。

## 兼容性

- 新字段默认值为 `indexed`，未传字段的现有客户端保持原有完整解析与向量化行为。
- 不改变已有接口路径和既有重解析策略名称。

## 验证

- Python 语法检查通过。
- 在 LazyMind 解析 Worker 容器中验证请求校验通过。
- 在实际解析运行环境验证：parsed 不切片、chunked 不调用 embedding、chunk 失败后 parse 根节点仍保留。
- LazyMind 仓库 `make lint` 通过。